### PR TITLE
fix: include fields in generated type guards

### DIFF
--- a/MetaSharp.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/MetaSharp.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -154,6 +154,7 @@ public sealed class TypeGuardBuilder(IReadOnlyDictionary<string, INamedTypeSymbo
             foreach (var member in current.GetMembers().OfType<IPropertySymbol>())
             {
                 if (member.IsImplicitlyDeclared) continue;
+                if (member.IsStatic) continue;
                 if (member.DeclaredAccessibility is Accessibility.Internal or Accessibility.NotApplicable) continue;
                 if (SymbolHelper.HasIgnore(member)) continue;
 

--- a/MetaSharp.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/MetaSharp.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -165,6 +165,21 @@ public sealed class TypeGuardBuilder(IReadOnlyDictionary<string, INamedTypeSymbo
                     fields.Add((name, tsType));
             }
 
+            foreach (var member in current.GetMembers().OfType<IFieldSymbol>())
+            {
+                if (member.IsImplicitlyDeclared) continue;
+                if (member.IsStatic) continue;
+                if (member.AssociatedSymbol is not null) continue;
+                if (member.DeclaredAccessibility is Accessibility.Private or Accessibility.Internal or Accessibility.NotApplicable) continue;
+                if (SymbolHelper.HasIgnore(member)) continue;
+
+                var name = SymbolHelper.GetNameOverride(member) ?? TypeScriptNaming.ToCamelCase(member.Name);
+                var tsType = TypeMapper.Map(member.Type);
+
+                if (fields.All(f => f.Name != name))
+                    fields.Add((name, tsType));
+            }
+
             current = current.BaseType;
         }
 

--- a/MetaSharp.Tests/TypeGuardTranspileTests.cs
+++ b/MetaSharp.Tests/TypeGuardTranspileTests.cs
@@ -179,4 +179,68 @@ public class TypeGuardTranspileTests
         var output = result["item.ts"];
         await Assert.That(output).Contains("): value is Item");
     }
+
+    [Test]
+    public async Task Class_WithPublicField_GuardChecksField()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public class Counter
+            {
+                public int Count;
+            }
+            """
+        );
+
+        var output = result["counter.ts"];
+        await Assert.That(output).Contains("export function isCounter(value: unknown): value is Counter");
+        await Assert.That(output).Contains("typeof v.count === \"number\"");
+    }
+
+    [Test]
+    public async Task InheritedProtectedField_GuardChecksInheritedField()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App
+            {
+                [Transpile]
+                public class Base
+                {
+                    protected bool _active = true;
+                }
+
+                [Transpile, GenerateGuard]
+                public class Child : Base
+                {
+                    public int Count;
+                }
+            }
+            """
+        );
+
+        var output = result["child.ts"];
+        await Assert.That(output).Contains("typeof v._active === \"boolean\"");
+        await Assert.That(output).Contains("typeof v.count === \"number\"");
+    }
+
+    [Test]
+    public async Task Guard_WithPropertyAndField_ChecksBoth()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public class Sample
+            {
+                public int Count;
+                public string Name { get; set; } = "";
+            }
+            """
+        );
+
+        var output = result["sample.ts"];
+        await Assert.That(output).Contains("typeof v.count === \"number\"");
+        await Assert.That(output).Contains("typeof v.name === \"string\"");
+    }
 }


### PR DESCRIPTION
## Summary
- include eligible instance fields in `GenerateGuard` shape validation
- keep the existing exclusions for implicit, static, backing, ignored, private, and internal fields
- add regression coverage for public fields, inherited protected fields, and mixed field/property scenarios

## Validation
- `dotnet run --project MetaSharp.Tests/MetaSharp.Tests.csproj`
- Result: `309/309` tests passed in the issue worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime type guards for classes now include eligible field members (including inherited fields) alongside properties, ensuring full per-member validation and improved type safety.
* **Tests**
  * Added test cases verifying guard generation for classes with public fields, inherited protected fields, and mixtures of fields and auto-properties to ensure correct emitted checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->