### PR TITLE
fix: prevent external import map collisions (#2)

### DIFF
--- a/MetaSharp.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/MetaSharp.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -116,10 +116,18 @@ public sealed class TypeTransformer(Compilation compilation)
             if (import is not null)
             {
                 var entry = (import.Name, import.From, import.AsDefault, import.Version);
-                _externalImportMap[t.Name] = entry;
+                RegisterExternalImportMapping(
+                    t.Name,
+                    entry,
+                    t.ToDisplayString(),
+                    t.Locations.FirstOrDefault());
                 var tsName = GetTsTypeName(t);
                 if (tsName != t.Name)
-                    _externalImportMap[tsName] = entry;
+                    RegisterExternalImportMapping(
+                        tsName,
+                        entry,
+                        t.ToDisplayString(),
+                        t.Locations.FirstOrDefault());
             }
         }
 
@@ -321,10 +329,18 @@ public sealed class TypeTransformer(Compilation compilation)
                 if (import is not null)
                 {
                     var entry = (import.Name, import.From, import.AsDefault, import.Version);
-                    _externalImportMap[type.Name] = entry;
+                    RegisterExternalImportMapping(
+                        type.Name,
+                        entry,
+                        type.ToDisplayString(),
+                        type.Locations.FirstOrDefault());
                     var tsName = GetTsTypeName(type);
                     if (tsName != type.Name)
-                        _externalImportMap[tsName] = entry;
+                        RegisterExternalImportMapping(
+                            tsName,
+                            entry,
+                            type.ToDisplayString(),
+                            type.Locations.FirstOrDefault());
                     continue;
                 }
 
@@ -602,6 +618,30 @@ public sealed class TypeTransformer(Compilation compilation)
     }
 
     private sealed record TypeFileGroup(string Namespace, string FileName, List<INamedTypeSymbol> Types);
+
+    private void RegisterExternalImportMapping(
+        string key,
+        (string Name, string From, bool IsDefault, string? Version) entry,
+        string ownerDisplayName,
+        Location? location)
+    {
+        if (!_externalImportMap.TryGetValue(key, out var existing))
+        {
+            _externalImportMap[key] = entry;
+            return;
+        }
+
+        if (existing == entry)
+            return;
+
+        _diagnostics.Add(new MetaSharpDiagnostic(
+            MetaSharpDiagnosticSeverity.Warning,
+            DiagnosticCodes.AmbiguousConstruct,
+            $"External import name collision for '{key}'. Keeping '{existing.From}' " +
+            $"('{existing.Name}') and ignoring conflicting mapping from " +
+            $"'{ownerDisplayName}' to '{entry.From}' ('{entry.Name}').",
+            location));
+    }
 
     /// <summary>
     /// Returns the TypeScript name for a type. Uses [Name] override if present, otherwise the C# name as-is.

--- a/MetaSharp.Tests/CrossPackageImportTests.cs
+++ b/MetaSharp.Tests/CrossPackageImportTests.cs
@@ -1,3 +1,6 @@
+using MetaSharp.Compiler.Diagnostics;
+using MetaSharp.TypeScript;
+
 namespace MetaSharp.Tests;
 
 /// <summary>
@@ -271,6 +274,95 @@ public class CrossPackageImportTests
         transformer.TransformAll();
 
         await Assert.That(transformer.CrossPackageDependencies.ContainsKey("hono")).IsFalse();
+    }
+
+    [Test]
+    public async Task LocalImportMapping_WinsOverReferencedCollision()
+    {
+        var library = """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("@acme/lib")]
+
+            namespace Lib;
+
+            [Import("Moment", from: "shared-moment")]
+            public class Moment { }
+            """;
+
+        var consumer = """
+            [assembly: TranspileAssembly]
+
+            [Import("Moment", from: "local-moment")]
+            public class Moment { }
+
+            public class App
+            {
+                public Moment Value { get; set; } = new Moment();
+            }
+            """;
+
+        var libCompilation = TranspileHelper.CompileLibrary(library);
+        var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
+
+        var transformer = new MetaSharp.Transformation.TypeTransformer(consumerCompilation);
+        var files = transformer.TransformAll();
+        var printer = new Printer();
+        var output = printer.Print(files.Single(f => f.FileName == "app.ts"));
+
+        await Assert.That(output).Contains("import { Moment } from \"local-moment\"");
+        await Assert.That(output).DoesNotContain("shared-moment");
+        await Assert.That(transformer.Diagnostics.Any(d =>
+            d.Code == DiagnosticCodes.AmbiguousConstruct &&
+            d.Message.Contains("Moment") &&
+            d.Message.Contains("local-moment") &&
+            d.Message.Contains("shared-moment"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ReferencedImportCollision_EmitsDiagnosticAndKeepsFirstMapping()
+    {
+        var libraryA = """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("@acme/lib-a")]
+
+            namespace LibA;
+
+            [Import("Moment", from: "moment-a")]
+            public class Moment { }
+            """;
+
+        var libraryB = """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("@acme/lib-b")]
+
+            namespace LibB;
+
+            [Import("Moment", from: "moment-b")]
+            public class Moment { }
+            """;
+
+        var consumer = """
+            [assembly: TranspileAssembly]
+
+            public class App
+            {
+                public string Name { get; set; } = "";
+            }
+            """;
+
+        var libACompilation = TranspileHelper.CompileLibrary(libraryA, "LibA");
+        var libBCompilation = TranspileHelper.CompileLibrary(libraryB, "LibB");
+        var consumerCompilation = TranspileHelper.CompileConsumer(
+            consumer,
+            libACompilation,
+            libBCompilation);
+
+        var transformer = new MetaSharp.Transformation.TypeTransformer(consumerCompilation);
+        transformer.TransformAll();
+
+        await Assert.That(transformer.Diagnostics.Any(d =>
+            d.Code == DiagnosticCodes.AmbiguousConstruct &&
+            d.Message.Contains("Moment"))).IsTrue();
     }
 
     [Test]

--- a/MetaSharp.Tests/TranspileHelper.cs
+++ b/MetaSharp.Tests/TranspileHelper.cs
@@ -173,6 +173,14 @@ public static class TranspileHelper
     /// the generated TS files.
     /// </summary>
     public static CSharpCompilation CompileLibrary(string librarySource)
+        => CompileLibrary(librarySource, "TestLibrary");
+
+    /// <summary>
+    /// Compiles a library source into an in-memory <see cref="CSharpCompilation"/>
+    /// using the provided assembly name. Useful for tests that need multiple distinct
+    /// referenced libraries in the same consumer compilation.
+    /// </summary>
+    public static CSharpCompilation CompileLibrary(string librarySource, string assemblyName)
     {
         var source = $"""
             using System;
@@ -183,7 +191,7 @@ public static class TranspileHelper
         var tree = CSharpSyntaxTree.ParseText(source,
             new CSharpParseOptions(LanguageVersion.Preview));
         var compilation = CSharpCompilation.Create(
-            "TestLibrary", [tree], BuildBaseReferences(),
+            assemblyName, [tree], BuildBaseReferences(),
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         var errors = compilation.GetDiagnostics()
@@ -202,6 +210,15 @@ public static class TranspileHelper
     /// </summary>
     public static CSharpCompilation CompileConsumer(
         string consumerSource, CSharpCompilation libraryCompilation)
+        => CompileConsumer(consumerSource, [libraryCompilation]);
+
+    /// <summary>
+    /// Compiles a consumer source that references multiple previously built library
+    /// compilations. Useful for tests that need to validate behavior across more than
+    /// one referenced assembly.
+    /// </summary>
+    public static CSharpCompilation CompileConsumer(
+        string consumerSource, params CSharpCompilation[] libraryCompilations)
     {
         var source = $"""
             using System;
@@ -214,7 +231,7 @@ public static class TranspileHelper
         var compilation = CSharpCompilation.Create(
             "TestConsumer",
             [tree],
-            BuildBaseReferences().Concat([libraryCompilation.ToMetadataReference()]),
+            BuildBaseReferences().Concat(libraryCompilations.Select(c => c.ToMetadataReference())),
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
         var errors = compilation.GetDiagnostics()


### PR DESCRIPTION
## Summary

- Replace unconditional `_externalImportMap[key] = entry` with `RegisterExternalImportMapping` that keeps the first registered entry and emits an `AmbiguousConstruct` warning on collision
- Add `CompileLibrary(source, assemblyName)` and `CompileConsumer(source, params compilations)` overloads to `TranspileHelper` to support multi-library test scenarios
- Add two tests: local-wins-over-referenced collision, and referenced-vs-referenced collision with diagnostic

## Test plan

- [x] All 308 TUnit tests pass
- [x] `LocalImportMapping_WinsOverReferencedCollision` — local `[Import]` wins, diagnostic emitted
- [x] `ReferencedImportCollision_EmitsDiagnosticAndKeepsFirstMapping` — first referenced library wins, diagnostic emitted

Closes #2