### PR TITLE
feat: merge local imports per barrel and sort values-first (#12)

### DIFF
--- a/js/sample-issue-tracker/src/issues/application/i-issue-repository.ts
+++ b/js/sample-issue-tracker/src/issues/application/i-issue-repository.ts
@@ -1,10 +1,5 @@
-import type { Issue } from "#/issues/domain";
-import type { IssueId } from "#/issues/domain";
-import { IssuePriority } from "#/issues/domain";
-import { IssueStatus } from "#/issues/domain";
-import type { PageRequest } from "#/shared-kernel";
-import type { PageResult } from "#/shared-kernel";
-import type { UserId } from "#/shared-kernel";
+import { IssuePriority, IssueStatus, type Issue, type IssueId } from "#/issues/domain";
+import type { PageRequest, PageResult, UserId } from "#/shared-kernel";
 
 export interface IIssueRepository {
   getByIdAsync(id: IssueId): Promise<Issue | null>;

--- a/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
+++ b/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
@@ -1,12 +1,7 @@
 import { Enumerable } from "metano-runtime";
+import { IssuePriority, IssueStatus, type Issue, type IssueId } from "#/issues/domain";
+import { PageResult, type PageRequest, type UserId } from "#/shared-kernel";
 import type { IIssueRepository } from "./i-issue-repository";
-import type { Issue } from "#/issues/domain";
-import type { IssueId } from "#/issues/domain";
-import { IssuePriority } from "#/issues/domain";
-import { IssueStatus } from "#/issues/domain";
-import type { PageRequest } from "#/shared-kernel";
-import { PageResult } from "#/shared-kernel";
-import type { UserId } from "#/shared-kernel";
 
 export class InMemoryIssueRepository implements IIssueRepository {
   private readonly _issues: Issue[] = [];

--- a/js/sample-issue-tracker/src/issues/application/issue-queries.ts
+++ b/js/sample-issue-tracker/src/issues/application/issue-queries.ts
@@ -1,8 +1,6 @@
 import { Enumerable } from "metano-runtime";
 import type { Grouping } from "metano-runtime";
-import type { Issue } from "#/issues/domain";
-import { IssuePriority } from "#/issues/domain";
-import { IssueStatus } from "#/issues/domain";
+import { IssuePriority, IssueStatus, type Issue } from "#/issues/domain";
 import type { UserId } from "#/shared-kernel";
 
 export function openIssues(issues: Issue[]): Issue[] {

--- a/js/sample-issue-tracker/src/issues/application/issue-service.ts
+++ b/js/sample-issue-tracker/src/issues/application/issue-service.ts
@@ -1,14 +1,7 @@
 import { isString } from "metano-runtime";
+import { Issue, IssueId, IssuePriority, IssueStatus, IssueType } from "#/issues/domain";
+import { OperationResult, type PageRequest, type PageResult, type UserId } from "#/shared-kernel";
 import type { IIssueRepository } from "./i-issue-repository";
-import { Issue } from "#/issues/domain";
-import { IssueId } from "#/issues/domain";
-import { IssuePriority } from "#/issues/domain";
-import { IssueStatus } from "#/issues/domain";
-import { IssueType } from "#/issues/domain";
-import { OperationResult } from "#/shared-kernel";
-import type { PageRequest } from "#/shared-kernel";
-import type { PageResult } from "#/shared-kernel";
-import type { UserId } from "#/shared-kernel";
 
 export class IssueService {
   private readonly _repository: IIssueRepository;

--- a/js/sample-issue-tracker/src/issues/domain/issue.ts
+++ b/js/sample-issue-tracker/src/issues/domain/issue.ts
@@ -1,12 +1,12 @@
 import { Temporal } from "@js-temporal/polyfill";
 import { isString } from "metano-runtime";
+import type { UserId } from "#/shared-kernel";
 import { Comment } from "./comment";
 import type { IssueId } from "./issue-id";
 import { IssuePriority } from "./issue-priority";
 import { IssueStatus } from "./issue-status";
 import { IssueType } from "./issue-type";
 import { IssueWorkflow } from "./issue-workflow";
-import type { UserId } from "#/shared-kernel";
 
 export class Issue {
   status: IssueStatus = IssueStatus.Backlog;

--- a/js/sample-todo-service/src/todos.ts
+++ b/js/sample-todo-service/src/todos.ts
@@ -1,7 +1,7 @@
 import { Enumerable } from "metano-runtime";
 import { UUID } from "metano-runtime";
 import { listRemove } from "metano-runtime";
-import { type Priority, TodoItem } from "sample-todo";
+import { TodoItem, type Priority } from "sample-todo";
 
 export interface StoredTodo {
   readonly id: string;

--- a/specs/next-steps.md
+++ b/specs/next-steps.md
@@ -367,10 +367,10 @@ name, so two assemblies with same-named types are correctly distinguished.
       source of truth).
 - [x] **Multi-type-per-file support** via `[EmitInFile("name")]`. Types decorated with
       the same file name (in the same C# namespace) are co-located in one `.ts` file
-      instead of producing one file per type. Cross-package consumers automatically
-      resolve the import to the file path: a reference to a co-located type becomes
-      `import { Foo, Bar } from "<package>/<ns>/<file>"`, and multiple names from the
-      same file are merged into one import line. Conflicting namespaces under the same
+      instead of producing one file per type. Under namespace-first resolution the
+      consumer imports the co-located names through the namespace barrel
+      (`import { Foo, Bar } from "<package>/<ns>"`), and multiple names from the same
+      barrel are merged into one import line. Conflicting namespaces under the same
       file name are rejected with MS0008.
 
 ### NuGet Library Path — `.metalib` (future)
@@ -397,81 +397,45 @@ as NuGet packages (no source), Metano needs a separate metadata sidecar file:
 - [ ] Compiler plugins para targets customizados (SolidJS JSX, React, etc.)
 - [ ] Source maps cross-project
 
-### Namespace-first imports / barrel-first resolution
+### ~~Namespace-first imports / barrel-first resolution~~ ✅
 
-**Status:** o transpiler hoje expõe barrels por namespace no `package.json`, mas continua
-resolvendo imports internos e cross-package pelo caminho do arquivo concreto. Isso
-diverge da regra desejada para simular o modelo de namespaces do C#:
-
-- desejado: `import { TypeA, TypeB } from "{package}/{namespace-path}"`
-- desejado quando namespace == root namespace / assembly namespace: `import { TypeA } from "{package}"`
-- fallback excepcional: `.../{type-name}` somente quando o barrel introduzir ciclo ou
-  outra ambiguidade real
-
-**Achados do audit (2026-04-10):**
-
-- `PathNaming.ComputeRelativeImportPath()` hoje sempre inclui o nome do arquivo no fim
-  do subpath `#/.../<type-or-file>`; não há modo "barrel-first".
-- `PathNaming.ComputeSubPath()` hoje produz subpaths cross-package com sufixo do arquivo
-  (`@scope/pkg/domain/money`, `@scope/pkg/widgets`, etc.).
-- `ImportCollector` agrupa imports por path já resolvido em arquivo e, portanto, reforça
-  a estratégia file-first tanto para imports locais quanto para cross-package.
-- `PackageJsonWriter` exporta tanto os barrels (`"./issues/domain"`) quanto os arquivos
-  individuais (`"./issues/domain/issue"`), o que viabiliza o comportamento atual.
-- O código gerado em `js/sample-issue-tracker` confirma isso: os imports internos usam
-  `#/issues/domain/issue`, `#/shared-kernel/page-request`, etc., nunca `#/issues/domain`
-  nem `# /shared-kernel`.
-
-**Tarefas:**
-
-- [ ] Introduzir uma estratégia explícita de resolução de imports (`file-first` vs
-      `namespace-first`), deixando `namespace-first` como padrão do target TypeScript.
-- [ ] Alterar `PathNaming` para resolver imports locais para o barrel do namespace
-      (`#/issues/domain`) e usar `#/` somente no root barrel quando o namespace alvo
-      for o root namespace do assembly/projeto.
-- [ ] Alterar o pipeline cross-package para resolver `TsTypeOrigin.SubPath` para o
-      barrel do namespace, usando apenas o nome do package quando o namespace do tipo
-      der match com o root namespace do assembly produtor.
-- [ ] Preservar fallback para caminho do arquivo apenas em cenários detectados de ciclo,
-      colisão de barrel (`index.ts`) ou impossibilidade real de re-export.
-- [ ] Revisar `PackageJsonWriter` para garantir export `"."` estável e compatível com o
-      root barrel, além de decidir se exports por arquivo continuam públicos ou viram
-      fallback interno.
-- [ ] Atualizar os testes existentes que hoje fixam imports file-first e adicionar
-      cobertura para:
-      - imports locais via barrel de namespace
-      - imports cross-package via barrel de namespace
-      - imports root-package quando namespace == root namespace do assembly
-      - fallback para arquivo em caso de ciclo/barrel collision
-- [ ] Regenerar `js/sample-issue-tracker` e validar que os imports passam a usar os
-      barrels de namespace em `src/` e `test/`.
-- [ ] Decidir se `js/metano-runtime` entra na mesma convenção imediatamente ou se fica
-      fora do escopo por ser código manual/runtime e não output direto do transpiler.
-
-**Plano detalhado:** `specs/namespace-imports-plan.md`
-
-### Imports relativos no mesmo namespace
-
-**Status:** hoje o transpiler já trata arquivos do mesmo namespace como exceção ao
-barrel-first, mas ainda usa o alias do package (`#/foo/bar/type`) para esses imports.
-O próximo refinamento é simplificar esse caso para imports relativos locais, deixando a
-regra completa assim:
+Regra final implementada:
 
 - mesmo namespace → import relativo por arquivo (`./issue-workflow`)
 - namespace diferente no mesmo package → barrel de namespace (`#/issues/domain`)
-- cross-package → namespace barrel ou root do package
+- root namespace do assembly no mesmo package → `#`
+- cross-package → `{package}/{namespace-path}` ou só `{package}` quando o tipo está no
+  root namespace do assembly produtor
 
-**Tarefas:**
+**Entregas:**
 
-- [ ] Trocar o fallback de mesmo namespace em `PathNaming` de `#/namespace/type` para
-      import relativo (`./type`) calculado a partir do arquivo atual.
-- [ ] Atualizar `CyclicReferenceDetector` para continuar analisando apenas aliases do
-      package (`#` e `#/*`) e ignorar imports relativos locais.
-- [ ] Ajustar testes que hoje ainda aceitam fallback file-first via alias do package.
-- [ ] Regenerar `js/sample-issue-tracker` e validar que `issues/domain/*` usa imports
-      relativos locais, enquanto `issues/application/*` continua usando barrels.
+- [x] `PathNaming.ComputeRelativeImportPath` resolve para barrel de namespace por padrão
+      e usa `./type-name` como caso especial para mesmo namespace (evita ciclo
+      `file → barrel → file`)
+- [x] `PathNaming.ComputeSubPath` (cross-package) retorna só o namespace path — sem
+      sufixo do arquivo — e vazio quando o namespace casa com o root do assembly
+- [x] `ImportCollector` coleta imports locais num bucket por path e emite uma linha
+      mesclada por barrel (merge + 3-case type-only form: all-value / all-type-only /
+      mixed values-first), espelhando o mesmo padrão já usado pelo loop cross-package
+- [x] `CyclicReferenceDetector` normaliza `#`, `#/...` e `./...` no grafo de ciclos
+- [x] `PackageJsonWriter` expõe `"#"` no `imports` quando há root `index.ts` e gera
+      export `"."` para o root barrel
+- [x] `BarrelFileGenerator` é leaf-only por padrão — preserva tree-shaking
+- [x] Testes novos em `NamespaceTranspileTests`: merge multi-tipo, all-type-only como
+      whole-statement (`import type { ... }`), mixed values-first (`{ V, type T }`)
+- [x] Samples regenerados: `sample-issue-tracker` vai de 9 linhas de import para 2 em
+      `issue-service.ts`; `sample-todo-service` adota values-first no mixed form
 
-**Plano detalhado:** `specs/same-namespace-relative-imports-plan.md`
+**Deixado de fora:**
+
+- [ ] **Root barrel agregado quando o root namespace é puramente sub-namespaces** — pode
+      ser adicionado como opt-in via flag (ex: `--namespace-barrels`) gerando o barrel
+      raiz com `export namespace` para espelhar a hierarquia C#. Ignorado por padrão
+      porque `export namespace { export * from ... }` quebra tree-shaking moderno.
+
+**Planos detalhados (concluídos):**
+- `specs/namespace-imports-plan.md`
+- `specs/same-namespace-relative-imports-plan.md`
 
 ---
 

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -211,6 +211,15 @@ public sealed class ImportCollector(
             (List<string> Names, HashSet<string> TypeOnlyNames)
         >(StringComparer.Ordinal);
 
+        // Per-specifier dedup inside a bucket. The outer `importedNames` set dedupes
+        // by the *referenced* identifier (the key used to look up the symbol), but
+        // `_transpilableTypeMap` is dual-keyed by C# name AND TS name when [Name]
+        // diverges, so two distinct lookup keys can resolve to the same `targetTsName`
+        // and attempt to add it twice. Without this guard the output would be
+        // `import { Foo, Foo } from "..."`. Also: if a specifier is observed as both
+        // value and type-only across iterations, the value form wins — type-only is
+        // the narrower claim, and runtime-imported names must not be demoted to
+        // type-only imports (would break `new Foo(...)` at runtime).
         void AddLocal(string importPath, string name, bool typeOnly)
         {
             if (!localByPath.TryGetValue(importPath, out var bucket))
@@ -218,9 +227,12 @@ public sealed class ImportCollector(
                 bucket = (new List<string>(), new HashSet<string>(StringComparer.Ordinal));
                 localByPath[importPath] = bucket;
             }
-            bucket.Names.Add(name);
+            if (!bucket.Names.Contains(name))
+                bucket.Names.Add(name);
             if (typeOnly)
                 bucket.TypeOnlyNames.Add(name);
+            else
+                bucket.TypeOnlyNames.Remove(name);
         }
 
         foreach (var typeName in referencedTypes.OrderBy(n => n))

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -174,7 +174,6 @@ public sealed class ImportCollector(
         }
         foreach (var (importPath, bucket) in byPath.OrderBy(kv => kv.Key, StringComparer.Ordinal))
         {
-            bucket.Names.Sort(StringComparer.Ordinal);
             // Per-name type-only detection. With `verbatimModuleSyntax: true` in the
             // consumer, importing a type-only reference as a value triggers TS2749 /
             // TS1484, so we mark each name independently:
@@ -190,6 +189,7 @@ public sealed class ImportCollector(
                 .ToHashSet(StringComparer.Ordinal);
             var allTypeOnly = typeOnlyNames.Count == bucket.Names.Count;
             var anyTypeOnly = typeOnlyNames.Count > 0;
+            SortValuesFirst(bucket.Names, typeOnlyNames);
 
             imports.Add(
                 new TsImport(
@@ -199,6 +199,28 @@ public sealed class ImportCollector(
                     TypeOnlyNames: !allTypeOnly && anyTypeOnly ? typeOnlyNames : null
                 )
             );
+        }
+
+        // Local imports (guards + transpilable types within the project) are bucketed
+        // by import path so multiple names from the same barrel collapse into one line.
+        // Same strategy the cross-package loop above uses — keeps barrel-first output
+        // clean and Biome-friendly (e.g., all-type-only → whole-statement `import type`
+        // rather than per-name `{ type A, type B }`).
+        var localByPath = new Dictionary<
+            string,
+            (List<string> Names, HashSet<string> TypeOnlyNames)
+        >(StringComparer.Ordinal);
+
+        void AddLocal(string importPath, string name, bool typeOnly)
+        {
+            if (!localByPath.TryGetValue(importPath, out var bucket))
+            {
+                bucket = (new List<string>(), new HashSet<string>(StringComparer.Ordinal));
+                localByPath[importPath] = bucket;
+            }
+            bucket.Names.Add(name);
+            if (typeOnly)
+                bucket.TypeOnlyNames.Add(name);
         }
 
         foreach (var typeName in referencedTypes.OrderBy(n => n))
@@ -231,7 +253,9 @@ public sealed class ImportCollector(
             )
                 continue;
 
-            // BCL export mapping (e.g., decimal → Decimal from "decimal.js")
+            // BCL export mapping (e.g., decimal → Decimal from "decimal.js").
+            // Not bucketed: each BCL mapping can land on a distinct external package,
+            // and the cross-package merge strategy doesn't apply here.
             var bclEntry = _bclExportMap.Values.FirstOrDefault(e => e.ExportedName == typeName);
             if (
                 bclEntry.ExportedName is not null
@@ -243,7 +267,9 @@ public sealed class ImportCollector(
                 continue;
             }
 
-            // External import mapping ([Import] attribute, with optional AsDefault)
+            // External import mapping ([Import] attribute, with optional AsDefault).
+            // Not bucketed: default imports never merge (`import Foo from "..."` is
+            // one-name-only) and named externals come from arbitrary modules.
             if (
                 _externalImportMap.TryGetValue(typeName, out var extImport)
                 && importedNames.Add(typeName)
@@ -259,7 +285,10 @@ public sealed class ImportCollector(
                 continue;
             }
 
-            // Guard function reference (e.g., isCurrency → import from Currency's file)
+            // Guard function reference (e.g., isCurrency → import from Currency's file).
+            // Bucketed alongside transpilable types so a file that uses both `Currency`
+            // and `isCurrency` ends up with a single `import { Currency, isCurrency }`
+            // line instead of two.
             if (
                 _guardNameToTypeMap.TryGetValue(typeName, out var guardedTypeName)
                 && _transpilableTypeMap.TryGetValue(guardedTypeName, out var guardedSymbol)
@@ -277,7 +306,8 @@ public sealed class ImportCollector(
                     guardNs,
                     guardFileName
                 );
-                imports.Add(new TsImport([typeName], guardPath));
+                // Guards are functions → always imported as values, never type-only.
+                AddLocal(guardPath, typeName, typeOnly: false);
                 continue;
             }
 
@@ -306,10 +336,53 @@ public sealed class ImportCollector(
             // StringEnums generate const objects — always import as value
             var isStringEnum = SymbolHelper.HasStringEnum(referencedSymbol);
             var typeOnly = !valueTypes.Contains(typeName) && !isStringEnum;
-            imports.Add(new TsImport([targetTsName], importPath, TypeOnly: typeOnly));
+            AddLocal(importPath, targetTsName, typeOnly);
+        }
+
+        // Emit one merged TsImport per bucketed local path. Three-case form:
+        //   - all type-only → `import type { A, B } from "..."`       (whole statement)
+        //   - all value     → `import { A, B } from "..."`            (plain)
+        //   - mixed         → `import { A, type B } from "..."`       (per-name)
+        // The whole-statement form is preferred when everything is type-only so Biome's
+        // `noImportTypeQualifier` lint stays quiet.
+        foreach (
+            var (importPath, bucket) in localByPath.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+        )
+        {
+            var allTypeOnly = bucket.TypeOnlyNames.Count == bucket.Names.Count;
+            var anyTypeOnly = bucket.TypeOnlyNames.Count > 0;
+            SortValuesFirst(bucket.Names, bucket.TypeOnlyNames);
+            imports.Add(
+                new TsImport(
+                    bucket.Names.ToArray(),
+                    importPath,
+                    TypeOnly: allTypeOnly,
+                    TypeOnlyNames: !allTypeOnly && anyTypeOnly ? bucket.TypeOnlyNames : null
+                )
+            );
         }
 
         return imports;
+    }
+
+    /// <summary>
+    /// Sorts named-import entries with values first (alphabetical), then type-only
+    /// names (alphabetical). In all-value or all-type-only buckets this reduces to a
+    /// plain alphabetical sort. In mixed buckets it produces the more readable
+    /// <c>{ Value, type Type }</c> shape instead of interleaving them by name.
+    /// </summary>
+    private static void SortValuesFirst(List<string> names, IReadOnlySet<string> typeOnlyNames)
+    {
+        names.Sort(
+            (a, b) =>
+            {
+                var aIsType = typeOnlyNames.Contains(a);
+                var bIsType = typeOnlyNames.Contains(b);
+                if (aIsType != bIsType)
+                    return aIsType ? 1 : -1;
+                return string.CompareOrdinal(a, b);
+            }
+        );
     }
 
     /// <summary>

--- a/tests/Metano.Tests/EndToEndOutputTests.cs
+++ b/tests/Metano.Tests/EndToEndOutputTests.cs
@@ -53,7 +53,8 @@ public class EndToEndOutputTests
         //    Issue is referenced only as a type (the property's declared type) while
         //    IssueStatus is used as a value (the auto-init `= IssueStatus.Open`); the
         //    per-name type qualifier handles the asymmetry without splitting into two
-        //    import statements.
+        //    import statements. Values come first, then types — each group sorted
+        //    alphabetically — so the mixed form reads as `{ Value, type TypeOnly }`.
         //
         // 2. The consumer does NOT import Decimal because it doesn't use decimal
         //    directly — only references Issue, which has a decimal field. The field's
@@ -65,7 +66,7 @@ public class EndToEndOutputTests
         //    TS would leave the field as `undefined` at runtime, breaking equality
         //    checks. The compiler picks the first enum member (value 0) automatically.
         var expected =
-            "import { type Issue, IssueStatus } from \"@acme/issues\";\n"
+            "import { IssueStatus, type Issue } from \"@acme/issues\";\n"
             + "\n"
             + "export class Tracker {\n"
             + "  current: Issue | null = null;\n"

--- a/tests/Metano.Tests/NamespaceTranspileTests.cs
+++ b/tests/Metano.Tests/NamespaceTranspileTests.cs
@@ -147,4 +147,114 @@ public class NamespaceTranspileTests
         // the namespace barrel (`money.ts -> barrel -> ./money.ts`).
         await Assert.That(moneyTs).Contains("from \"./currency\"");
     }
+
+    [Test]
+    public async Task MultipleTypesFromSameBarrel_MergeIntoSingleImportLine()
+    {
+        // Several values from the same foreign namespace should collapse into one
+        // import line pointing at the namespace barrel, not N separate lines.
+        // StringEnums are always imported as values (they generate const objects),
+        // so using three of them keeps the assertion unambiguous.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App.Domain
+            {
+                [Transpile, StringEnum]
+                public enum Priority { Low, High }
+
+                [Transpile, StringEnum]
+                public enum Status { Open, Closed }
+
+                [Transpile, StringEnum]
+                public enum Category { Bug, Feature }
+            }
+
+            namespace App.Application
+            {
+                [Transpile]
+                public readonly record struct Ticket(
+                    App.Domain.Priority Priority,
+                    App.Domain.Status Status,
+                    App.Domain.Category Category
+                );
+            }
+            """
+        );
+
+        var ticketTs = result["application/ticket.ts"];
+        // Merged into a single value import from the domain barrel. Names sorted
+        // alphabetically within the values group.
+        await Assert
+            .That(ticketTs)
+            .Contains("import { Category, Priority, Status } from \"#/domain\";");
+        // And not split across three lines.
+        await Assert.That(ticketTs).DoesNotContain("import { Category } from \"#/domain\"");
+        await Assert.That(ticketTs).DoesNotContain("import { Priority } from \"#/domain\"");
+        await Assert.That(ticketTs).DoesNotContain("import { Status } from \"#/domain\"");
+    }
+
+    [Test]
+    public async Task AllTypeOnlyFromSameBarrel_UsesWholeStatementImportType()
+    {
+        // When every name in a bucket is type-only, prefer the whole-statement
+        // `import type { … }` form over per-name `{ type A, type B }` — the
+        // latter triggers Biome's noImportTypeQualifier warning.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App.Domain
+            {
+                [Transpile]
+                public interface IReadable { string Read(); }
+
+                [Transpile]
+                public interface IWritable { void Write(string value); }
+            }
+
+            namespace App.Application
+            {
+                [Transpile]
+                public interface IHandler
+                {
+                    void Handle(App.Domain.IReadable reader, App.Domain.IWritable writer);
+                }
+            }
+            """
+        );
+
+        var handlerTs = result["application/i-handler.ts"];
+        await Assert
+            .That(handlerTs)
+            .Contains("import type { IReadable, IWritable } from \"#/domain\";");
+        // No per-name type qualifier form.
+        await Assert.That(handlerTs).DoesNotContain("{ type IReadable");
+        await Assert.That(handlerTs).DoesNotContain("type IWritable }");
+    }
+
+    [Test]
+    public async Task MixedValueAndTypeOnlyFromSameBarrel_UsesPerNameQualifier()
+    {
+        // Mixed bucket: values stay plain, types get the inline `type` qualifier.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App.Domain
+            {
+                [Transpile, StringEnum]
+                public enum Priority { Low, High }
+
+                [Transpile]
+                public interface IReadable { string Read(); }
+            }
+
+            namespace App.Application
+            {
+                [Transpile]
+                public readonly record struct Job(App.Domain.Priority Priority, App.Domain.IReadable Reader);
+            }
+            """
+        );
+
+        var jobTs = result["application/job.ts"];
+        // Priority is a StringEnum (value); IReadable is an interface (type-only).
+        await Assert.That(jobTs).Contains("import { Priority, type IReadable } from \"#/domain\";");
+    }
 }


### PR DESCRIPTION
Refactor ImportCollector's local-type branch to bucket by import path and emit one merged TsImport per barrel, mirroring the strategy the cross-package branch already uses. Guards and transpilable types share the same bucket so `Currency` + `isCurrency` collapse onto a single line.

Extract SortValuesFirst and apply it in both the cross-package and local emit loops so mixed type-only imports consistently read as `{ Value, type TypeOnly }` instead of interleaving names by ordinal.

Output impact: in sample-issue-tracker, `issue-service.ts` goes from 9 import lines to 2; `sample-todo-service` adopts values-first in the mixed cross-package form. All four test suites stay green (C# 337, metano-runtime 261, sample-todo 18, sample-todo-service 9, sample-issue-tracker 51).

Adds NamespaceTranspileTests coverage for multi-type merge, all-type-only whole-statement form, and mixed values-first. Updates EndToEndOutputTests to match the new ordering. Marks the namespace-first imports section as done in specs/next-steps.md and fixes a stale `<package>/<ns>/<file>` reference in the cross-project description.

Closes #12