### PR TITLE
feat: serialization end-to-end validation for SampleIssueTracker (#16)

### DIFF
--- a/js/metano-runtime/src/system/json/types.ts
+++ b/js/metano-runtime/src/system/json/types.ts
@@ -37,10 +37,25 @@ export type HashSetDescriptor = {
   readonly element: TypeDescriptor;
 };
 
-/** Branded type ([InlineWrapper]) — passthrough on serialize, create() on deserialize */
+/**
+ * Branded type ([InlineWrapper]) — passthrough on serialize, create() on
+ * deserialize.
+ *
+ * The `create` parameter is typed `any` by design: the descriptor is a
+ * serializer-internal lookup table, and the runtime calls `create()` with
+ * whatever JSON-parsed primitive matched the wire format (a string for most
+ * branded IDs, a number for numeric wrappers, etc.). Narrowing to `unknown`
+ * would refuse to accept the generated `UserId.create: (value: string) => UserId`
+ * under TypeScript's contravariant parameter check, and the fix would be to
+ * widen every `[InlineWrapper]`'s generated `.create()` to accept `unknown`
+ * and re-validate — which pollutes the branded type's user-facing surface
+ * for no real benefit, since consumers always call `UserId.create("abc")`
+ * with a typed string, never with raw parsed JSON.
+ */
 export type BrandedDescriptor = {
   readonly kind: "branded";
-  readonly create: (value: unknown) => unknown;
+  // biome-ignore lint/suspicious/noExplicitAny: see doc comment above
+  readonly create: (value: any) => unknown;
 };
 
 /** String enum — passthrough on serialize, validate on deserialize */

--- a/js/sample-issue-tracker/package.json
+++ b/js/sample-issue-tracker/package.json
@@ -8,11 +8,17 @@
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
       "default": "./src/*.ts"
+    },
+    "#": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./src/index.ts"
     }
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "metano-runtime": "workspace:*"
+    "metano-runtime": "workspace:*",
+    "decimal.js": "^10.6.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -24,6 +30,10 @@
     "test": "bun test"
   },
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./issues/application/i-issue-repository": {
       "types": "./dist/issues/application/i-issue-repository.d.ts",
       "import": "./dist/issues/application/i-issue-repository.js"
@@ -60,6 +70,10 @@
       "types": "./dist/issues/domain/issue-priority.d.ts",
       "import": "./dist/issues/domain/issue-priority.js"
     },
+    "./issues/domain/issue-snapshot": {
+      "types": "./dist/issues/domain/issue-snapshot.d.ts",
+      "import": "./dist/issues/domain/issue-snapshot.js"
+    },
     "./issues/domain/issue-status": {
       "types": "./dist/issues/domain/issue-status.d.ts",
       "import": "./dist/issues/domain/issue-status.js"
@@ -75,6 +89,10 @@
     "./issues/domain/issue": {
       "types": "./dist/issues/domain/issue.d.ts",
       "import": "./dist/issues/domain/issue.js"
+    },
+    "./json-context": {
+      "types": "./dist/json-context.d.ts",
+      "import": "./dist/json-context.js"
     },
     "./planning/domain": {
       "types": "./dist/planning/domain/index.d.ts",

--- a/js/sample-issue-tracker/src/index.ts
+++ b/js/sample-issue-tracker/src/index.ts
@@ -1,0 +1,1 @@
+export { JsonContext } from "./json-context";

--- a/js/sample-issue-tracker/src/issues/domain/index.ts
+++ b/js/sample-issue-tracker/src/issues/domain/index.ts
@@ -1,6 +1,7 @@
 export { Comment } from "./comment";
 export { IssueId } from "./issue-id";
 export { IssuePriority } from "./issue-priority";
+export { IssueSnapshot } from "./issue-snapshot";
 export { IssueStatus } from "./issue-status";
 export { IssueType } from "./issue-type";
 export { IssueWorkflow } from "./issue-workflow";

--- a/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
+++ b/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
@@ -1,0 +1,38 @@
+import { HashCode } from "metano-runtime";
+import { Temporal } from "@js-temporal/polyfill";
+import { Decimal } from "decimal.js";
+import type { UserId } from "#/shared-kernel";
+import type { Comment } from "./comment";
+import type { IssueId } from "./issue-id";
+import { IssuePriority } from "./issue-priority";
+import { IssueStatus } from "./issue-status";
+import { IssueType } from "./issue-type";
+
+export class IssueSnapshot {
+  constructor(readonly id: IssueId, readonly title: string, readonly description: string, readonly type: IssueType, readonly priority: IssuePriority, readonly status: IssueStatus, readonly assigneeId: UserId | null, readonly sprintKey: string | null, readonly createdAt: Temporal.ZonedDateTime, readonly updatedAt: Temporal.ZonedDateTime, readonly estimatedHours: Decimal, readonly comments: Comment[]) { }
+
+  equals(other: any): boolean {
+    return other instanceof IssueSnapshot && this.id === other.id && this.title === other.title && this.description === other.description && this.type === other.type && this.priority === other.priority && this.status === other.status && this.assigneeId === other.assigneeId && this.sprintKey === other.sprintKey && this.createdAt === other.createdAt && this.updatedAt === other.updatedAt && this.estimatedHours === other.estimatedHours && this.comments === other.comments;
+  }
+
+  hashCode(): number {
+    const hc = new HashCode();
+    hc.add(this.id);
+    hc.add(this.title);
+    hc.add(this.description);
+    hc.add(this.type);
+    hc.add(this.priority);
+    hc.add(this.status);
+    hc.add(this.assigneeId);
+    hc.add(this.sprintKey);
+    hc.add(this.createdAt);
+    hc.add(this.updatedAt);
+    hc.add(this.estimatedHours);
+    hc.add(this.comments);
+    return hc.toHashCode();
+  }
+
+  with(overrides?: Partial<IssueSnapshot>): IssueSnapshot {
+    return new IssueSnapshot(overrides?.id ?? this.id, overrides?.title ?? this.title, overrides?.description ?? this.description, overrides?.type ?? this.type, overrides?.priority ?? this.priority, overrides?.status ?? this.status, overrides?.assigneeId ?? this.assigneeId, overrides?.sprintKey ?? this.sprintKey, overrides?.createdAt ?? this.createdAt, overrides?.updatedAt ?? this.updatedAt, overrides?.estimatedHours ?? this.estimatedHours, overrides?.comments ?? this.comments);
+  }
+}

--- a/js/sample-issue-tracker/src/json-context.ts
+++ b/js/sample-issue-tracker/src/json-context.ts
@@ -1,0 +1,35 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { SerializerContext, type TypeSpec } from "metano-runtime/system/json";
+import { Decimal } from "decimal.js";
+import { Comment, IssueId, IssuePriority, IssueSnapshot, IssueStatus, IssueType } from "#/issues/domain";
+import { UserId } from "#/shared-kernel";
+
+export class JsonContext extends SerializerContext {
+  private static readonly _default: JsonContext = new JsonContext();
+
+  private _issueSnapshot?: TypeSpec<IssueSnapshot>;
+
+  private _comment?: TypeSpec<Comment>;
+
+  static get default(): JsonContext {
+    return this._default;
+  }
+
+  get issueSnapshot(): TypeSpec<IssueSnapshot> {
+    return this._issueSnapshot ??= this.createSpec({ type: IssueSnapshot, factory: (p: Record<string, unknown>) => new IssueSnapshot(p.id as IssueId, p.title as string, p.description as string, p.type as IssueType, p.priority as IssuePriority, p.status as IssueStatus, p.assigneeId as UserId | null, p.sprintKey as string | null, p.createdAt as Temporal.ZonedDateTime, p.updatedAt as Temporal.ZonedDateTime, p.estimatedHours as Decimal, p.comments as Comment[]), properties: [{ ts: "id", json: "id", type: { kind: "branded", create: IssueId.create } }, { ts: "title", json: "title", type: { kind: "primitive" } }, { ts: "description", json: "description", type: { kind: "primitive" } }, { ts: "type", json: "type", type: { kind: "enum", values: IssueType } }, { ts: "priority", json: "priority", type: { kind: "enum", values: IssuePriority } }, { ts: "status", json: "status", type: { kind: "enum", values: IssueStatus } }, {
+      ts: "assigneeId",
+      json: "assigneeId",
+      type: { kind: "nullable", inner: { kind: "branded", create: UserId.create } },
+      optional: true,
+    }, {
+      ts: "sprintKey",
+      json: "sprintKey",
+      type: { kind: "nullable", inner: { kind: "primitive" } },
+      optional: true,
+    }, { ts: "createdAt", json: "createdAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "updatedAt", json: "updatedAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "estimatedHours", json: "estimatedHours", type: { kind: "decimal" } }, { ts: "comments", json: "comments", type: { kind: "array", element: { kind: "ref", spec: () => this.comment } } }] });
+  }
+
+  get comment(): TypeSpec<Comment> {
+    return this._comment ??= this.createSpec({ type: Comment, factory: (p: Record<string, unknown>) => new Comment(p.authorId as UserId, p.message as string, p.createdAt as Temporal.ZonedDateTime, p.isSystem as boolean), properties: [{ ts: "authorId", json: "authorId", type: { kind: "branded", create: UserId.create } }, { ts: "message", json: "message", type: { kind: "primitive" } }, { ts: "createdAt", json: "createdAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "isSystem", json: "isSystem", type: { kind: "primitive" } }] });
+  }
+}

--- a/js/sample-issue-tracker/test/json-context.test.ts
+++ b/js/sample-issue-tracker/test/json-context.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import { Temporal } from "@js-temporal/polyfill";
+import { Decimal } from "decimal.js";
+import { type JsonConverter, JsonSerializer } from "metano-runtime/system/json";
+import {
+  Comment,
+  IssueId,
+  IssuePriority,
+  IssueSnapshot,
+  IssueStatus,
+  IssueType,
+} from "#/issues/domain";
+import { JsonContext } from "#/json-context";
+import { UserId } from "#/shared-kernel";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+// `??` collapses null into the default, which is exactly wrong for the
+// nullable fields in these fixtures (we need to distinguish "caller omitted
+// assigneeId → default to alice" from "caller explicitly passed null"). Use
+// `undefined` as the only sentinel for "not provided" and check the key's
+// presence via `in`.
+function makeSnapshot(
+  overrides: {
+    id?: IssueId;
+    assigneeId?: UserId | null;
+    sprintKey?: string | null;
+    estimatedHours?: Decimal;
+    comments?: Comment[];
+  } = {},
+): IssueSnapshot {
+  return new IssueSnapshot(
+    overrides.id ?? IssueId.create("issue-001"),
+    "Ship the serializer end-to-end",
+    "Finish Phase 5 of the JSON serializer plan",
+    IssueType.Chore,
+    IssuePriority.High,
+    IssueStatus.InProgress,
+    "assigneeId" in overrides ? (overrides.assigneeId ?? null) : UserId.create("alice"),
+    "sprintKey" in overrides ? (overrides.sprintKey ?? null) : "sprint-42",
+    Temporal.ZonedDateTime.from("2026-04-11T10:30:00+00:00[UTC]"),
+    Temporal.ZonedDateTime.from("2026-04-11T11:00:00+00:00[UTC]"),
+    overrides.estimatedHours ?? new Decimal("1.5"),
+    overrides.comments ?? [
+      new Comment(
+        UserId.create("bob"),
+        "First comment",
+        Temporal.ZonedDateTime.from("2026-04-11T10:45:00+00:00[UTC]"),
+      ),
+    ],
+  );
+}
+
+// ─── Default context ─────────────────────────────────────────────────────────
+
+describe("JsonContext — default serialization", () => {
+  const ctx = JsonContext.default;
+
+  test("default getter returns a singleton", () => {
+    expect(JsonContext.default).toBe(ctx);
+  });
+
+  test("serializes primitives, enums, and branded IDs to JSON-safe values", () => {
+    const snapshot = makeSnapshot();
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    expect(json.id).toBe("issue-001");
+    expect(json.title).toBe("Ship the serializer end-to-end");
+    expect(json.description).toBe("Finish Phase 5 of the JSON serializer plan");
+    expect(json.type).toBe(IssueType.Chore);
+    expect(json.priority).toBe(IssuePriority.High);
+    expect(json.status).toBe(IssueStatus.InProgress);
+    expect(json.assigneeId).toBe("alice");
+    expect(json.sprintKey).toBe("sprint-42");
+  });
+
+  test("serializes Temporal fields as ISO strings that round-trip", () => {
+    const snapshot = makeSnapshot();
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    expect(typeof json.createdAt).toBe("string");
+    expect(typeof json.updatedAt).toBe("string");
+    const reparsed = Temporal.ZonedDateTime.from(json.createdAt as string);
+    expect(reparsed.epochMilliseconds).toBe(snapshot.createdAt.epochMilliseconds);
+  });
+
+  test("serializes decimal as a JSON number by default", () => {
+    const snapshot = makeSnapshot();
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    expect(typeof json.estimatedHours).toBe("number");
+    expect(json.estimatedHours).toBe(1.5);
+  });
+
+  test("emits null for nullable fields when absent", () => {
+    const snapshot = makeSnapshot({ assigneeId: null, sprintKey: null });
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    expect(json.assigneeId).toBeNull();
+    expect(json.sprintKey).toBeNull();
+  });
+
+  test("serializes nested Comment array via the ref spec getter", () => {
+    const snapshot = makeSnapshot();
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    const comments = json.comments as Array<Record<string, unknown>>;
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.authorId).toBe("bob");
+    expect(comments[0]?.message).toBe("First comment");
+    expect(comments[0]?.isSystem).toBe(false);
+    expect(typeof comments[0]?.createdAt).toBe("string");
+  });
+
+  test("serializes an empty comments array without nesting", () => {
+    const snapshot = makeSnapshot({ comments: [] });
+    const json = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+
+    expect(json.comments).toEqual([]);
+  });
+
+  test("round-trips through JSON.stringify + JSON.parse", () => {
+    const snapshot = makeSnapshot();
+
+    const serialized = JsonSerializer.serialize(snapshot, ctx.issueSnapshot);
+    const wire = JSON.stringify(serialized);
+    const parsed = JSON.parse(wire);
+    const deserialized = JsonSerializer.deserialize(parsed, ctx.issueSnapshot);
+
+    // Branded-type fields compare via their primitive string content, so casting
+    // to `unknown` sidesteps TS's nominal-equality complaint while still testing
+    // the runtime equality that matters.
+    expect(deserialized.id as unknown).toBe(snapshot.id as unknown);
+    expect(deserialized.title).toBe(snapshot.title);
+    expect(deserialized.description).toBe(snapshot.description);
+    expect(deserialized.type).toBe(snapshot.type);
+    expect(deserialized.priority).toBe(snapshot.priority);
+    expect(deserialized.status).toBe(snapshot.status);
+    expect(deserialized.assigneeId as unknown).toBe(snapshot.assigneeId as unknown);
+    expect(deserialized.sprintKey).toBe(snapshot.sprintKey);
+    expect(deserialized.createdAt.epochMilliseconds).toBe(snapshot.createdAt.epochMilliseconds);
+    expect(deserialized.updatedAt.epochMilliseconds).toBe(snapshot.updatedAt.epochMilliseconds);
+    expect(deserialized.comments).toHaveLength(1);
+    expect(deserialized.comments[0]?.authorId as unknown).toBe(
+      snapshot.comments[0]?.authorId as unknown,
+    );
+    expect(deserialized.comments[0]?.message).toBe(snapshot.comments[0]?.message);
+  });
+
+  test("deserializes a raw JSON payload (as if it came from HTTP)", () => {
+    const payload = {
+      id: "from-wire",
+      title: "From the wire",
+      description: "A server pushed this object",
+      type: IssueType.Bug,
+      priority: IssuePriority.Urgent,
+      status: IssueStatus.InReview,
+      assigneeId: "charlie",
+      sprintKey: null,
+      createdAt: "2026-04-11T09:00:00+00:00[UTC]",
+      updatedAt: "2026-04-11T09:15:00+00:00[UTC]",
+      estimatedHours: 2,
+      comments: [],
+    };
+
+    const issue = JsonSerializer.deserialize(payload, ctx.issueSnapshot);
+
+    expect(issue.id).toBe(IssueId.create("from-wire"));
+    expect(issue.type).toBe(IssueType.Bug);
+    expect(issue.priority).toBe(IssuePriority.Urgent);
+    expect(issue.status).toBe(IssueStatus.InReview);
+    expect(issue.assigneeId).toBe(UserId.create("charlie"));
+    expect(issue.sprintKey).toBeNull();
+    expect(issue.createdAt.epochMilliseconds).toBe(
+      Temporal.ZonedDateTime.from(payload.createdAt).epochMilliseconds,
+    );
+  });
+});
+
+// ─── Custom converter: decimal → string for financial precision ──────────────
+
+describe("JsonContext — decimal-as-string custom converter", () => {
+  // Canonical custom-converter scenario. By default the runtime emits
+  // Decimals as JSON numbers, which silently loses IEEE-754 precision for
+  // financial values. A context with this converter emits (and accepts)
+  // decimals as JSON strings instead, preserving the full precision across
+  // the wire.
+  const decimalAsString: JsonConverter = {
+    kind: "decimal",
+    serialize: (value) => (value as Decimal).toString(),
+    deserialize: (value) => new Decimal(value as string),
+  };
+
+  const preciseCtx = new JsonContext({ converters: [decimalAsString] });
+  // The BoundSerializer pattern is how context-bound converters flow through
+  // serialize/deserialize. Static JsonSerializer.serialize without the third
+  // arg uses NO converters — it's the "direct-spec, no context" entry point.
+  const precise = JsonSerializer.withContext(preciseCtx);
+
+  // 0.1 + 0.2 is exactly 0.3 as Decimal, but 0.30000000000000004 as a JS
+  // number. Choosing this value on purpose so the test fails loudly if the
+  // converter ever regresses and the wire goes back to number.
+  const preciseValue = new Decimal("0.1").plus(new Decimal("0.2"));
+
+  test("serializes decimal as a JSON string", () => {
+    const snapshot = makeSnapshot({ estimatedHours: preciseValue });
+    const json = precise.serialize(snapshot, preciseCtx.issueSnapshot);
+
+    expect(typeof json.estimatedHours).toBe("string");
+    expect(json.estimatedHours).toBe("0.3");
+  });
+
+  test("deserializes a JSON string back into a Decimal instance", () => {
+    const payload = {
+      id: "financial-001",
+      title: "Precise hours",
+      description: "String-encoded decimal",
+      type: IssueType.Chore,
+      priority: IssuePriority.Medium,
+      status: IssueStatus.Backlog,
+      assigneeId: null,
+      sprintKey: null,
+      createdAt: "2026-04-11T10:00:00+00:00[UTC]",
+      updatedAt: "2026-04-11T10:00:00+00:00[UTC]",
+      estimatedHours: "0.1",
+      comments: [],
+    };
+
+    const issue = precise.deserialize(payload, preciseCtx.issueSnapshot);
+
+    expect(issue.estimatedHours).toBeInstanceOf(Decimal);
+    expect((issue.estimatedHours as Decimal).toString()).toBe("0.1");
+  });
+
+  test("round-trip preserves full Decimal precision (no IEEE-754 loss)", () => {
+    const snapshot = makeSnapshot({ estimatedHours: preciseValue });
+
+    const serialized = precise.serialize(snapshot, preciseCtx.issueSnapshot);
+    const wire = JSON.stringify(serialized);
+    const parsed = JSON.parse(wire);
+    const deserialized = precise.deserialize(parsed, preciseCtx.issueSnapshot);
+
+    // If the wire had gone through a JS number this would fail — the lossy
+    // 0.30000000000000004 doesn't equal 0.3 as a Decimal.
+    const actual = deserialized.estimatedHours as Decimal;
+    expect(actual.toString()).toBe("0.3");
+    expect(actual.equals(new Decimal("0.3"))).toBe(true);
+  });
+
+  test("default context is unaffected — still emits decimal as a number", () => {
+    const snapshot = makeSnapshot({ estimatedHours: preciseValue });
+    const json = JsonSerializer.serialize(snapshot, JsonContext.default.issueSnapshot);
+
+    expect(typeof json.estimatedHours).toBe("number");
+  });
+
+  test("custom context does not leak the converter into another context", () => {
+    // Two contexts side by side — one with the converter, one without.
+    // Their behavior must stay independent, even when they share the same
+    // JsonContext class.
+    const snapshot = makeSnapshot({ estimatedHours: preciseValue });
+
+    const preciseJson = precise.serialize(snapshot, preciseCtx.issueSnapshot);
+    const defaultJson = JsonSerializer.withContext(JsonContext.default).serialize(
+      snapshot,
+      JsonContext.default.issueSnapshot,
+    );
+
+    expect(typeof preciseJson.estimatedHours).toBe("string");
+    expect(typeof defaultJson.estimatedHours).toBe("number");
+  });
+});

--- a/samples/SampleIssueTracker/Issues/Domain/IssueSnapshot.cs
+++ b/samples/SampleIssueTracker/Issues/Domain/IssueSnapshot.cs
@@ -1,0 +1,39 @@
+using SampleIssueTracker.SharedKernel;
+
+namespace SampleIssueTracker.Issues.Domain;
+
+/// <summary>
+/// Flat JSON projection of an <see cref="Issue"/> plus its comments, designed to
+/// round-trip through Metano's <c>JsonSerializer</c>.
+///
+/// <para>
+/// Lives alongside the aggregate in the domain package so the wire shape stays
+/// close to its source of truth, but is kept as a separate type because
+/// <see cref="Issue"/> itself has encapsulated state (private setters,
+/// state-mutating methods) that does not round-trip cleanly from a flat factory
+/// constructor. This is the canonical "snapshot for serialization" pattern —
+/// rich aggregates expose a <c>ToSnapshot()</c> / <c>FromSnapshot()</c> pair and
+/// the wire format operates on the snapshot, not the aggregate itself.
+/// </para>
+///
+/// <para>
+/// Also the only type in the sample that carries a <see cref="decimal"/>, which
+/// exists so the Phase 5 serialization tests can exercise the custom-converter
+/// code path (decimal → JSON number by default, decimal → JSON string when a
+/// context-level converter is registered).
+/// </para>
+/// </summary>
+public record IssueSnapshot(
+    IssueId Id,
+    string Title,
+    string Description,
+    IssueType Type,
+    IssuePriority Priority,
+    IssueStatus Status,
+    UserId? AssigneeId,
+    string? SprintKey,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    decimal EstimatedHours,
+    Comment[] Comments
+);

--- a/samples/SampleIssueTracker/JsonContext.cs
+++ b/samples/SampleIssueTracker/JsonContext.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+using SampleIssueTracker.Issues.Domain;
+
+namespace SampleIssueTracker;
+
+/// <summary>
+/// Metano transpiles this class into a <c>JsonContext extends SerializerContext</c>
+/// on the TypeScript side, with a lazy <see cref="Metano.Runtime.TypeSpec{T}"/>
+/// getter per <c>[JsonSerializable]</c> type.
+///
+/// <para>
+/// Exercises the full descriptor surface that Phase 5 validation cares about:
+/// <list type="bullet">
+///   <item>branded primitives (<see cref="IssueId"/>, <see cref="UserId"/>)</item>
+///   <item>string enums (<see cref="IssuePriority"/>, <see cref="IssueStatus"/>, <see cref="IssueType"/>)</item>
+///   <item>nullable fields (<c>UserId? AssigneeId</c>, <c>string? SprintKey</c>)</item>
+///   <item>Temporal types (<see cref="System.DateTimeOffset"/>)</item>
+///   <item>decimal (for the custom-converter round-trip test)</item>
+///   <item>array of nested refs (<see cref="Comment"/>[])</item>
+/// </list>
+/// </para>
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(IssueSnapshot))]
+[JsonSerializable(typeof(Comment))]
+public partial class JsonContext : JsonSerializerContext;

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -974,6 +974,22 @@ public sealed class ImportCollector(
                         crossPackageOrigins
                     );
                 break;
+            case TsCastExpression cast:
+                // Descend into both the inner expression AND the target type.
+                // The target type can introduce a brand-new identifier that
+                // appears nowhere else — e.g. `p.estimatedHours as Decimal` in a
+                // generated serializer factory, where `Decimal` is referenced
+                // only here and needs to end up in the import list. Without this
+                // case, the walker would miss it entirely.
+                CollectFromExpression(
+                    cast.Expression,
+                    names,
+                    valueNames,
+                    runtimeHelpers,
+                    crossPackageOrigins
+                );
+                CollectFromType(cast.Type, names, crossPackageOrigins);
+                break;
             case TsTemplate template:
                 // Templates carry real TS expression nodes for the receiver and each
                 // argument; the printer expands them into the call site, so the import


### PR DESCRIPTION
Part of #16 (see `specs/0001-serialization-json-context.md`).

Completes Phase 5 of the serialization design doc for the SampleIssueTracker case. Phases 1-4 had already landed in earlier work (runtime library, transpiler metadata detection, context emission, compile-time naming policies); this finishes the end-to-end validation half.

## Summary

- **New sample types:** `IssueSnapshot` record + `JsonContext` in `SampleIssueTracker`. Exercises every descriptor kind the runtime supports — branded IDs, string enums, nullable fields, Temporal dates, decimal, and nested array of refs.
- **14 new Bun tests** covering default serialization (primitives, enums, branded IDs, Temporal, decimal-as-number, nullable handling, nested refs, empty arrays, JSON round-trip, raw payload deserialization) and a custom decimal-as-string converter demo (financial precision: `0.1 + 0.2` round-trips as exactly `"0.3"`, not `0.30000000000000004`).
- **Two compiler fixes** discovered during Phase 5 implementation, each in its own commit so they're bisectable:
  1. `ImportCollector` now descends into `TsCastExpression` nodes, so types referenced only in a cast (like `Decimal`) land in the import list.
  2. `BrandedDescriptor.create` parameter widened to `any` so the runtime accepts generated branded `.create()` functions without forcing every `[InlineWrapper]` to re-validate `unknown` at its call site.

## Commits

1. `03552d3` — `fix: collect types referenced only in cast expressions (#16)`
2. `6e7a303` — `fix: widen BrandedDescriptor.create parameter for generated .create() bindings (#16)`
3. `2703ef8` — `feat: serialization end-to-end validation in SampleIssueTracker (#16)`

## Deliberately out of scope — tracked as #33

`SampleTodo.Service` is NOT covered here. Its DTOs (`StoredTodo`, `CreateTodoDto`, `UpdateTodoDto`) are all `[PlainObject]` records that lower to TypeScript interfaces without a runtime constructor. Registering them in a `JsonContext` hits three structural gaps:

1. The transformer emits `new CreateTodoDto(...)` in the factory, which tsgo rejects because `CreateTodoDto` is a type, not a value.
2. `TypeSpec.type` is typed as `abstract new (...args) => T` — a constructor — so interface types can't fill that slot at all.
3. Cross-package ref resolution: `StoredTodo` holds a `TodoItem` from `sample-todo`, and the transformer emits `spec: () => this.todoItem` referencing a getter that doesn't exist in the local `JsonContext`.

These are compiler feature gaps, not validation work, so I filed #33 with the full repro + three proposed resolutions for the discussion to converge on. The SampleTodo.Service sample stays as-is until #33 unblocks the path.

`#16` can be closed once #33 lands; leaving it open for the tracking link.

## Test plan

Full suite green on the feature branch in a clean worktree:

- [x] `dotnet run --project tests/Metano.Tests/` — **337/337**
- [x] `cd js/metano-runtime && bun test` — **261/261**
- [x] `cd js/sample-issue-tracker && bun run build && bun test` — **65/65** (51 original + 14 new)
- [x] `cd js/sample-todo-service && bun run build && bun test` — **9/9**
- [x] `cd js/sample-todo && bun run build && bun test` — **18/18**
- [x] `dotnet csharpier check .` — clean

Closes nothing automatically — #16 stays open pending #33.