### PR TITLE
chore: gitignore the tasks/ working-plan dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ Thumbs.db
 # Build artifacts
 *.tsbuildinfo
 bun.lock
+
+# Local working plans (per CLAUDE.md workflow — private per-session notes,
+# not committed — the authoritative backlog lives in GitHub issues)
+tasks/


### PR DESCRIPTION
Tiny housekeeping change. The CLAUDE.md workflow convention puts per-session working plans under `tasks/todo.md`; those are private notes, not committed — the authoritative backlog lives in GitHub issues. Adding `tasks/` to `.gitignore` keeps `git status` quiet in the main repo working copy.

No code changes, no tests affected, safe to merge without review.