### PR TITLE
fix: blank-line spacing and complexity-aware formatting in Printer (#35)

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -2,6 +2,18 @@
   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
   "tasks": [
     {
+      "name": "csharpier-format",
+      "group": "pre-commit",
+      "command": "dotnet",
+      "args": ["csharpier", "format", "."]
+    },
+    {
+      "name": "biome-fix",
+      "group": "pre-commit",
+      "command": "bash",
+      "args": ["-c", "cd js && bunx biome check --fix ."]
+    },
+    {
       "name": "csharpier-check",
       "group": "pre-push",
       "command": "dotnet",

--- a/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
+++ b/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
@@ -18,11 +18,13 @@ export class InMemoryIssueRepository implements IIssueRepository {
 
   saveAsync(entity: Issue): Promise<void> {
     const existingIndex = this._issues.findIndex((issue: Issue) => issue.id === entity.id);
+
     if (existingIndex >= 0) {
       this._issues[existingIndex] = entity;
     } else {
       this._issues.push(entity);
     }
+
     return Promise.resolve();
   }
 
@@ -37,6 +39,7 @@ export class InMemoryIssueRepository implements IIssueRepository {
   searchAsync(status: IssueStatus | null, priority: IssuePriority | null, assigneeId: UserId | null, sprintKey: string | null, page: PageRequest): Promise<PageResult<Issue>> {
     const filtered = Enumerable.from(this._issues).where((issue: Issue) => status === null || issue.status === status).where((issue: Issue) => priority === null || issue.priority === priority).where((issue: Issue) => assigneeId === null || issue.assigneeId === assigneeId).where((issue: Issue) => sprintKey === null || issue.sprintKey === sprintKey).orderByDescending((issue: Issue) => issue.priority).thenBy((issue: Issue) => issue.title).toArray();
     const items = Enumerable.from(filtered).skip(page.skip).take(page.safeSize).toArray();
+
     return Promise.resolve(new PageResult(items, filtered.length, page));
   }
 }

--- a/js/sample-issue-tracker/src/issues/application/issue-service.ts
+++ b/js/sample-issue-tracker/src/issues/application/issue-service.ts
@@ -13,6 +13,7 @@ export class IssueService {
   private async createAsyncTitleDescriptionTypePriority(title: string, description: string, type: IssueType, priority: IssuePriority): Promise<OperationResult<Issue>> {
     const issue = new Issue(IssueId.new_(), title, description, type, priority);
     await this._repository.saveAsync(issue);
+
     return OperationResult.ok(issue);
   }
 
@@ -26,48 +27,60 @@ export class IssueService {
     if (args.length === 4 && isString(args[0]) && isString(args[1]) && (args[2] === "story" || args[2] === "bug" || args[2] === "chore" || args[2] === "spike") && (args[3] === "low" || args[3] === "medium" || args[3] === "high" || args[3] === "urgent")) {
       return this.createAsyncTitleDescriptionTypePriority(args[0] as string, args[1] as string, args[2] as IssueType, args[3] as IssuePriority);
     }
+
     if (args.length === 3 && isString(args[0]) && isString(args[1]) && (args[2] === "story" || args[2] === "bug" || args[2] === "chore" || args[2] === "spike")) {
       return this.createAsyncTitleDescriptionType(args[0] as string, args[1] as string, args[2] as IssueType);
     }
+
     throw new Error("No matching overload for createAsync");
   }
 
   async loadAsync(issueId: IssueId): Promise<OperationResult<Issue>> {
     const issue = await this._repository.getByIdAsync(issueId);
+
     return issue === null ? OperationResult.fail("issue_not_found", `Issue ${issueId} was not found.`) : OperationResult.ok(issue);
   }
 
   async assignAsync(issueId: IssueId, assigneeId: UserId): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
+
     if (!loadResult.hasValue || loadResult.value === null) {
       return loadResult;
     }
+
     loadResult.value.assignTo(assigneeId);
     await this._repository.saveAsync(loadResult.value);
+
     return loadResult;
   }
 
   async planSprintAsync(issueId: IssueId, sprintKey: string): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
+
     if (!loadResult.hasValue || loadResult.value === null) {
       return loadResult;
     }
+
     loadResult.value.planForSprint(sprintKey);
     await this._repository.saveAsync(loadResult.value);
+
     return loadResult;
   }
 
   private async addCommentAsyncIssueIdAuthorIdMessage(issueId: IssueId, authorId: UserId, message: string): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
+
     if (!loadResult.hasValue || loadResult.value === null) {
       return loadResult;
     }
+
     return await this.addCommentAsync(loadResult.value, authorId, message);
   }
 
   private async addCommentAsyncIssueAuthorIdMessage(issue: Issue, authorId: UserId, message: string): Promise<OperationResult<Issue>> {
     issue.addComment(authorId, message);
     await this._repository.saveAsync(issue);
+
     return OperationResult.ok(issue);
   }
 
@@ -77,19 +90,24 @@ export class IssueService {
     if (args.length === 3 && typeof args[0] === "string" && typeof args[1] === "string" && isString(args[2])) {
       return this.addCommentAsyncIssueIdAuthorIdMessage(args[0] as IssueId, args[1] as UserId, args[2] as string);
     }
+
     if (args.length === 3 && args[0] instanceof Issue && typeof args[1] === "string" && isString(args[2])) {
       return this.addCommentAsyncIssueAuthorIdMessage(args[0] as Issue, args[1] as UserId, args[2] as string);
     }
+
     throw new Error("No matching overload for addCommentAsync");
   }
 
   async transitionAsync(issueId: IssueId, nextStatus: IssueStatus, actorId: UserId): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
+
     if (!loadResult.hasValue || loadResult.value === null) {
       return loadResult;
     }
+
     loadResult.value.transitionTo(nextStatus, actorId);
     await this._repository.saveAsync(loadResult.value);
+
     return loadResult;
   }
 

--- a/js/sample-issue-tracker/src/issues/domain/comment.ts
+++ b/js/sample-issue-tracker/src/issues/domain/comment.ts
@@ -19,6 +19,7 @@ export class Comment {
     hc.add(this.message);
     hc.add(this.createdAt);
     hc.add(this.isSystem);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
+++ b/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
@@ -29,6 +29,7 @@ export class IssueSnapshot {
     hc.add(this.updatedAt);
     hc.add(this.estimatedHours);
     hc.add(this.comments);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-issue-tracker/src/issues/domain/issue.ts
+++ b/js/sample-issue-tracker/src/issues/domain/issue.ts
@@ -88,20 +88,26 @@ export class Issue {
   addComment(...args: unknown[]): void {
     if (args.length === 3 && typeof args[0] === "string" && isString(args[1]) && typeof args[2] === "object") {
       this.addCommentAuthorIdMessageCreatedAt(args[0] as UserId, args[1] as string, args[2] as Temporal.ZonedDateTime);
+
       return;
     }
+
     if (args.length === 2 && typeof args[0] === "string" && isString(args[1])) {
       this.addCommentAuthorIdMessage(args[0] as UserId, args[1] as string);
+
       return;
     }
+
     throw new Error("No matching overload for addComment");
   }
 
   private transitionToNextStatusActorIdChangedAt(nextStatus: IssueStatus, actorId: UserId, changedAt: Temporal.ZonedDateTime): void {
     const previousStatus = this.status;
+
     if (!IssueWorkflow.canTransition(previousStatus, nextStatus)) {
       throw new Error(`Cannot transition issue from ${previousStatus} to ${nextStatus}.`);
     }
+
     this.status = nextStatus;
     this._comments.push(Comment.system(`Status changed from ${previousStatus} to ${nextStatus} by ${actorId}.`, changedAt));
     this.touch(changedAt);
@@ -116,12 +122,16 @@ export class Issue {
   transitionTo(...args: unknown[]): void {
     if (args.length === 3 && (args[0] === "backlog" || args[0] === "ready" || args[0] === "in-progress" || args[0] === "in-review" || args[0] === "done" || args[0] === "cancelled") && typeof args[1] === "string" && typeof args[2] === "object") {
       this.transitionToNextStatusActorIdChangedAt(args[0] as IssueStatus, args[1] as UserId, args[2] as Temporal.ZonedDateTime);
+
       return;
     }
+
     if (args.length === 2 && (args[0] === "backlog" || args[0] === "ready" || args[0] === "in-progress" || args[0] === "in-review" || args[0] === "done" || args[0] === "cancelled") && typeof args[1] === "string") {
       this.transitionToNextStatusActorId(args[0] as IssueStatus, args[1] as UserId);
+
       return;
     }
+
     throw new Error("No matching overload for transitionTo");
   }
 

--- a/js/sample-issue-tracker/src/json-context.ts
+++ b/js/sample-issue-tracker/src/json-context.ts
@@ -16,20 +16,114 @@ export class JsonContext extends SerializerContext {
   }
 
   get issueSnapshot(): TypeSpec<IssueSnapshot> {
-    return this._issueSnapshot ??= this.createSpec({ type: IssueSnapshot, factory: (p: Record<string, unknown>) => new IssueSnapshot(p.id as IssueId, p.title as string, p.description as string, p.type as IssueType, p.priority as IssuePriority, p.status as IssueStatus, p.assigneeId as UserId | null, p.sprintKey as string | null, p.createdAt as Temporal.ZonedDateTime, p.updatedAt as Temporal.ZonedDateTime, p.estimatedHours as Decimal, p.comments as Comment[]), properties: [{ ts: "id", json: "id", type: { kind: "branded", create: IssueId.create } }, { ts: "title", json: "title", type: { kind: "primitive" } }, { ts: "description", json: "description", type: { kind: "primitive" } }, { ts: "type", json: "type", type: { kind: "enum", values: IssueType } }, { ts: "priority", json: "priority", type: { kind: "enum", values: IssuePriority } }, { ts: "status", json: "status", type: { kind: "enum", values: IssueStatus } }, {
-      ts: "assigneeId",
-      json: "assigneeId",
-      type: { kind: "nullable", inner: { kind: "branded", create: UserId.create } },
-      optional: true,
-    }, {
-      ts: "sprintKey",
-      json: "sprintKey",
-      type: { kind: "nullable", inner: { kind: "primitive" } },
-      optional: true,
-    }, { ts: "createdAt", json: "createdAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "updatedAt", json: "updatedAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "estimatedHours", json: "estimatedHours", type: { kind: "decimal" } }, { ts: "comments", json: "comments", type: { kind: "array", element: { kind: "ref", spec: () => this.comment } } }] });
+    return this._issueSnapshot ??= this.createSpec({
+      type: IssueSnapshot,
+      factory: (p: Record<string, unknown>) => new IssueSnapshot(p.id as IssueId, p.title as string, p.description as string, p.type as IssueType, p.priority as IssuePriority, p.status as IssueStatus, p.assigneeId as UserId | null, p.sprintKey as string | null, p.createdAt as Temporal.ZonedDateTime, p.updatedAt as Temporal.ZonedDateTime, p.estimatedHours as Decimal, p.comments as Comment[]),
+      properties: [
+        {
+          ts: "id",
+          json: "id",
+          type: { kind: "branded", create: IssueId.create },
+        },
+        {
+          ts: "title",
+          json: "title",
+          type: { kind: "primitive" },
+        },
+        {
+          ts: "description",
+          json: "description",
+          type: { kind: "primitive" },
+        },
+        {
+          ts: "type",
+          json: "type",
+          type: { kind: "enum", values: IssueType },
+        },
+        {
+          ts: "priority",
+          json: "priority",
+          type: { kind: "enum", values: IssuePriority },
+        },
+        {
+          ts: "status",
+          json: "status",
+          type: { kind: "enum", values: IssueStatus },
+        },
+        {
+          ts: "assigneeId",
+          json: "assigneeId",
+          type: {
+            kind: "nullable",
+            inner: { kind: "branded", create: UserId.create },
+          },
+          optional: true,
+        },
+        {
+          ts: "sprintKey",
+          json: "sprintKey",
+          type: {
+            kind: "nullable",
+            inner: { kind: "primitive" },
+          },
+          optional: true,
+        },
+        {
+          ts: "createdAt",
+          json: "createdAt",
+          type: { kind: "temporal", parse: Temporal.ZonedDateTime.from },
+        },
+        {
+          ts: "updatedAt",
+          json: "updatedAt",
+          type: { kind: "temporal", parse: Temporal.ZonedDateTime.from },
+        },
+        {
+          ts: "estimatedHours",
+          json: "estimatedHours",
+          type: { kind: "decimal" },
+        },
+        {
+          ts: "comments",
+          json: "comments",
+          type: {
+            kind: "array",
+            element: {
+              kind: "ref",
+              spec: () => this.comment,
+            },
+          },
+        },
+      ],
+    });
   }
 
   get comment(): TypeSpec<Comment> {
-    return this._comment ??= this.createSpec({ type: Comment, factory: (p: Record<string, unknown>) => new Comment(p.authorId as UserId, p.message as string, p.createdAt as Temporal.ZonedDateTime, p.isSystem as boolean), properties: [{ ts: "authorId", json: "authorId", type: { kind: "branded", create: UserId.create } }, { ts: "message", json: "message", type: { kind: "primitive" } }, { ts: "createdAt", json: "createdAt", type: { kind: "temporal", parse: Temporal.ZonedDateTime.from } }, { ts: "isSystem", json: "isSystem", type: { kind: "primitive" } }] });
+    return this._comment ??= this.createSpec({
+      type: Comment,
+      factory: (p: Record<string, unknown>) => new Comment(p.authorId as UserId, p.message as string, p.createdAt as Temporal.ZonedDateTime, p.isSystem as boolean),
+      properties: [
+        {
+          ts: "authorId",
+          json: "authorId",
+          type: { kind: "branded", create: UserId.create },
+        },
+        {
+          ts: "message",
+          json: "message",
+          type: { kind: "primitive" },
+        },
+        {
+          ts: "createdAt",
+          json: "createdAt",
+          type: { kind: "temporal", parse: Temporal.ZonedDateTime.from },
+        },
+        {
+          ts: "isSystem",
+          json: "isSystem",
+          type: { kind: "primitive" },
+        },
+      ],
+    });
   }
 }

--- a/js/sample-issue-tracker/src/shared-kernel/operation-result.ts
+++ b/js/sample-issue-tracker/src/shared-kernel/operation-result.ts
@@ -25,6 +25,7 @@ export class OperationResult<T> {
     hc.add(this.value);
     hc.add(this.errorCode);
     hc.add(this.errorMessage);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-issue-tracker/src/shared-kernel/page-request.ts
+++ b/js/sample-issue-tracker/src/shared-kernel/page-request.ts
@@ -23,6 +23,7 @@ export class PageRequest {
     const hc = new HashCode();
     hc.add(this.number);
     hc.add(this.size);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-issue-tracker/src/shared-kernel/page-result.ts
+++ b/js/sample-issue-tracker/src/shared-kernel/page-result.ts
@@ -21,6 +21,7 @@ export class PageResult<T> {
     hc.add(this.items);
     hc.add(this.totalCount);
     hc.add(this.page);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-todo-service/src/program.ts
+++ b/js/sample-todo-service/src/program.ts
@@ -2,52 +2,52 @@ import { Hono } from "hono";
 import { TodoStore } from "#";
 
 const app = new Hono();
-
-
 const store = new TodoStore();
-
 
 app.get("/", (c) => c.text("sample-todo-service"));
 
-
 app.get("/todos", (c) => c.json(store.all()));
 
-
-app.get("/todos/:id", (c) =>  {
+app.get("/todos/:id", (c) => {
   const id = c.req.param("id");
+
   if (id === null) {
     return c.notFound();
   }
+
   const stored = store.get(id);
+
   return stored === null ? c.notFound() : c.json(stored);
 });
 
-
-app.post("/todos", async (c) =>  {
+app.post("/todos", async (c) => {
   const dto = await c.req.json();
   const created = store.add(dto);
+
   return c.json(created, 201);
 });
 
-
-app.patch("/todos/:id", async (c) =>  {
+app.patch("/todos/:id", async (c) => {
   const id = c.req.param("id");
+
   if (id === null) {
     return c.notFound();
   }
+
   const patch = await c.req.json();
   const updated = store.update(id, patch);
+
   return updated === null ? c.notFound() : c.json(updated);
 });
 
-
-app.delete("/todos/:id", (c) =>  {
+app.delete("/todos/:id", (c) => {
   const id = c.req.param("id");
+
   if (id === null) {
     return c.notFound();
   }
+
   return store.remove(id) ? c.body(null, 204) : c.notFound();
 });
-
 
 export default app;

--- a/js/sample-todo-service/src/todos.ts
+++ b/js/sample-todo-service/src/todos.ts
@@ -36,38 +36,50 @@ export class TodoStore {
     const id = UUID.newUuid();
     const stored = { id: id, item: new TodoItem(dto.title, false, dto.priority) };
     this._items.push(stored);
+
     return stored;
   }
 
   update(id: string, patch: UpdateTodoDto): StoredTodo | null {
     const existing = (this._items.find((t: StoredTodo) => t.id === id) ?? null);
+
     if (existing === null) {
       return null;
     }
+
     let item = existing.item;
+
     if (!(patch.title === null)) {
       item = item.with({ title: patch.title });
     }
+
     if (!(patch.priority === null)) {
       item = item.with({ priority: patch.priority });
     }
+
     if (!(patch.completed === null)) {
       item = item.with({ completed: patch.completed });
     }
+
     const updated = {
       ...existing,
       item: item,
     };
+
     this._items[this._items.indexOf(existing)] = updated;
+
     return updated;
   }
 
   remove(id: string): boolean {
     const existing = (this._items.find((t: StoredTodo) => t.id === id) ?? null);
+
     if (existing === null) {
       return false;
     }
+
     listRemove(this._items, existing);
+
     return true;
   }
 }

--- a/js/sample-todo/src/json-context.ts
+++ b/js/sample-todo/src/json-context.ts
@@ -12,6 +12,26 @@ export class JsonContext extends SerializerContext {
   }
 
   get todoItem(): TypeSpec<TodoItem> {
-    return this._todoItem ??= this.createSpec({ type: TodoItem, factory: (p: Record<string, unknown>) => new TodoItem(p.title as string, p.completed as boolean, p.priority as Priority), properties: [{ ts: "title", json: "Title", type: { kind: "primitive" } }, { ts: "completed", json: "Completed", type: { kind: "primitive" } }, { ts: "priority", json: "Priority", type: { kind: "enum", values: Priority } }] });
+    return this._todoItem ??= this.createSpec({
+      type: TodoItem,
+      factory: (p: Record<string, unknown>) => new TodoItem(p.title as string, p.completed as boolean, p.priority as Priority),
+      properties: [
+        {
+          ts: "title",
+          json: "Title",
+          type: { kind: "primitive" },
+        },
+        {
+          ts: "completed",
+          json: "Completed",
+          type: { kind: "primitive" },
+        },
+        {
+          ts: "priority",
+          json: "Priority",
+          type: { kind: "enum", values: Priority },
+        },
+      ],
+    });
   }
 }

--- a/js/sample-todo/src/todo-item.ts
+++ b/js/sample-todo/src/todo-item.ts
@@ -25,6 +25,7 @@ export class TodoItem {
     hc.add(this.title);
     hc.add(this.completed);
     hc.add(this.priority);
+
     return hc.toHashCode();
   }
 

--- a/js/sample-todo/src/todo-list.ts
+++ b/js/sample-todo/src/todo-list.ts
@@ -38,16 +38,22 @@ export class TodoList {
   add(...args: unknown[]): void {
     if (args.length === 2 && isString(args[0]) && (args[1] === "low" || args[1] === "medium" || args[1] === "high")) {
       this.addTitlePriority(args[0] as string, args[1] as Priority);
+
       return;
     }
+
     if (args.length === 1 && args[0] instanceof TodoItem) {
       this.addItem(args[0] as TodoItem);
+
       return;
     }
+
     if (args.length === 1 && isString(args[0])) {
       this.addTitle(args[0] as string);
+
       return;
     }
+
     throw new Error("No matching overload for add");
   }
 

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -35,7 +35,7 @@ public sealed class Printer(string indent = "  ")
     /// items (e.g., consecutive functions) also get a blank line for readability.
     /// For ModuleEntryPoint bodies — where both sides are <see cref="TsTopLevelStatement"/>
     /// wrapping inner statements — the rule delegates to
-    /// <see cref="ShouldInsertBlankBefore"/> so the same "conditionals / loops /
+    /// <see cref="ShouldInsertBlankBefore"/> so the same "conditionals /
     /// return / multi-line var decls are separated; simple consecutive vars are
     /// not" rule applies uniformly.
     /// </summary>
@@ -66,9 +66,11 @@ public sealed class Printer(string indent = "  ")
     /// Encodes the statement-level blank-line rule used by
     /// <see cref="PrintStatementList"/> and <see cref="NeedsBlankLineBetween"/>:
     /// <list type="bullet">
-    ///   <item>Always one blank line around <c>if</c> / <c>switch</c> and before <c>return</c>.</item>
+    ///   <item>Always one blank line around control-flow (<c>if</c> / <c>switch</c>)
+    ///   and before <c>return</c>. No loop nodes exist in the AST today; extend
+    ///   <see cref="IsControlFlow"/> when they're added.</item>
     ///   <item>Always one blank line around a variable declaration whose initializer
-    ///   prints on more than one line (object literals with spread or &gt;3 props).</item>
+    ///   prints multi-line (see <see cref="IsMultiLineVarDecl"/>).</item>
     ///   <item>No separator between consecutive single-line variable declarations
     ///   or between a variable declaration and a trivial expression statement.</item>
     /// </list>
@@ -107,43 +109,67 @@ public sealed class Printer(string indent = "  ")
 
     /// <summary>
     /// The set of statements that always get a blank line around them.
+    /// The AST currently has no loop statement nodes (for / while / foreach);
+    /// if they're added in the future, extend this predicate.
     /// </summary>
     private static bool IsControlFlow(TsStatement stmt) =>
         stmt is TsIfStatement or TsSwitchStatement;
 
     /// <summary>
-    /// An expression is "complex" when it shouldn't be inlined as a property
-    /// value or array element because doing so produces an unreadably long line.
-    /// Used by <see cref="PrintObjectLiteral"/> and the array-literal branch to
-    /// decide inline vs. multi-line layout.
+    /// An expression is "complex" when it shouldn't appear inline inside an
+    /// object literal property or array element because doing so produces an
+    /// unreadably long line. Used by <see cref="ShouldPrintObjectMultiLine"/>
+    /// and <see cref="ShouldPrintArrayMultiLine"/> to decide layout.
     /// </summary>
-    private static bool IsComplexPropertyValue(TsExpression expr) =>
+    private static bool IsComplexInlineExpression(TsExpression expr) =>
         expr
             is TsArrowFunction
                 or TsArrayLiteral { Elements.Count: > 0 }
                 or TsObjectLiteral { Properties.Count: > 0 };
 
     /// <summary>
-    /// A variable declaration is "multi-line" when its initializer is an object
-    /// literal that <see cref="PrintObjectLiteral"/> would emit in block form:
-    /// more than three properties, or any spread property. Everything else
-    /// (primitives, identifiers, calls, arrays, single-prop or small object
-    /// literals) prints inline and does not need surrounding blank lines.
+    /// Whether <see cref="PrintObjectLiteral"/> would emit this object in
+    /// block form. Shared by the printer and <see cref="IsMultiLineVarDecl"/>
+    /// so the blank-line spacing rule stays in sync with the actual layout.
     /// </summary>
-    private static bool IsMultiLineVarDecl(TsStatement stmt)
+    private static bool ShouldPrintObjectMultiLine(TsObjectLiteral obj)
     {
-        if (stmt is not TsVariableDeclaration varDecl)
-            return false;
-        if (varDecl.Initializer is not TsObjectLiteral obj)
-            return false;
         if (obj.Properties.Count > 3)
             return true;
         foreach (var prop in obj.Properties)
         {
             if (prop.Value is TsSpreadExpression)
                 return true;
+            if (IsComplexInlineExpression(prop.Value))
+                return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Whether the array-literal branch would emit this array in block form.
+    /// Shared by the printer and <see cref="IsMultiLineVarDecl"/>.
+    /// </summary>
+    private static bool ShouldPrintArrayMultiLine(TsArrayLiteral arr) =>
+        arr.Elements.Count > 0 && arr.Elements.Any(IsComplexInlineExpression);
+
+    /// <summary>
+    /// A variable declaration is "multi-line" when its initializer is a literal
+    /// that the printer emits in block form — object literals that match
+    /// <see cref="ShouldPrintObjectMultiLine"/> or array literals that match
+    /// <see cref="ShouldPrintArrayMultiLine"/>. Everything else prints inline
+    /// and does not need surrounding blank lines.
+    /// </summary>
+    private static bool IsMultiLineVarDecl(TsStatement stmt)
+    {
+        if (stmt is not TsVariableDeclaration varDecl)
+            return false;
+        return varDecl.Initializer switch
+        {
+            TsObjectLiteral obj => ShouldPrintObjectMultiLine(obj),
+            TsArrayLiteral arr => ShouldPrintArrayMultiLine(arr),
+            _ => false,
+        };
     }
 
     /// <summary>
@@ -882,7 +908,7 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsArrayLiteral arrayLit:
-                if (arrayLit.Elements.Count > 0 && arrayLit.Elements.Any(IsComplexPropertyValue))
+                if (ShouldPrintArrayMultiLine(arrayLit))
                 {
                     _sb.Write("[");
                     _sb.WriteLn();
@@ -1064,9 +1090,7 @@ public sealed class Printer(string indent = "  ")
             return;
         }
 
-        var hasSpread = obj.Properties.Any(p => p.Value is TsSpreadExpression);
-        var hasComplexValue = obj.Properties.Any(p => IsComplexPropertyValue(p.Value));
-        if (obj.Properties.Count <= 3 && !hasSpread && !hasComplexValue)
+        if (!ShouldPrintObjectMultiLine(obj))
         {
             _sb.Write("{ ");
             _sb.WriteList(obj.Properties, PrintObjectProperty);

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -33,6 +33,11 @@ public sealed class Printer(string indent = "  ")
     /// Imports/re-exports are grouped together with no blank lines. Distinct kinds
     /// (types vs functions vs constants) get a blank line between them. Same-kind
     /// items (e.g., consecutive functions) also get a blank line for readability.
+    /// For ModuleEntryPoint bodies — where both sides are <see cref="TsTopLevelStatement"/>
+    /// wrapping inner statements — the rule delegates to
+    /// <see cref="ShouldInsertBlankBefore"/> so the same "conditionals / loops /
+    /// return / multi-line var decls are separated; simple consecutive vars are
+    /// not" rule applies uniformly.
     /// </summary>
     private static bool NeedsBlankLineBetween(TsTopLevel prev, TsTopLevel next)
     {
@@ -45,8 +50,107 @@ public sealed class Printer(string indent = "  ")
         if (prevIsImport != nextIsImport)
             return true;
 
-        // For non-imports, separate everything by blank lines (types, functions, constants)
+        // Both are [ModuleEntryPoint] body statements — apply the statement-level
+        // spacing rule so consecutive `const` vars don't get spuriously separated,
+        // but everything else at the top level still gets air (each route handler
+        // call, each class instantiation, etc. is a distinct logical unit).
+        if (prev is TsTopLevelStatement prevStmt && next is TsTopLevelStatement nextStmt)
+            return ShouldInsertBlankBefore(prevStmt.Inner, nextStmt.Inner, topLevel: true);
+
+        // For non-imports, separate everything else by blank lines (types, functions,
+        // constants, classes, mixed top-level statement + non-statement).
         return true;
+    }
+
+    /// <summary>
+    /// Encodes the statement-level blank-line rule used by
+    /// <see cref="PrintStatementList"/> and <see cref="NeedsBlankLineBetween"/>:
+    /// <list type="bullet">
+    ///   <item>Always one blank line around <c>if</c> / <c>switch</c> and before <c>return</c>.</item>
+    ///   <item>Always one blank line around a variable declaration whose initializer
+    ///   prints on more than one line (object literals with spread or &gt;3 props).</item>
+    ///   <item>No separator between consecutive single-line variable declarations
+    ///   or between a variable declaration and a trivial expression statement.</item>
+    /// </list>
+    /// The rule is symmetric — if either side is a control-flow statement or a
+    /// multi-line variable, the pair is separated.
+    /// </summary>
+    private static bool ShouldInsertBlankBefore(
+        TsStatement prev,
+        TsStatement curr,
+        bool topLevel = false
+    )
+    {
+        // Blank before any `return` (unless it's the first statement, which is
+        // the caller's responsibility to skip).
+        if (curr is TsReturnStatement)
+            return true;
+
+        // Control-flow structures get visual air on both sides.
+        if (IsControlFlow(prev) || IsControlFlow(curr))
+            return true;
+
+        // Multi-line variable declarations get blank lines above and below so the
+        // block shape is visually detached from its siblings.
+        if (IsMultiLineVarDecl(prev) || IsMultiLineVarDecl(curr))
+            return true;
+
+        // Top-level statements (ModuleEntryPoint) are separated by default —
+        // each route handler, middleware registration, etc. is a logical unit.
+        // The only exception is consecutive single-line variable declarations
+        // (`const app = ...; const store = ...;`) which stay grouped.
+        if (topLevel && !(prev is TsVariableDeclaration && curr is TsVariableDeclaration))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// The set of statements that always get a blank line around them.
+    /// </summary>
+    private static bool IsControlFlow(TsStatement stmt) =>
+        stmt is TsIfStatement or TsSwitchStatement;
+
+    /// <summary>
+    /// A variable declaration is "multi-line" when its initializer is an object
+    /// literal that <see cref="PrintObjectLiteral"/> would emit in block form:
+    /// more than three properties, or any spread property. Everything else
+    /// (primitives, identifiers, calls, arrays, single-prop or small object
+    /// literals) prints inline and does not need surrounding blank lines.
+    /// </summary>
+    private static bool IsMultiLineVarDecl(TsStatement stmt)
+    {
+        if (stmt is not TsVariableDeclaration varDecl)
+            return false;
+        if (varDecl.Initializer is not TsObjectLiteral obj)
+            return false;
+        if (obj.Properties.Count > 3)
+            return true;
+        foreach (var prop in obj.Properties)
+        {
+            if (prop.Value is TsSpreadExpression)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Prints a list of statements (method / constructor / lambda / block body,
+    /// or a switch case body) applying the statement-level blank-line rule from
+    /// <see cref="ShouldInsertBlankBefore"/>. Replaces direct
+    /// <c>_sb.WriteLines(list, PrintStatement)</c> calls, which would glue every
+    /// statement together with a single newline regardless of kind.
+    /// </summary>
+    private void PrintStatementList(IReadOnlyList<TsStatement> statements)
+    {
+        for (var i = 0; i < statements.Count; i++)
+        {
+            var curr = statements[i];
+            if (i > 0 && ShouldInsertBlankBefore(statements[i - 1], curr))
+                _sb.WriteLn();
+            PrintStatement(curr);
+            _sb.WriteLn();
+        }
     }
 
     // ─── Top-level ──────────────────────────────────────────
@@ -83,8 +187,12 @@ public sealed class Printer(string indent = "  ")
                 PrintClass(n);
                 break;
             case TsTopLevelStatement n:
+                // Do NOT emit an extra WriteLn here — the `Print()` top-level
+                // loop already writes a single trailing newline after every
+                // PrintTopLevel call. Emitting one here produced the historical
+                // double-blank-line bug in ModuleEntryPoint output
+                // (`\n\n\n` between each statement in program.ts).
                 PrintStatement(n.Inner);
-                _sb.WriteLn();
                 break;
             case TsModuleExport n:
                 _sb.Write(n.IsDefault ? $"export default {n.Name};" : $"export {{ {n.Name} }};");
@@ -613,11 +721,11 @@ public sealed class Printer(string indent = "  ")
                 _sb.Write("if (");
                 PrintExpression(ifStmt.Condition);
                 _sb.Write(")");
-                _sb.WriteBlock(() => _sb.WriteLines(ifStmt.Then, PrintStatement));
+                _sb.WriteBlock(() => PrintStatementList(ifStmt.Then));
                 if (ifStmt.Else is { Count: > 0 })
                 {
                     _sb.Write(" else");
-                    _sb.WriteBlock(() => _sb.WriteLines(ifStmt.Else, PrintStatement));
+                    _sb.WriteBlock(() => PrintStatementList(ifStmt.Else));
                 }
 
                 break;
@@ -674,7 +782,7 @@ public sealed class Printer(string indent = "  ")
 
                         _sb.WriteLn();
                         _sb.Indent();
-                        _sb.WriteLines(c.Body, PrintStatement);
+                        PrintStatementList(c.Body);
                         _sb.Dedent();
                     }
                 });
@@ -785,15 +893,21 @@ public sealed class Printer(string indent = "  ")
                     _sb.Write("async ");
                 _sb.Write("(");
                 PrintParameters(arrow.Parameters);
-                _sb.Write(") => ");
-                // Single return statement → concise expression body
+                // Write the arrow without a trailing space — the concise form
+                // adds its own space before the expression, and the block form
+                // lets WriteBlock insert " {" (including its own leading space).
+                // Without this split, block-body arrows printed as `) =>  {`
+                // with two spaces — cosmetic but visible in every route handler
+                // in sample-todo-service/src/program.ts.
+                _sb.Write(") =>");
                 if (arrow.Body is [TsReturnStatement { Expression: { } returnExpr }])
                 {
+                    _sb.Write(" ");
                     PrintExpression(returnExpr);
                 }
                 else
                 {
-                    _sb.WriteBlock(() => _sb.WriteLines(arrow.Body, PrintStatement));
+                    _sb.WriteBlock(() => PrintStatementList(arrow.Body));
                 }
                 break;
 
@@ -1019,6 +1133,6 @@ public sealed class Printer(string indent = "  ")
 
     private void PrintBody(IReadOnlyList<TsStatement> body)
     {
-        _sb.WriteBlock(() => _sb.WriteLines(body, PrintStatement));
+        _sb.WriteBlock(() => PrintStatementList(body));
     }
 }

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -118,9 +118,10 @@ public sealed class Printer(string indent = "  ")
     /// decide inline vs. multi-line layout.
     /// </summary>
     private static bool IsComplexPropertyValue(TsExpression expr) =>
-        expr is TsArrowFunction
-            or TsArrayLiteral { Elements.Count: > 0 }
-            or TsObjectLiteral { Properties.Count: > 0 };
+        expr
+            is TsArrowFunction
+                or TsArrayLiteral { Elements.Count: > 0 }
+                or TsObjectLiteral { Properties.Count: > 0 };
 
     /// <summary>
     /// A variable declaration is "multi-line" when its initializer is an object
@@ -881,10 +882,7 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsArrayLiteral arrayLit:
-                if (
-                    arrayLit.Elements.Count > 0
-                    && arrayLit.Elements.Any(IsComplexPropertyValue)
-                )
+                if (arrayLit.Elements.Count > 0 && arrayLit.Elements.Any(IsComplexPropertyValue))
                 {
                     _sb.Write("[");
                     _sb.WriteLn();

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -112,6 +112,17 @@ public sealed class Printer(string indent = "  ")
         stmt is TsIfStatement or TsSwitchStatement;
 
     /// <summary>
+    /// An expression is "complex" when it shouldn't be inlined as a property
+    /// value or array element because doing so produces an unreadably long line.
+    /// Used by <see cref="PrintObjectLiteral"/> and the array-literal branch to
+    /// decide inline vs. multi-line layout.
+    /// </summary>
+    private static bool IsComplexPropertyValue(TsExpression expr) =>
+        expr is TsArrowFunction
+            or TsArrayLiteral { Elements.Count: > 0 }
+            or TsObjectLiteral { Properties.Count: > 0 };
+
+    /// <summary>
     /// A variable declaration is "multi-line" when its initializer is an object
     /// literal that <see cref="PrintObjectLiteral"/> would emit in block form:
     /// more than three properties, or any spread property. Everything else
@@ -870,9 +881,29 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsArrayLiteral arrayLit:
-                _sb.Write("[");
-                _sb.WriteList(arrayLit.Elements, PrintExpression);
-                _sb.Write("]");
+                if (
+                    arrayLit.Elements.Count > 0
+                    && arrayLit.Elements.Any(IsComplexPropertyValue)
+                )
+                {
+                    _sb.Write("[");
+                    _sb.WriteLn();
+                    _sb.Indent();
+                    foreach (var elem in arrayLit.Elements)
+                    {
+                        PrintExpression(elem);
+                        _sb.Write(",");
+                        _sb.WriteLn();
+                    }
+                    _sb.Dedent();
+                    _sb.Write("]");
+                }
+                else
+                {
+                    _sb.Write("[");
+                    _sb.WriteList(arrayLit.Elements, PrintExpression);
+                    _sb.Write("]");
+                }
                 break;
 
             case TsNewExpression newExpr:
@@ -1036,7 +1067,8 @@ public sealed class Printer(string indent = "  ")
         }
 
         var hasSpread = obj.Properties.Any(p => p.Value is TsSpreadExpression);
-        if (obj.Properties.Count <= 3 && !hasSpread)
+        var hasComplexValue = obj.Properties.Any(p => IsComplexPropertyValue(p.Value));
+        if (obj.Properties.Count <= 3 && !hasSpread && !hasComplexValue)
         {
             _sb.Write("{ ");
             _sb.WriteList(obj.Properties, PrintObjectProperty);

--- a/tests/Metano.Tests/EndToEndOutputTests.cs
+++ b/tests/Metano.Tests/EndToEndOutputTests.cs
@@ -124,6 +124,7 @@ public class EndToEndOutputTests
             + "    hc.add(this.title);\n"
             + "    hc.add(this.status);\n"
             + "    hc.add(this.estimatedCost);\n"
+            + "\n"
             + "    return hc.toHashCode();\n"
             + "  }\n"
             + "\n"

--- a/tests/Metano.Tests/Expected/generic-constraint.ts
+++ b/tests/Metano.Tests/Expected/generic-constraint.ts
@@ -11,6 +11,7 @@ export class Repo<T extends IEntity> {
   hashCode(): number {
     const hc = new HashCode();
     hc.add(this.item);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/generic-multi-param.ts
+++ b/tests/Metano.Tests/Expected/generic-multi-param.ts
@@ -11,6 +11,7 @@ export class Pair<K, V> {
     const hc = new HashCode();
     hc.add(this.key);
     hc.add(this.value);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/generic-record.ts
+++ b/tests/Metano.Tests/Expected/generic-record.ts
@@ -11,6 +11,7 @@ export class Result<T> {
     const hc = new HashCode();
     hc.add(this.value);
     hc.add(this.success);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/if-else-throw.ts
+++ b/tests/Metano.Tests/Expected/if-else-throw.ts
@@ -17,6 +17,7 @@ export class Pair {
     const hc = new HashCode();
     hc.add(this.a);
     hc.add(this.b);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/inheritance-base.ts
+++ b/tests/Metano.Tests/Expected/inheritance-base.ts
@@ -11,6 +11,7 @@ export class Shape {
     const hc = new HashCode();
     hc.add(this.x);
     hc.add(this.y);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/inheritance-derived.ts
+++ b/tests/Metano.Tests/Expected/inheritance-derived.ts
@@ -19,6 +19,7 @@ export class Circle extends Shape {
     hc.add(this.x);
     hc.add(this.y);
     hc.add(this.radius);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/operator-with-name.ts
+++ b/tests/Metano.Tests/Expected/operator-with-name.ts
@@ -19,6 +19,7 @@ export class Vec2 {
     const hc = new HashCode();
     hc.add(this.x);
     hc.add(this.y);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/record-with-methods.ts
+++ b/tests/Metano.Tests/Expected/record-with-methods.ts
@@ -18,6 +18,7 @@ export class Amount {
   hashCode(): number {
     const hc = new HashCode();
     hc.add(this.value);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/simple-record.ts
+++ b/tests/Metano.Tests/Expected/simple-record.ts
@@ -11,6 +11,7 @@ export class Point {
     const hc = new HashCode();
     hc.add(this.x);
     hc.add(this.y);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/unary-operator.ts
+++ b/tests/Metano.Tests/Expected/unary-operator.ts
@@ -19,6 +19,7 @@ export class Vec2 {
     const hc = new HashCode();
     hc.add(this.x);
     hc.add(this.y);
+
     return hc.toHashCode();
   }
 

--- a/tests/Metano.Tests/Expected/with-expression.ts
+++ b/tests/Metano.Tests/Expected/with-expression.ts
@@ -15,6 +15,7 @@ export class Coord {
     const hc = new HashCode();
     hc.add(this.x);
     hc.add(this.y);
+
     return hc.toHashCode();
   }
 


### PR DESCRIPTION
Closes #35.

Three Printer fixes that collectively make the generated TypeScript output match the project's style rule and stay readable for large generated files like json-context.ts.

## Changes

### 1. Statement-level blank-line spacing (`PrintStatementList` + `ShouldInsertBlankBefore`)

New helper replaces all `_sb.WriteLines(body, PrintStatement)` calls. The rule:

- Blank before `return` (unless first statement)
- Blank before / after `if` and `switch`
- Blank around multi-line variable declarations (object literals with >3 props or spread)
- No blank between consecutive single-line variable declarations
- At top level (ModuleEntryPoint): everything gets air except consecutive simple vars

### 2. Double-blank bug at ModuleEntryPoint top level

The `TsTopLevelStatement` case emitted an extra `WriteLn()` that, combined with the `Print()` loop's own `WriteLn` + `NeedsBlankLineBetween`, produced `\n\n\n` between statements in `program.ts`. Removed the extra call.

### 3. Complexity-aware object/array literal formatting

`PrintObjectLiteral`'s inline threshold (≤3 props, no spread) didn't account for value complexity. A `createSpec({ type, factory, properties })` — 3 props, but one is an arrow function and another is an array of objects — printed as a 300+ character single line.

Added `IsComplexPropertyValue`: forces multi-line layout when any property value is an arrow function, non-empty array, or non-empty object literal. Applied to both object literals and array literals, so json-context.ts specs break cleanly into readable indented blocks.

### 4. Arrow function cosmetic

`=> {` (two spaces) → `=> {` (one space). The trailing space after `=>` collided with WriteBlock's leading space.

## Commits

1. `0436172` — Printer: blank-line rule + double-blank fix + arrow cosmetic
2. `46952f1` — regenerated samples + updated 11 Expected golden files + 1 inline expected string
3. `a68e032` — complexity-aware object/array literal multi-line formatting + regenerated json-context.ts files

## Test plan

- [x] `dotnet run --project tests/Metano.Tests/` — **337/337**
- [x] `cd js/metano-runtime && bun test` — **261/261**
- [x] `cd js/sample-todo && bun run build && bun test` — **18/18**
- [x] `cd js/sample-todo-service && bun run build && bun test` — **9/9**
- [x] `cd js/sample-issue-tracker && bun run build && bun test` — **65/65**
- [x] `dotnet csharpier check .` — clean