### PR TITLE
fix: add CamelCase naming policy to SampleTodo's JsonContext (#39)

### DIFF
--- a/js/sample-todo/src/json-context.ts
+++ b/js/sample-todo/src/json-context.ts
@@ -18,17 +18,17 @@ export class JsonContext extends SerializerContext {
       properties: [
         {
           ts: "title",
-          json: "Title",
+          json: "title",
           type: { kind: "primitive" },
         },
         {
           ts: "completed",
-          json: "Completed",
+          json: "completed",
           type: { kind: "primitive" },
         },
         {
           ts: "priority",
-          json: "Priority",
+          json: "priority",
           type: { kind: "enum", values: Priority },
         },
       ],

--- a/samples/SampleTodo/JsonContext.cs
+++ b/samples/SampleTodo/JsonContext.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace SampleTodo;
 
-[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase
+)]
 [JsonSerializable(typeof(TodoItem))]
 public partial class JsonContext : JsonSerializerContext;


### PR DESCRIPTION
Closes #39. (Replaces the auto-closed PR #40 whose commit was skipped during rebase due to cherry-pick detection against the reverted commit in PR #38.)

Adds `PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase` to `SampleTodo/JsonContext.cs`. The generated `json-context.ts` now emits `json: "title"` (camelCase) instead of `json: "Title"` (PascalCase), matching `SampleTodo.Service`'s convention and real-world web API expectations.

Not a transpiler bug — the naming policy application was correct (no policy = preserve casing). Just a sample config gap.