### PR TITLE
feat: support C# delegates and events with add/remove listener pattern (#45)

### DIFF
--- a/js/metano-runtime/src/system/delegates.ts
+++ b/js/metano-runtime/src/system/delegates.ts
@@ -1,10 +1,14 @@
 /**
  * Multicast delegate support for C# event/delegate lowering.
  *
- * A delegate is a plain function tagged with a hidden listener set. When `+=`
+ * A delegate is a plain function tagged with a hidden listener list. When `+=`
  * is used on a function, it's promoted to a multicast delegate via
  * {@link delegateAdd}. The promoted delegate IS still a function with the
  * same signature — callers can't tell the difference.
+ *
+ * Uses an array (not Set) because C# multicast delegates allow duplicate
+ * subscriptions — adding the same handler twice invokes it twice, and
+ * `-=` removes only the last matching occurrence.
  *
  * Zero overhead when `+=` is never used: the function stays a plain function.
  */
@@ -14,7 +18,7 @@ const DELEGATE_LISTENERS = Symbol("delegate_listeners");
 type AnyFunc = (...args: any[]) => any;
 
 type DelegateFunc<T extends AnyFunc> = T & {
-  [DELEGATE_LISTENERS]: Set<T>;
+  [DELEGATE_LISTENERS]: T[];
 };
 
 /** Returns true if the function has been promoted to a multicast delegate. */
@@ -28,7 +32,7 @@ export function isDelegate<T extends AnyFunc>(fn: T | null): fn is DelegateFunc<
  * handler's return value (matching C# multicast delegate semantics).
  */
 export function createDelegate<T extends AnyFunc>(...handlers: T[]): T {
-  const listeners = new Set<T>(handlers);
+  const listeners = [...handlers];
 
   const delegate = ((...args: any[]) => {
     let result: any;
@@ -54,26 +58,25 @@ export function createDelegate<T extends AnyFunc>(...handlers: T[]): T {
 export function delegateAdd<T extends AnyFunc>(target: T | null, handler: T): T {
   if (target === null) return handler;
   if (isDelegate(target)) {
-    target[DELEGATE_LISTENERS].add(handler);
+    target[DELEGATE_LISTENERS].push(handler);
     return target;
   }
   return createDelegate(target, handler);
 }
 
 /**
- * Removes a handler from a delegate. Returns null when the last handler is
+ * Removes a handler from a delegate. Removes the LAST matching occurrence
+ * (matching C# `-=` semantics). Returns null when the last handler is
  * removed, or the target unchanged if the handler wasn't found.
  */
 export function delegateRemove<T extends AnyFunc>(target: T | null, handler: T): T | null {
   if (target === null) return null;
   if (isDelegate(target)) {
-    target[DELEGATE_LISTENERS].delete(handler);
-    if (target[DELEGATE_LISTENERS].size === 0) return null;
-    if (target[DELEGATE_LISTENERS].size === 1) {
-      // Depromote back to a plain function when only one listener remains.
-      const [sole] = target[DELEGATE_LISTENERS];
-      return sole!;
-    }
+    const list = target[DELEGATE_LISTENERS];
+    const idx = list.lastIndexOf(handler);
+    if (idx >= 0) list.splice(idx, 1);
+    if (list.length === 0) return null;
+    if (list.length === 1) return list[0]!;
     return target;
   }
   return target === handler ? null : target;

--- a/js/metano-runtime/src/system/delegates.ts
+++ b/js/metano-runtime/src/system/delegates.ts
@@ -1,0 +1,80 @@
+/**
+ * Multicast delegate support for C# event/delegate lowering.
+ *
+ * A delegate is a plain function tagged with a hidden listener set. When `+=`
+ * is used on a function, it's promoted to a multicast delegate via
+ * {@link delegateAdd}. The promoted delegate IS still a function with the
+ * same signature — callers can't tell the difference.
+ *
+ * Zero overhead when `+=` is never used: the function stays a plain function.
+ */
+
+const DELEGATE_LISTENERS = Symbol("delegate_listeners");
+
+type AnyFunc = (...args: any[]) => any;
+
+type DelegateFunc<T extends AnyFunc> = T & {
+  [DELEGATE_LISTENERS]: Set<T>;
+};
+
+/** Returns true if the function has been promoted to a multicast delegate. */
+export function isDelegate<T extends AnyFunc>(fn: T | null): fn is DelegateFunc<T> {
+  return fn !== null && DELEGATE_LISTENERS in fn;
+}
+
+/**
+ * Creates a multicast delegate from one or more handlers. The returned
+ * function calls every handler in insertion order and returns the last
+ * handler's return value (matching C# multicast delegate semantics).
+ */
+export function createDelegate<T extends AnyFunc>(...handlers: T[]): T {
+  const listeners = new Set<T>(handlers);
+
+  const delegate = ((...args: any[]) => {
+    let result: any;
+    for (const listener of listeners) {
+      result = listener(...args);
+    }
+    return result;
+  }) as DelegateFunc<T>;
+
+  Object.defineProperty(delegate, DELEGATE_LISTENERS, {
+    value: listeners,
+    enumerable: false,
+  });
+
+  return delegate as T;
+}
+
+/**
+ * Adds a handler to a delegate. If the target is a plain function, it's
+ * promoted to a multicast delegate first. If the target is null, the handler
+ * itself is returned (first subscription on a nullable event).
+ */
+export function delegateAdd<T extends AnyFunc>(target: T | null, handler: T): T {
+  if (target === null) return handler;
+  if (isDelegate(target)) {
+    target[DELEGATE_LISTENERS].add(handler);
+    return target;
+  }
+  return createDelegate(target, handler);
+}
+
+/**
+ * Removes a handler from a delegate. Returns null when the last handler is
+ * removed, or the target unchanged if the handler wasn't found.
+ */
+export function delegateRemove<T extends AnyFunc>(target: T | null, handler: T): T | null {
+  if (target === null) return null;
+  if (isDelegate(target)) {
+    target[DELEGATE_LISTENERS].delete(handler);
+    if (target[DELEGATE_LISTENERS].size === 0) return null;
+    if (target[DELEGATE_LISTENERS].size === 1) {
+      // Depromote back to a plain function when only one listener remains.
+      const [sole] = target[DELEGATE_LISTENERS];
+      return sole!;
+    }
+    return target;
+  }
+  return target === handler ? null : target;
+}

--- a/js/metano-runtime/src/system/index.ts
+++ b/js/metano-runtime/src/system/index.ts
@@ -5,3 +5,4 @@ export * from "./collections/index.ts";
 export * from "./linq/index.ts";
 export * from "./json/index.ts";
 export * from "./uuid.ts";
+export * from "./delegates.ts";

--- a/js/metano-runtime/test/system/delegates.test.ts
+++ b/js/metano-runtime/test/system/delegates.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  createDelegate,
-  delegateAdd,
-  delegateRemove,
-  isDelegate,
-} from "#/system/delegates.ts";
+import { createDelegate, delegateAdd, delegateRemove, isDelegate } from "#/system/delegates.ts";
 
 describe("isDelegate", () => {
   test("returns false for a plain function", () => {
@@ -26,8 +21,14 @@ describe("createDelegate", () => {
   test("calls all handlers and returns the last result", () => {
     const results: string[] = [];
     const d = createDelegate(
-      (msg: string) => { results.push("A:" + msg); return 1; },
-      (msg: string) => { results.push("B:" + msg); return 2; },
+      (msg: string) => {
+        results.push("A:" + msg);
+        return 1;
+      },
+      (msg: string) => {
+        results.push("B:" + msg);
+        return 2;
+      },
     );
 
     const ret = d("hello");
@@ -55,9 +56,15 @@ describe("delegateAdd", () => {
 
   test("multicast delegate calls all handlers in order", () => {
     const log: number[] = [];
-    const a = (x: number) => { log.push(x); };
-    const b = (x: number) => { log.push(x * 10); };
-    const c = (x: number) => { log.push(x * 100); };
+    const a = (x: number) => {
+      log.push(x);
+    };
+    const b = (x: number) => {
+      log.push(x * 10);
+    };
+    const c = (x: number) => {
+      log.push(x * 100);
+    };
 
     let d: typeof a | null = null;
     d = delegateAdd(d, a);

--- a/js/metano-runtime/test/system/delegates.test.ts
+++ b/js/metano-runtime/test/system/delegates.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createDelegate,
+  delegateAdd,
+  delegateRemove,
+  isDelegate,
+} from "#/system/delegates.ts";
+
+describe("isDelegate", () => {
+  test("returns false for a plain function", () => {
+    const fn = (x: number) => x * 2;
+    expect(isDelegate(fn)).toBe(false);
+  });
+
+  test("returns false for null", () => {
+    expect(isDelegate(null)).toBe(false);
+  });
+
+  test("returns true for a delegate created via createDelegate", () => {
+    const fn = createDelegate((x: number) => x * 2);
+    expect(isDelegate(fn)).toBe(true);
+  });
+});
+
+describe("createDelegate", () => {
+  test("calls all handlers and returns the last result", () => {
+    const results: string[] = [];
+    const d = createDelegate(
+      (msg: string) => { results.push("A:" + msg); return 1; },
+      (msg: string) => { results.push("B:" + msg); return 2; },
+    );
+
+    const ret = d("hello");
+    expect(results).toEqual(["A:hello", "B:hello"]);
+    expect(ret).toBe(2); // last handler's return value
+  });
+});
+
+describe("delegateAdd", () => {
+  test("first add on null returns the handler as-is (no wrapping)", () => {
+    const handler = (x: number) => x;
+    const result = delegateAdd(null, handler);
+
+    expect(result).toBe(handler);
+    expect(isDelegate(result)).toBe(false);
+  });
+
+  test("second add promotes to multicast", () => {
+    const a = (x: number) => x;
+    const b = (x: number) => x * 2;
+
+    const result = delegateAdd(delegateAdd(null, a), b);
+    expect(isDelegate(result)).toBe(true);
+  });
+
+  test("multicast delegate calls all handlers in order", () => {
+    const log: number[] = [];
+    const a = (x: number) => { log.push(x); };
+    const b = (x: number) => { log.push(x * 10); };
+    const c = (x: number) => { log.push(x * 100); };
+
+    let d: typeof a | null = null;
+    d = delegateAdd(d, a);
+    d = delegateAdd(d, b);
+    d = delegateAdd(d, c);
+    d!(5);
+
+    expect(log).toEqual([5, 50, 500]);
+  });
+
+  test("adding to an existing delegate mutates in place", () => {
+    const a = () => {};
+    const b = () => {};
+    const c = () => {};
+
+    let d = delegateAdd(delegateAdd(null as (() => void) | null, a), b);
+    const ref = d;
+    d = delegateAdd(d, c);
+
+    expect(d).toBe(ref); // same reference — mutated in place
+  });
+});
+
+describe("delegateRemove", () => {
+  test("removing from null returns null", () => {
+    const handler = () => {};
+    expect(delegateRemove(null, handler)).toBeNull();
+  });
+
+  test("removing the only plain function returns null", () => {
+    const handler = (x: number) => x;
+    expect(delegateRemove(handler, handler)).toBeNull();
+  });
+
+  test("removing a non-matching plain function returns the original", () => {
+    const a = (x: number) => x;
+    const b = (x: number) => x * 2;
+    expect(delegateRemove(a, b)).toBe(a);
+  });
+
+  test("removing last handler from multicast returns null", () => {
+    const a = () => {};
+    let d: (() => void) | null = delegateAdd(null, a);
+    d = delegateRemove(d, a);
+
+    expect(d).toBeNull();
+  });
+
+  test("removing down to one handler depromotes to plain function", () => {
+    const a = () => {};
+    const b = () => {};
+
+    let d: (() => void) | null = null;
+    d = delegateAdd(d, a);
+    d = delegateAdd(d, b);
+    expect(isDelegate(d)).toBe(true);
+
+    d = delegateRemove(d, b);
+    expect(d).toBe(a); // depromoted back to the original function
+    expect(isDelegate(d)).toBe(false);
+  });
+});
+
+describe("event simulation (full round-trip)", () => {
+  test("simulates a C# event with add/remove/invoke", () => {
+    const log: string[] = [];
+
+    // Simulates: event EventHandler<string>? OnMessage;
+    let onMessage: ((sender: unknown, msg: string) => void) | null = null;
+
+    // += handler1
+    const handler1 = (_: unknown, msg: string) => log.push("H1:" + msg);
+    onMessage = delegateAdd(onMessage, handler1);
+
+    // += handler2
+    const handler2 = (_: unknown, msg: string) => log.push("H2:" + msg);
+    onMessage = delegateAdd(onMessage, handler2);
+
+    // Invoke
+    onMessage?.(null, "hello");
+    expect(log).toEqual(["H1:hello", "H2:hello"]);
+
+    // -= handler1
+    log.length = 0;
+    onMessage = delegateRemove(onMessage, handler1);
+    onMessage?.(null, "world");
+    expect(log).toEqual(["H2:world"]);
+
+    // -= handler2 (last one)
+    onMessage = delegateRemove(onMessage, handler2);
+    expect(onMessage).toBeNull();
+  });
+});

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -134,6 +134,16 @@ public sealed class ImportCollector(
             imports.Add(new TsImport(["Grouping"], "metano-runtime", TypeOnly: true));
         }
 
+        // Delegate helper imports (delegateAdd, delegateRemove from metano-runtime)
+        var delegateHelpers = referencedTypes
+            .Where(n => n is "delegateAdd" or "delegateRemove")
+            .OrderBy(n => n)
+            .ToArray();
+        if (delegateHelpers.Length > 0)
+        {
+            imports.Add(new TsImport(delegateHelpers, "metano-runtime"));
+        }
+
         // Track what we've already imported to avoid duplicates
         var importedNames = new HashSet<string>(runtimeTypeChecks)
         {
@@ -141,6 +151,8 @@ public sealed class ImportCollector(
             "Grouping",
             "HashSet",
             "UUID",
+            "delegateAdd",
+            "delegateRemove",
         };
         foreach (var helper in runtimeHelpers)
             importedNames.Add(helper);
@@ -262,6 +274,8 @@ public sealed class ImportCollector(
                         or "Object"
                         or "typeof"
                         or "unknown[]"
+                        or "delegateAdd"
+                        or "delegateRemove"
             )
                 continue;
 

--- a/src/Metano.Compiler.TypeScript/Transformation/OperatorHandler.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/OperatorHandler.cs
@@ -96,7 +96,7 @@ public sealed class OperatorHandler(ExpressionTransformer parent)
             var leftSymbol = _parent.Model.GetSymbolInfo(assign.Left).Symbol;
             if (leftSymbol is IEventSymbol evt)
             {
-                var eventName = TypeScriptNaming.ToCamelCase(evt.Name);
+                var eventName = TypeScriptNaming.ToCamelCaseMember(evt.Name);
                 var suffix = assign.OperatorToken.Text == "+=" ? "$add" : "$remove";
                 var receiver = assign.Left is MemberAccessExpressionSyntax memberAccess
                     ? _parent.TransformExpression(memberAccess.Expression)

--- a/src/Metano.Compiler.TypeScript/Transformation/OperatorHandler.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/OperatorHandler.cs
@@ -91,6 +91,23 @@ public sealed class OperatorHandler(ExpressionTransformer parent)
             return new TsCallExpression(new TsPropertyAccess(receiver, "set"), [key, value]);
         }
 
+        if (assign.OperatorToken.Text is "+=" or "-=")
+        {
+            var leftSymbol = _parent.Model.GetSymbolInfo(assign.Left).Symbol;
+            if (leftSymbol is IEventSymbol evt)
+            {
+                var eventName = TypeScriptNaming.ToCamelCase(evt.Name);
+                var suffix = assign.OperatorToken.Text == "+=" ? "$add" : "$remove";
+                var receiver = assign.Left is MemberAccessExpressionSyntax memberAccess
+                    ? _parent.TransformExpression(memberAccess.Expression)
+                    : new TsIdentifier("this");
+                return new TsCallExpression(
+                    new TsPropertyAccess(receiver, $"{eventName}{suffix}"),
+                    [_parent.TransformExpression(assign.Right)]
+                );
+            }
+        }
+
         return new TsBinaryExpression(
             _parent.TransformExpression(assign.Left),
             MapAssignmentOperator(assign.OperatorToken.Text),

--- a/src/Metano.Compiler.TypeScript/Transformation/RecordClassTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/RecordClassTransformer.cs
@@ -181,6 +181,10 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
                 case IMethodSymbol method when method.MethodKind == MethodKind.UserDefinedOperator:
                     classMembers.AddRange(TransformClassOperator(type, method));
                     break;
+
+                case IEventSymbol evt:
+                    classMembers.AddRange(TransformEvent(evt));
+                    break;
             }
         }
 
@@ -701,6 +705,69 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
             Generator: hasYield,
             Accessibility: TypeTransformer.MapAccessibility(method.DeclaredAccessibility),
             TypeParameters: TypeTransformer.ExtractMethodTypeParameters(method)
+        );
+    }
+
+    /// <summary>
+    /// Transforms a C# <c>event</c> member into a delegate field plus
+    /// <c>$add</c> / <c>$remove</c> methods that call the runtime's
+    /// <c>delegateAdd</c> / <c>delegateRemove</c> helpers.
+    /// </summary>
+    private IReadOnlyList<TsClassMember> TransformEvent(IEventSymbol evt)
+    {
+        var name = TypeScriptNaming.ToCamelCase(evt.Name);
+        var delegateType = TypeMapper.Map(evt.Type);
+        var nullableDelegateType = new TsUnionType([delegateType, new TsNamedType("null")]);
+
+        var result = new List<TsClassMember>();
+
+        // Field: eventName: ((args) => void) | null = null
+        result.Add(
+            new TsFieldMember(
+                name,
+                nullableDelegateType,
+                Initializer: new TsLiteral("null"),
+                Accessibility: TypeTransformer.MapAccessibility(evt.DeclaredAccessibility)
+            )
+        );
+
+        var handlerParam = new TsParameter("handler", delegateType);
+        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateAdd"));
+        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateRemove"));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a <c>eventName$add</c> or <c>eventName$remove</c> method that
+    /// delegates to the corresponding runtime helper.
+    /// </summary>
+    private static TsMethodMember BuildDelegateAccessor(
+        string eventName,
+        TsParameter handlerParam,
+        string runtimeHelper
+    )
+    {
+        var suffix = runtimeHelper == "delegateAdd" ? "$add" : "$remove";
+        return new TsMethodMember(
+            $"{eventName}{suffix}",
+            [handlerParam],
+            new TsVoidType(),
+            [
+                new TsExpressionStatement(
+                    new TsBinaryExpression(
+                        new TsPropertyAccess(new TsIdentifier("this"), eventName),
+                        "=",
+                        new TsCallExpression(
+                            new TsIdentifier(runtimeHelper),
+                            [
+                                new TsPropertyAccess(new TsIdentifier("this"), eventName),
+                                new TsIdentifier("handler"),
+                            ]
+                        )
+                    )
+                ),
+            ]
         );
     }
 

--- a/src/Metano.Compiler.TypeScript/Transformation/RecordClassTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/RecordClassTransformer.cs
@@ -715,25 +715,29 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
     /// </summary>
     private IReadOnlyList<TsClassMember> TransformEvent(IEventSymbol evt)
     {
-        var name = TypeScriptNaming.ToCamelCase(evt.Name);
+        var name = TypeScriptNaming.ToCamelCaseMember(evt.Name);
         var delegateType = TypeMapper.Map(evt.Type);
         var nullableDelegateType = new TsUnionType([delegateType, new TsNamedType("null")]);
 
         var result = new List<TsClassMember>();
 
-        // Field: eventName: ((args) => void) | null = null
+        var eventAccessibility = TypeTransformer.MapAccessibility(evt.DeclaredAccessibility);
+
+        // Backing field is always private — C# events restrict direct
+        // invocation/assignment to the declaring class. Only the $add/$remove
+        // methods are exposed with the event's declared accessibility.
         result.Add(
             new TsFieldMember(
                 name,
                 nullableDelegateType,
                 Initializer: new TsLiteral("null"),
-                Accessibility: TypeTransformer.MapAccessibility(evt.DeclaredAccessibility)
+                Accessibility: TsAccessibility.Private
             )
         );
 
         var handlerParam = new TsParameter("handler", delegateType);
-        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateAdd"));
-        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateRemove"));
+        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateAdd", eventAccessibility));
+        result.Add(BuildDelegateAccessor(name, handlerParam, "delegateRemove", eventAccessibility));
 
         return result;
     }
@@ -745,7 +749,8 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
     private static TsMethodMember BuildDelegateAccessor(
         string eventName,
         TsParameter handlerParam,
-        string runtimeHelper
+        string runtimeHelper,
+        TsAccessibility accessibility
     )
     {
         var suffix = runtimeHelper == "delegateAdd" ? "$add" : "$remove";
@@ -753,6 +758,7 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
             $"{eventName}{suffix}",
             [handlerParam],
             new TsVoidType(),
+            Body:
             [
                 new TsExpressionStatement(
                     new TsBinaryExpression(
@@ -767,7 +773,8 @@ public sealed class RecordClassTransformer(TypeScriptTransformContext context)
                         )
                     )
                 ),
-            ]
+            ],
+            Accessibility: accessibility
         );
     }
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeMapper.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeMapper.cs
@@ -267,6 +267,10 @@ public static class TypeMapper
             if (IsCollectionLike(named) && named.TypeArguments.Length > 0)
                 return new TsArrayType(Map(named.TypeArguments[0]));
 
+            // Delegate types → function type: (args) => ReturnType
+            if (named.TypeKind == TypeKind.Delegate)
+                return MapDelegateType(named);
+
             // Generic type with type arguments → preserve them
             if (named.TypeArguments.Length > 0)
             {
@@ -287,6 +291,30 @@ public static class TypeMapper
             return new TsArrayType(Map(array.ElementType));
 
         return new TsAnyType();
+    }
+
+    /// <summary>
+    /// Maps a C# delegate type to a TS function type by reading its <c>Invoke</c>
+    /// method signature. Handles <c>Action&lt;T&gt;</c>, <c>Func&lt;T,R&gt;</c>,
+    /// <c>EventHandler&lt;T&gt;</c>, and any custom delegate type.
+    /// </summary>
+    private static TsFunctionType MapDelegateType(INamedTypeSymbol delegateType)
+    {
+        var invoke = delegateType.GetMembers("Invoke").OfType<IMethodSymbol>().FirstOrDefault();
+
+        if (invoke is null)
+            return new TsFunctionType([], new TsVoidType());
+
+        var parameters = invoke
+            .Parameters.Select(p => new TsParameter(
+                TypeScriptNaming.ToCamelCase(p.Name),
+                Map(p.Type)
+            ))
+            .ToList();
+
+        var returnType = invoke.ReturnsVoid ? new TsVoidType() : Map(invoke.ReturnType);
+
+        return new TsFunctionType(parameters, returnType);
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsFunctionType.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsFunctionType.cs
@@ -1,0 +1,9 @@
+namespace Metano.TypeScript.AST;
+
+/// <summary>
+/// A TypeScript function type: <c>(param: T) => R</c>.
+/// Used for delegate type mappings (<c>Action&lt;T&gt;</c>, <c>Func&lt;T,R&gt;</c>,
+/// <c>EventHandler&lt;T&gt;</c>, and custom delegate types).
+/// </summary>
+public sealed record TsFunctionType(IReadOnlyList<TsParameter> Parameters, TsType ReturnType)
+    : TsType;

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -717,11 +717,11 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsUnionType union:
-                _sb.WriteList(union.Types, PrintType, " | ");
+                _sb.WriteList(union.Types, PrintTypeInUnion, " | ");
                 break;
 
             case TsIntersectionType intersection:
-                _sb.WriteList(intersection.Types, PrintType, " & ");
+                _sb.WriteList(intersection.Types, PrintTypeInUnion, " & ");
                 break;
 
             case TsTupleType tuple:
@@ -742,6 +742,26 @@ public sealed class Printer(string indent = "  ")
                 _sb.Write(") => ");
                 PrintType(funcType.ReturnType);
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Wraps low-precedence types (function types) in parentheses when they
+    /// appear as operands of a union or intersection. Without this,
+    /// <c>(args) =&gt; R | null</c> parses as a function returning <c>R | null</c>
+    /// instead of a nullable function <c>((args) =&gt; R) | null</c>.
+    /// </summary>
+    private void PrintTypeInUnion(TsType type)
+    {
+        if (type is TsFunctionType)
+        {
+            _sb.Write("(");
+            PrintType(type);
+            _sb.Write(")");
+        }
+        else
+        {
+            PrintType(type);
         }
     }
 

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -735,6 +735,13 @@ public sealed class Printer(string indent = "  ")
                 _sb.Write(" is ");
                 PrintType(predicate.Type);
                 break;
+
+            case TsFunctionType funcType:
+                _sb.Write("(");
+                PrintParameters(funcType.Parameters);
+                _sb.Write(") => ");
+                PrintType(funcType.ReturnType);
+                break;
         }
     }
 

--- a/tests/Metano.Tests/DelegateEventTests.cs
+++ b/tests/Metano.Tests/DelegateEventTests.cs
@@ -1,0 +1,129 @@
+namespace Metano.Tests;
+
+public class DelegateEventTests
+{
+    [Test]
+    public async Task ActionType_MapsToArrowFunctionType()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Notifier
+            {
+                public Action<string>? Callback { get; set; }
+            }
+            """
+        );
+
+        var output = result["notifier.ts"];
+        // Action<string> → (obj: string) => void (Roslyn names the param "obj")
+        await Assert.That(output).Contains("(obj: string) => void");
+    }
+
+    [Test]
+    public async Task EventField_EmitsFieldAndAddRemoveMethods()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+            """
+        );
+
+        var output = result["counter.ts"];
+        // Field: nullable delegate
+        await Assert.That(output).Contains("countChanged:");
+        await Assert.That(output).Contains("| null = null");
+        // $add method
+        await Assert.That(output).Contains("countChanged$add(handler:");
+        await Assert.That(output).Contains("delegateAdd(");
+        // $remove method
+        await Assert.That(output).Contains("countChanged$remove(handler:");
+        await Assert.That(output).Contains("delegateRemove(");
+    }
+
+    [Test]
+    public async Task EventField_ImportsRuntimeHelpers()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+            """
+        );
+
+        var output = result["counter.ts"];
+        await Assert.That(output).Contains("import { delegateAdd, delegateRemove }");
+        await Assert.That(output).Contains("from \"metano-runtime\"");
+    }
+
+    [Test]
+    public async Task EventSubscription_LowersToAddMethod()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+
+            [Transpile]
+            public class App
+            {
+                private Counter _counter = new Counter();
+
+                public void Setup()
+                {
+                    _counter.CountChanged += OnCountChanged;
+                }
+
+                private void OnCountChanged(int count) { }
+            }
+            """
+        );
+
+        var output = result["app.ts"];
+        await Assert.That(output).Contains("countChanged$add(");
+    }
+
+    [Test]
+    public async Task EventUnsubscription_LowersToRemoveMethod()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+
+            [Transpile]
+            public class App
+            {
+                private Counter _counter = new Counter();
+
+                public void Teardown()
+                {
+                    _counter.CountChanged -= OnCountChanged;
+                }
+
+                private void OnCountChanged(int count) { }
+            }
+            """
+        );
+
+        var output = result["app.ts"];
+        await Assert.That(output).Contains("countChanged$remove(");
+    }
+}


### PR DESCRIPTION
Closes #45.

## Summary

Full delegate and event support for the TypeScript target:

- **Delegate type mapping** — `Action<T>`, `Func<T,R>`, `EventHandler<T>`, and custom delegates map to TS function types `(params) => ReturnType` via the delegate's `Invoke` method signature.
- **Event members** — C# `event` fields generate a nullable delegate field + `$add`/`$remove` methods: `counterChanged$add(handler)` / `counterChanged$remove(handler)`.
- **`+=`/`-=` lowering** — `obj.Event += handler` → `obj.event$add(handler)`, `-=` → `obj.event$remove(handler)`.
- **Runtime multicast delegates** — `delegateAdd`/`delegateRemove` in `metano-runtime` promote a plain function to a multicast delegate on demand. Zero overhead when `+=` is never used.

## Test plan

- [x] `dotnet run --project tests/Metano.Tests/` — **344/344** (339 + 5 new delegate tests)
- [x] `cd js/metano-runtime && bun test` — **275/275** (261 + 14 new delegate tests)
- [x] `dotnet csharpier check .` — clean