### PR TITLE
fix: restrict package.json exports to namespace barrels and mark Metano as build-only (#48, #47)

### DIFF
--- a/js/sample-issue-tracker/package.json
+++ b/js/sample-issue-tracker/package.json
@@ -34,93 +34,21 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./issues/application/i-issue-repository": {
-      "types": "./dist/issues/application/i-issue-repository.d.ts",
-      "import": "./dist/issues/application/i-issue-repository.js"
-    },
-    "./issues/application/in-memory-issue-repository": {
-      "types": "./dist/issues/application/in-memory-issue-repository.d.ts",
-      "import": "./dist/issues/application/in-memory-issue-repository.js"
-    },
     "./issues/application": {
       "types": "./dist/issues/application/index.d.ts",
       "import": "./dist/issues/application/index.js"
-    },
-    "./issues/application/issue-queries": {
-      "types": "./dist/issues/application/issue-queries.d.ts",
-      "import": "./dist/issues/application/issue-queries.js"
-    },
-    "./issues/application/issue-service": {
-      "types": "./dist/issues/application/issue-service.d.ts",
-      "import": "./dist/issues/application/issue-service.js"
-    },
-    "./issues/domain/comment": {
-      "types": "./dist/issues/domain/comment.d.ts",
-      "import": "./dist/issues/domain/comment.js"
     },
     "./issues/domain": {
       "types": "./dist/issues/domain/index.d.ts",
       "import": "./dist/issues/domain/index.js"
     },
-    "./issues/domain/issue-id": {
-      "types": "./dist/issues/domain/issue-id.d.ts",
-      "import": "./dist/issues/domain/issue-id.js"
-    },
-    "./issues/domain/issue-priority": {
-      "types": "./dist/issues/domain/issue-priority.d.ts",
-      "import": "./dist/issues/domain/issue-priority.js"
-    },
-    "./issues/domain/issue-snapshot": {
-      "types": "./dist/issues/domain/issue-snapshot.d.ts",
-      "import": "./dist/issues/domain/issue-snapshot.js"
-    },
-    "./issues/domain/issue-status": {
-      "types": "./dist/issues/domain/issue-status.d.ts",
-      "import": "./dist/issues/domain/issue-status.js"
-    },
-    "./issues/domain/issue-type": {
-      "types": "./dist/issues/domain/issue-type.d.ts",
-      "import": "./dist/issues/domain/issue-type.js"
-    },
-    "./issues/domain/issue-workflow": {
-      "types": "./dist/issues/domain/issue-workflow.d.ts",
-      "import": "./dist/issues/domain/issue-workflow.js"
-    },
-    "./issues/domain/issue": {
-      "types": "./dist/issues/domain/issue.d.ts",
-      "import": "./dist/issues/domain/issue.js"
-    },
-    "./json-context": {
-      "types": "./dist/json-context.d.ts",
-      "import": "./dist/json-context.js"
-    },
     "./planning/domain": {
       "types": "./dist/planning/domain/index.d.ts",
       "import": "./dist/planning/domain/index.js"
     },
-    "./planning/domain/sprint": {
-      "types": "./dist/planning/domain/sprint.d.ts",
-      "import": "./dist/planning/domain/sprint.js"
-    },
     "./shared-kernel": {
       "types": "./dist/shared-kernel/index.d.ts",
       "import": "./dist/shared-kernel/index.js"
-    },
-    "./shared-kernel/operation-result": {
-      "types": "./dist/shared-kernel/operation-result.d.ts",
-      "import": "./dist/shared-kernel/operation-result.js"
-    },
-    "./shared-kernel/page-request": {
-      "types": "./dist/shared-kernel/page-request.d.ts",
-      "import": "./dist/shared-kernel/page-request.js"
-    },
-    "./shared-kernel/page-result": {
-      "types": "./dist/shared-kernel/page-result.d.ts",
-      "import": "./dist/shared-kernel/page-result.js"
-    },
-    "./shared-kernel/user-id": {
-      "types": "./dist/shared-kernel/user-id.d.ts",
-      "import": "./dist/shared-kernel/user-id.js"
     }
   }
 }

--- a/js/sample-todo-service/package.json
+++ b/js/sample-todo-service/package.json
@@ -29,23 +29,5 @@
     "generate": "dotnet run --project ../../src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj -- -p ../../samples/SampleTodo.Service/SampleTodo.Service.csproj -o ./src --clean --time",
     "build": "tsgo -b .",
     "test": "bun test"
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
-    "./json-context": {
-      "types": "./dist/json-context.d.ts",
-      "import": "./dist/json-context.js"
-    },
-    "./program": {
-      "types": "./dist/program.d.ts",
-      "import": "./dist/program.js"
-    },
-    "./todos": {
-      "types": "./dist/todos.d.ts",
-      "import": "./dist/todos.js"
-    }
   }
 }

--- a/js/sample-todo/package.json
+++ b/js/sample-todo/package.json
@@ -31,22 +31,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./json-context": {
-      "types": "./dist/json-context.d.ts",
-      "import": "./dist/json-context.js"
-    },
-    "./priority": {
-      "types": "./dist/priority.d.ts",
-      "import": "./dist/priority.js"
-    },
-    "./todo-item": {
-      "types": "./dist/todo-item.d.ts",
-      "import": "./dist/todo-item.js"
-    },
-    "./todo-list": {
-      "types": "./dist/todo-list.d.ts",
-      "import": "./dist/todo-list.js"
     }
   }
 }

--- a/samples/SampleCounter/SampleCounter.csproj
+++ b/samples/SampleCounter/SampleCounter.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Metano/Metano.csproj" />
+    <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SampleCounter/js/package.json
+++ b/samples/SampleCounter/js/package.json
@@ -21,8 +21,5 @@
   "sideEffects": false,
   "imports": {
     "#/*": "./src/*"
-  },
-  "exports": {
-    "./*": "./src/*"
   }
 }

--- a/samples/SampleIssueTracker/SampleIssueTracker.csproj
+++ b/samples/SampleIssueTracker/SampleIssueTracker.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Metano/Metano.csproj" />
+    <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../src/Metano.Build/build/Metano.Build.targets" />

--- a/samples/SampleTodo.Service/SampleTodo.Service.csproj
+++ b/samples/SampleTodo.Service/SampleTodo.Service.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
     <ProjectReference Include="../SampleTodo/SampleTodo.csproj" />
   </ItemGroup>
 

--- a/samples/SampleTodo/SampleTodo.csproj
+++ b/samples/SampleTodo/SampleTodo.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Metano/Metano.csproj" />
+    <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../src/Metano.Build/build/Metano.Build.targets" />

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -56,12 +56,11 @@ public static class PackageJsonWriter
         var packageJsonPath = Path.Combine(packageRoot, "package.json");
         var srcRelative = NormalizePath(Path.GetRelativePath(packageRoot, outputDirAbsolute));
 
-        // Build the imports/exports objects
-        var hasRootIndex = files.Any(f =>
-            NormalizePath(f.FileName).Equals("index.ts", StringComparison.Ordinal)
-        );
+        // Build the imports/exports objects. Exports are only needed for libraries;
+        // the root-index check is derived from the exports object to avoid a duplicate scan.
+        var exports = isExecutable ? null : BuildExports(files, distDirRelativeToPackageRoot);
+        var hasRootIndex = exports?.ContainsKey(".") ?? false;
         var imports = BuildImports(srcRelative, distDirRelativeToPackageRoot, hasRootIndex);
-        var exports = BuildExports(files, distDirRelativeToPackageRoot);
 
         JsonObject root;
         if (File.Exists(packageJsonPath))
@@ -106,15 +105,17 @@ public static class PackageJsonWriter
         root["type"] = "module";
         root["sideEffects"] = false;
 
-        // Only populate imports/exports when the user hasn't customized them.
-        // If the key already exists, the user's version prevails.
+        // Only populate imports when the user hasn't customized them.
         if (root["imports"] is null)
             root["imports"] = imports;
-        // Executables (ConsoleApplication) don't need exports — they're not
-        // consumed by other packages. Libraries always get exports so
-        // cross-package resolution works.
-        if (!isExecutable && root["exports"] is null)
+        // Exports are always overwritten — they're a transpiler-computed artifact
+        // derived from the namespace barrel structure. Stale exports from previous
+        // runs must not survive. Executables don't need exports (they're not
+        // consumed by other packages), so any stale entries are removed.
+        if (exports is not null)
             root["exports"] = exports;
+        else
+            root.Remove("exports");
 
         // Merge auto-generated cross-package dependencies into the existing
         // `dependencies` object, leaving any user-hand-written entries for OTHER
@@ -170,35 +171,28 @@ public static class PackageJsonWriter
     }
 
     /// <summary>
-    /// Builds the `exports` object listing every public path the consumer can import.
-    /// Each barrel becomes a directory-level subpath, each individual file gets its own subpath.
+    /// Builds the <c>exports</c> object listing the public subpaths the consumer can import.
+    /// Only namespace barrel files (<c>index.ts</c>) become export entries — individual type
+    /// files are accessed through their barrel, matching the namespace-first convention
+    /// from ADR-0006.
     /// </summary>
     private static JsonObject BuildExports(IReadOnlyList<TsSourceFile> files, string distRelative)
     {
         var dist = NormalizePath(distRelative).TrimEnd('/');
         var exports = new JsonObject();
 
-        // Sort for deterministic output
-        var ordered = files.OrderBy(f => f.FileName, StringComparer.Ordinal).ToList();
+        var barrels = files
+            .Select(f => NormalizePath(f.FileName))
+            .Where(name => Path.GetFileName(name).Equals("index.ts", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal);
 
-        foreach (var file in ordered)
+        foreach (var name in barrels)
         {
-            var name = NormalizePath(file.FileName);
-            // Strip .ts
-            var withoutExt = name.EndsWith(".ts") ? name[..^3] : name;
+            var withoutExt = name[..^3]; // Strip .ts
 
-            string subpath;
-            if (Path.GetFileName(withoutExt) == "index")
-            {
-                // Barrel: ./issues/domain/index.ts → "./issues/domain"
-                var parent = Path.GetDirectoryName(withoutExt)?.Replace('\\', '/') ?? "";
-                subpath = parent.Length == 0 ? "." : $"./{parent}";
-            }
-            else
-            {
-                // Regular file: ./issues/domain/issue.ts → "./issues/domain/issue"
-                subpath = $"./{withoutExt}";
-            }
+            // Barrel: issues/domain/index → "./issues/domain", root index → "."
+            var parent = Path.GetDirectoryName(withoutExt)?.Replace('\\', '/') ?? "";
+            var subpath = parent.Length == 0 ? "." : $"./{parent}";
 
             exports[subpath] = new JsonObject
             {

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -219,6 +219,114 @@ public class EmitPackageTests
         Directory.Delete(tempDir, recursive: true);
     }
 
+    [Test]
+    public async Task Exports_OnlyIncludeBarrelFiles()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("domain/index.ts", [], ""),
+            new TsSourceFile("domain/item.ts", [], ""),
+            new TsSourceFile("domain/category.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        // Only barrels: "." and "./domain"
+        await Assert.That(exports!.Count).IsEqualTo(2);
+        await Assert.That(exports.ContainsKey(".")).IsTrue();
+        await Assert.That(exports.ContainsKey("./domain")).IsTrue();
+        // Individual files must NOT appear
+        await Assert.That(exports.ContainsKey("./domain/item")).IsFalse();
+        await Assert.That(exports.ContainsKey("./domain/category")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_FlatPackageOnlyExportsRoot()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("todo-item.ts", [], ""),
+            new TsSourceFile("todo-list.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "sample-todo"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.Count).IsEqualTo(1);
+        await Assert.That(exports.ContainsKey(".")).IsTrue();
+        await Assert.That(exports.ContainsKey("./todo-item")).IsFalse();
+        await Assert.That(exports.ContainsKey("./todo-list")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_RegeneratedOnSubsequentRuns()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // First run: stale file-based exports (simulating old behavior)
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "test-pkg",
+              "exports": {
+                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+                "./item": { "types": "./dist/item.d.ts", "import": "./dist/item.js" }
+              }
+            }
+            """
+        );
+
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("item.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(tempDir, srcDir, files, authoritativePackageName: "test-pkg");
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        // Stale "./item" entry must be gone — only barrel "." remains
+        await Assert.That(exports!.Count).IsEqualTo(1);
+        await Assert.That(exports.ContainsKey(".")).IsTrue();
+        await Assert.That(exports.ContainsKey("./item")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
     private static string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"metasharp-test-{Guid.NewGuid():N}");

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -314,7 +314,12 @@ public class EmitPackageTests
             new TsSourceFile("item.ts", [], ""),
         };
 
-        PackageJsonWriter.UpdateOrCreate(tempDir, srcDir, files, authoritativePackageName: "test-pkg");
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
 
         var pkg = ReadJson(tempDir);
         var exports = pkg["exports"] as JsonObject;


### PR DESCRIPTION
## Summary

- **#48**: `BuildExports()` was exporting every generated file as a subpath in `package.json`. Now only barrel files (`index.ts`) become export entries, matching ADR-0006 namespace-first convention. Exports are always overwritten on re-transpile (stale entries no longer survive), and executables have their exports removed entirely.
- **#47**: Added `PrivateAssets="all"` to the Metano `ProjectReference` in all sample `.csproj` files so annotations don't leak as transitive runtime dependencies.

## Test plan

- [x] 3 new unit tests in `EmitPackageTests.cs` (barrel-only, flat-root, regeneration)
- [x] 347 .NET tests pass
- [x] sample-todo: 18 JS tests pass
- [x] sample-issue-tracker: 65 JS tests pass
- [x] sample-todo-service: 19 JS tests pass
- [x] All 4 sample projects build successfully with `PrivateAssets="all"`
- [x] Generated `package.json` exports verified for all samples

Closes #48
Closes #47