### PR TITLE
fix: add --src-root for subdirectory-aware package.json paths (#50)

### DIFF
--- a/js/sample-todo-service/package.json
+++ b/js/sample-todo-service/package.json
@@ -5,15 +5,15 @@
   "sideEffects": false,
   "module": "./dist/program.js",
   "imports": {
-    "#/*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js",
-      "default": "./src/*.ts"
-    },
     "#": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./src/index.ts"
+    },
+    "#/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./src/*.ts"
     }
   },
   "dependencies": {

--- a/js/sample-todo-service/package.json
+++ b/js/sample-todo-service/package.json
@@ -5,11 +5,6 @@
   "sideEffects": false,
   "module": "./dist/program.js",
   "imports": {
-    "#": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./src/index.ts"
-    },
     "#/*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -13,6 +13,7 @@
       MetanoClean            (optional)  true to wipe the output dir first (default: false)
       MetanoDist             (optional)  JS dist dir relative to package root (default: ./dist)
       MetanoPackageRoot      (optional)  Root of the npm package (default: parent of OutputDir)
+      MetanoSrcRoot          (optional)  TS source root relative to package root (default: inferred)
       MetanoSkipPackageJson  (optional)  true to skip package.json generation (default: false)
       MetanoShowTimings      (optional)  true to print timing info (default: false)
       MetanoExtraArgs        (optional)  Additional CLI arguments
@@ -37,6 +38,9 @@
       >
       <_MetanoArgs Condition="'$(MetanoPackageRoot)' != ''"
         >$(_MetanoArgs) --package-root "$(MetanoPackageRoot)"</_MetanoArgs
+      >
+      <_MetanoArgs Condition="'$(MetanoSrcRoot)' != ''"
+        >$(_MetanoArgs) --src-root "$(MetanoSrcRoot)"</_MetanoArgs
       >
       <_MetanoArgs Condition="'$(MetanoSkipPackageJson)' == 'true'"
         >$(_MetanoArgs) --skip-package-json</_MetanoArgs

--- a/src/Metano.Build/buildTransitive/Metano.Build.targets
+++ b/src/Metano.Build/buildTransitive/Metano.Build.targets
@@ -13,6 +13,7 @@
       MetanoClean            (optional)  true to wipe the output dir first (default: false)
       MetanoDist             (optional)  JS dist dir relative to package root (default: ./dist)
       MetanoPackageRoot      (optional)  Root of the npm package (default: parent of OutputDir)
+      MetanoSrcRoot          (optional)  TS source root relative to package root (default: inferred)
       MetanoSkipPackageJson  (optional)  true to skip package.json generation (default: false)
       MetanoShowTimings      (optional)  true to print timing info (default: false)
       MetanoExtraArgs        (optional)  Additional CLI arguments
@@ -37,6 +38,9 @@
       >
       <_MetanoArgs Condition="'$(MetanoPackageRoot)' != ''"
         >$(_MetanoArgs) --package-root "$(MetanoPackageRoot)"</_MetanoArgs
+      >
+      <_MetanoArgs Condition="'$(MetanoSrcRoot)' != ''"
+        >$(_MetanoArgs) --src-root "$(MetanoSrcRoot)"</_MetanoArgs
       >
       <_MetanoArgs Condition="'$(MetanoSkipPackageJson)' == 'true'"
         >$(_MetanoArgs) --skip-package-json</_MetanoArgs

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -14,6 +14,7 @@ public class Commands
     /// <param name="clean">-c, Clean output directory before generating</param>
     /// <param name="packageRoot">Root directory of the consumer package (default: parent of --output)</param>
     /// <param name="dist">Path (relative to packageRoot) where the JS build output lives (default: ./dist)</param>
+    /// <param name="srcRoot">TypeScript source root relative to packageRoot (default: inferred from first segment of output path). Used to compute the dist prefix when output targets a subdirectory (e.g., src/domain/).</param>
     /// <param name="skipPackageJson">Skip generating/updating package.json</param>
     [Command("")]
     public async Task Transpile(
@@ -23,6 +24,7 @@ public class Commands
         bool clean = false,
         string? packageRoot = null,
         string dist = "./dist",
+        string? srcRoot = null,
         bool skipPackageJson = false
     )
     {
@@ -60,7 +62,8 @@ public class Commands
                 dist,
                 authoritativePackageName: target.LastEmitPackageName,
                 crossPackageDependencies: target.LastCrossPackageDependencies,
-                isExecutable: target.LastIsExecutable
+                isExecutable: target.LastIsExecutable,
+                srcRoot: srcRoot
             );
 
             foreach (var d in pkgDiagnostics)

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -69,10 +69,30 @@ public static class PackageJsonWriter
 
         // Output prefix: the path from the source root to the output directory.
         // Empty when outputDir IS the source root (e.g., srcRelative = "src").
-        var outputPrefix =
-            srcRelative == resolvedSrcRoot
-                ? ""
-                : NormalizePath(Path.GetRelativePath(resolvedSrcRoot, srcRelative));
+        // Validate that srcRelative is within resolvedSrcRoot — if not, fall back
+        // to empty prefix and warn rather than producing silently wrong paths.
+        string outputPrefix;
+        if (srcRelative == resolvedSrcRoot)
+        {
+            outputPrefix = "";
+        }
+        else if (srcRelative.StartsWith(resolvedSrcRoot + "/", StringComparison.Ordinal))
+        {
+            outputPrefix = srcRelative[(resolvedSrcRoot.Length + 1)..];
+        }
+        else
+        {
+            outputPrefix = "";
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Warning,
+                    DiagnosticCodes.CrossPackageResolution,
+                    $"--src-root '{resolvedSrcRoot}' is not an ancestor of output path "
+                        + $"'{srcRelative}'. Ignoring prefix — imports/exports paths may be incorrect. "
+                        + $"Set --src-root to the directory that your build tool uses as rootDir."
+                )
+            );
+        }
 
         // Build the imports/exports objects. Exports are only needed for libraries.
         var exports = isExecutable
@@ -127,14 +147,24 @@ public static class PackageJsonWriter
         root["type"] = "module";
         root["sideEffects"] = false;
 
-        // Merge transpiler-managed entries into the existing imports/exports objects.
-        // User-defined entries for other subpaths are preserved.
-        MergeJsonObject(root, "imports", imports);
+        // Replace transpiler-managed entries while preserving user-defined ones.
+        // For imports, the transpiler manages "#" and "#/*" — stale aliases are removed.
+        HashSet<string> managedImportKeys = ["#", "#/*"];
+        ReplacePreservingUserEntries(root, "imports", imports, managedImportKeys);
 
+        // Exports are fully transpiler-controlled — replace entirely.
+        // Unlike imports (where users may add custom aliases like "#custom/*"),
+        // export subpaths are derived from namespace barrels and cannot be
+        // distinguished from user entries.
         if (exports is not null)
-            MergeJsonObject(root, "exports", exports);
-        else
+        {
             root.Remove("exports");
+            root["exports"] = exports;
+        }
+        else
+        {
+            root.Remove("exports");
+        }
 
         // Merge auto-generated cross-package dependencies into the existing
         // `dependencies` object, leaving any user-hand-written entries for OTHER
@@ -153,22 +183,34 @@ public static class PackageJsonWriter
     }
 
     /// <summary>
-    /// Merges entries from <paramref name="generated"/> into the existing JSON object at
-    /// <paramref name="key"/>. Creates the object if it doesn't exist. Overwrites entries
-    /// with matching keys but preserves user-defined entries with other keys.
+    /// Replaces the JSON object at <paramref name="key"/> with <paramref name="generated"/>,
+    /// preserving any user-defined entries whose keys are absent from the generated set.
+    /// Keys listed in <paramref name="managedKeys"/> are considered transpiler-managed — if
+    /// they appear in the existing object but not in <paramref name="generated"/>, they are
+    /// stale and silently dropped instead of being preserved.
     /// </summary>
-    private static void MergeJsonObject(JsonObject root, string key, JsonObject generated)
+    private static void ReplacePreservingUserEntries(
+        JsonObject root,
+        string key,
+        JsonObject generated,
+        IReadOnlySet<string>? managedKeys = null
+    )
     {
-        var existing = root[key] as JsonObject ?? new JsonObject();
-
-        foreach (var (entryKey, entryValue) in generated)
+        if (root[key] is JsonObject existing)
         {
-            // Remove existing entry first (JsonObject doesn't allow duplicate keys)
-            existing.Remove(entryKey);
-            existing[entryKey] = entryValue?.DeepClone();
+            // Copy user-defined entries that the transpiler doesn't manage.
+            foreach (var (entryKey, entryValue) in existing.ToList())
+            {
+                if (generated.ContainsKey(entryKey))
+                    continue; // Already in generated — transpiler's version wins.
+                if (managedKeys is not null && managedKeys.Contains(entryKey))
+                    continue; // Stale transpiler key — drop it.
+                generated[entryKey] = entryValue?.DeepClone();
+            }
         }
 
-        root[key] = existing;
+        root.Remove(key);
+        root[key] = generated;
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -6,11 +6,14 @@ using Metano.TypeScript.AST;
 namespace Metano;
 
 /// <summary>
-/// Generates and updates the consumer's package.json with `imports`, `exports`, `sideEffects`,
-/// and `type` fields based on the TypeScript files emitted by the transpiler.
+/// Generates and updates the consumer's package.json with <c>imports</c>, <c>exports</c>,
+/// <c>sideEffects</c>, and <c>type</c> fields based on the TypeScript files emitted by the
+/// transpiler.
 ///
 /// Strategy: non-destructive merge. The user's hand-written fields (name, dependencies,
-/// scripts, etc.) are preserved. Only the controlled fields are overwritten.
+/// scripts, etc.) are preserved. Transpiler-managed entries inside <c>imports</c> and
+/// <c>exports</c> are merged into the existing objects — user-defined entries for other
+/// subpaths survive untouched.
 /// </summary>
 public static class PackageJsonWriter
 {
@@ -28,19 +31,23 @@ public static class PackageJsonWriter
     /// </summary>
     /// <param name="packageRoot">Root directory of the consumer Bun/Node package.</param>
     /// <param name="outputDirAbsolute">Absolute path where TS files are emitted (e.g., /path/to/pkg/src).</param>
-    /// <param name="distDirRelativeToPackageRoot">Relative path from packageRoot to the JS output directory (default: "./dist").</param>
     /// <param name="files">All generated TsSourceFile objects (type files + barrels).</param>
+    /// <param name="distDirRelativeToPackageRoot">Relative path from packageRoot to the JS output
+    /// directory (default: "./dist").</param>
     /// <param name="authoritativePackageName">When non-null, this name (typically read
     /// from <c>[assembly: EmitPackage(...)]</c>) is written to <c>package.json#name</c>
-    /// as the source of truth. If the existing file already had a different name, an
-    /// MS0007 diagnostic is returned and the authoritative value still wins (because
-    /// cross-package import resolution depends on it).</param>
-    /// <param name="crossPackageDependencies">Maps each cross-package npm name that the
-    /// transpiler emitted an import for, to its version specifier (e.g., <c>^1.2.3</c>
-    /// or <c>workspace:*</c>). The writer MERGES these into <c>package.json#dependencies</c>
-    /// — existing entries the user has hand-written for OTHER packages are preserved
-    /// untouched; existing entries for the same package are overwritten with the
-    /// compiler-computed version (so versions stay in sync with the C# project).</param>
+    /// as the source of truth.</param>
+    /// <param name="crossPackageDependencies">Maps each cross-package npm name to its version
+    /// specifier. Merged into <c>package.json#dependencies</c> — user entries for other
+    /// packages are preserved.</param>
+    /// <param name="isExecutable">When true, exports are not generated (executables are not
+    /// consumed by other packages).</param>
+    /// <param name="srcRoot">TypeScript source root relative to the package root
+    /// (e.g., <c>src</c>). When the output directory is a subdirectory of the source root
+    /// (e.g., <c>src/domain</c>), the prefix (<c>domain</c>) is applied to dist paths and
+    /// export subpaths so they mirror the build tool's directory structure.
+    /// Default: inferred as the first path segment of the output directory relative to the
+    /// package root.</param>
     /// <returns>List of diagnostics raised while writing — empty in the happy path.</returns>
     public static IReadOnlyList<MetanoDiagnostic> UpdateOrCreate(
         string packageRoot,
@@ -49,18 +56,36 @@ public static class PackageJsonWriter
         string distDirRelativeToPackageRoot = "./dist",
         string? authoritativePackageName = null,
         IReadOnlyDictionary<string, string>? crossPackageDependencies = null,
-        bool isExecutable = false
+        bool isExecutable = false,
+        string? srcRoot = null
     )
     {
         var diagnostics = new List<MetanoDiagnostic>();
         var packageJsonPath = Path.Combine(packageRoot, "package.json");
         var srcRelative = NormalizePath(Path.GetRelativePath(packageRoot, outputDirAbsolute));
 
-        // Build the imports/exports objects. Exports are only needed for libraries;
-        // the root-index check is derived from the exports object to avoid a duplicate scan.
-        var exports = isExecutable ? null : BuildExports(files, distDirRelativeToPackageRoot);
-        var hasRootIndex = exports?.ContainsKey(".") ?? false;
-        var imports = BuildImports(srcRelative, distDirRelativeToPackageRoot, hasRootIndex);
+        // Resolve the source root: explicit parameter, or infer from first path segment.
+        var resolvedSrcRoot = NormalizePath(srcRoot ?? srcRelative.Split('/')[0]);
+
+        // Output prefix: the path from the source root to the output directory.
+        // Empty when outputDir IS the source root (e.g., srcRelative = "src").
+        var outputPrefix =
+            srcRelative == resolvedSrcRoot
+                ? ""
+                : NormalizePath(Path.GetRelativePath(resolvedSrcRoot, srcRelative));
+
+        // Build the imports/exports objects. Exports are only needed for libraries.
+        var exports = isExecutable
+            ? null
+            : BuildExports(files, distDirRelativeToPackageRoot, outputPrefix);
+        var rootExportKey = outputPrefix.Length > 0 ? $"./{outputPrefix}" : ".";
+        var hasRootIndex = exports?.ContainsKey(rootExportKey) ?? false;
+        var imports = BuildImports(
+            srcRelative,
+            distDirRelativeToPackageRoot,
+            hasRootIndex,
+            outputPrefix
+        );
 
         JsonObject root;
         if (File.Exists(packageJsonPath))
@@ -79,9 +104,6 @@ public static class PackageJsonWriter
         }
 
         // [EmitPackage] is the source of truth for the package name when present.
-        // If the existing file's name diverges, warn and overwrite — cross-package
-        // import resolution depends on the attribute value, so the package.json must
-        // match what consumers will write in their `import { … } from "<name>/…"` lines.
         if (authoritativePackageName is not null)
         {
             var existingName = root["name"]?.GetValue<string>();
@@ -105,22 +127,18 @@ public static class PackageJsonWriter
         root["type"] = "module";
         root["sideEffects"] = false;
 
-        // Only populate imports when the user hasn't customized them.
-        if (root["imports"] is null)
-            root["imports"] = imports;
-        // Exports are always overwritten — they're a transpiler-computed artifact
-        // derived from the namespace barrel structure. Stale exports from previous
-        // runs must not survive. Executables don't need exports (they're not
-        // consumed by other packages), so any stale entries are removed.
+        // Merge transpiler-managed entries into the existing imports/exports objects.
+        // User-defined entries for other subpaths are preserved.
+        MergeJsonObject(root, "imports", imports);
+
         if (exports is not null)
-            root["exports"] = exports;
+            MergeJsonObject(root, "exports", exports);
         else
             root.Remove("exports");
 
         // Merge auto-generated cross-package dependencies into the existing
         // `dependencies` object, leaving any user-hand-written entries for OTHER
-        // packages alone. We only touch the keys we know about, so adding `react` or
-        // `bun-types` by hand will survive a regenerate cycle.
+        // packages alone.
         if (crossPackageDependencies is { Count: > 0 })
         {
             var deps = root["dependencies"] as JsonObject ?? new JsonObject();
@@ -135,24 +153,45 @@ public static class PackageJsonWriter
     }
 
     /// <summary>
-    /// Builds the `imports` object with conditional exports for the `#/*` alias.
+    /// Merges entries from <paramref name="generated"/> into the existing JSON object at
+    /// <paramref name="key"/>. Creates the object if it doesn't exist. Overwrites entries
+    /// with matching keys but preserves user-defined entries with other keys.
+    /// </summary>
+    private static void MergeJsonObject(JsonObject root, string key, JsonObject generated)
+    {
+        var existing = root[key] as JsonObject ?? new JsonObject();
+
+        foreach (var (entryKey, entryValue) in generated)
+        {
+            // Remove existing entry first (JsonObject doesn't allow duplicate keys)
+            existing.Remove(entryKey);
+            existing[entryKey] = entryValue?.DeepClone();
+        }
+
+        root[key] = existing;
+    }
+
+    /// <summary>
+    /// Builds the <c>imports</c> object with conditional exports for the <c>#/*</c> alias.
     /// Format: dist (.js + .d.ts) is preferred, source .ts is the fallback for dev.
     /// </summary>
     private static JsonObject BuildImports(
         string srcRelative,
         string distRelative,
-        bool hasRootIndex
+        bool hasRootIndex,
+        string outputPrefix
     )
     {
         var src = NormalizePath(srcRelative).TrimEnd('/');
         var dist = NormalizePath(distRelative).TrimEnd('/');
+        var distBase = outputPrefix.Length > 0 ? $"{dist}/{outputPrefix}" : dist;
 
         var imports = new JsonObject
         {
             ["#/*"] = new JsonObject
             {
-                ["types"] = $"./{dist}/*.d.ts",
-                ["import"] = $"./{dist}/*.js",
+                ["types"] = $"./{distBase}/*.d.ts",
+                ["import"] = $"./{distBase}/*.js",
                 ["default"] = $"./{src}/*.ts",
             },
         };
@@ -161,8 +200,8 @@ public static class PackageJsonWriter
         {
             imports["#"] = new JsonObject
             {
-                ["types"] = $"./{dist}/index.d.ts",
-                ["import"] = $"./{dist}/index.js",
+                ["types"] = $"./{distBase}/index.d.ts",
+                ["import"] = $"./{distBase}/index.js",
                 ["default"] = $"./{src}/index.ts",
             };
         }
@@ -174,11 +213,17 @@ public static class PackageJsonWriter
     /// Builds the <c>exports</c> object listing the public subpaths the consumer can import.
     /// Only namespace barrel files (<c>index.ts</c>) become export entries — individual type
     /// files are accessed through their barrel, matching the namespace-first convention
-    /// from ADR-0006.
+    /// from ADR-0006. When <paramref name="outputPrefix"/> is non-empty, it is prepended
+    /// to both the subpath key and the dist path.
     /// </summary>
-    private static JsonObject BuildExports(IReadOnlyList<TsSourceFile> files, string distRelative)
+    private static JsonObject BuildExports(
+        IReadOnlyList<TsSourceFile> files,
+        string distRelative,
+        string outputPrefix
+    )
     {
         var dist = NormalizePath(distRelative).TrimEnd('/');
+        var distBase = outputPrefix.Length > 0 ? $"{dist}/{outputPrefix}" : dist;
         var exports = new JsonObject();
 
         var barrels = files
@@ -190,14 +235,22 @@ public static class PackageJsonWriter
         {
             var withoutExt = name[..^3]; // Strip .ts
 
-            // Barrel: issues/domain/index → "./issues/domain", root index → "."
+            // Barrel directory: "issues/domain/index" → "issues/domain", root "index" → ""
             var parent = Path.GetDirectoryName(withoutExt)?.Replace('\\', '/') ?? "";
-            var subpath = parent.Length == 0 ? "." : $"./{parent}";
+
+            // Subpath: prepend outputPrefix when present.
+            // root index.ts with prefix "domain" → "./domain"
+            // users/index.ts with prefix "domain" → "./domain/users"
+            string subpath;
+            if (outputPrefix.Length > 0)
+                subpath = parent.Length == 0 ? $"./{outputPrefix}" : $"./{outputPrefix}/{parent}";
+            else
+                subpath = parent.Length == 0 ? "." : $"./{parent}";
 
             exports[subpath] = new JsonObject
             {
-                ["types"] = $"./{dist}/{withoutExt}.d.ts",
-                ["import"] = $"./{dist}/{withoutExt}.js",
+                ["types"] = $"./{distBase}/{withoutExt}.d.ts",
+                ["import"] = $"./{distBase}/{withoutExt}.js",
             };
         }
 

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -153,13 +153,20 @@ public static class PackageJsonWriter
         ReplacePreservingUserEntries(root, "imports", imports, managedImportKeys);
 
         // Exports are fully transpiler-controlled — replace entirely.
-        // Unlike imports (where users may add custom aliases like "#custom/*"),
-        // export subpaths are derived from namespace barrels and cannot be
-        // distinguished from user entries.
         if (exports is not null)
         {
-            root.Remove("exports");
-            root["exports"] = exports;
+            if (root["exports"] is JsonObject existingExports)
+            {
+                // Replace in-place to preserve key ordering.
+                foreach (var k in existingExports.Select(e => e.Key).ToList())
+                    existingExports.Remove(k);
+                foreach (var (ek, ev) in exports)
+                    existingExports[ek] = ev?.DeepClone();
+            }
+            else
+            {
+                root["exports"] = exports;
+            }
         }
         else
         {
@@ -207,9 +214,17 @@ public static class PackageJsonWriter
                     continue; // Stale transpiler key — drop it.
                 generated[entryKey] = entryValue?.DeepClone();
             }
+
+            // Replace in-place to preserve key ordering in the JSON output.
+            // Clear the existing object and copy generated entries into it.
+            foreach (var k in existing.Select(e => e.Key).ToList())
+                existing.Remove(k);
+            foreach (var (entryKey, entryValue) in generated)
+                existing[entryKey] = entryValue?.DeepClone();
+            // existing is already parented to root at the correct position.
+            return;
         }
 
-        root.Remove(key);
         root[key] = generated;
     }
 

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -288,21 +288,20 @@ public class EmitPackageTests
     }
 
     [Test]
-    public async Task Exports_RegeneratedOnSubsequentRuns()
+    public async Task Exports_MergedWithUserDefinedEntries()
     {
         var tempDir = CreateTempDir();
         var srcDir = Path.Combine(tempDir, "src");
         Directory.CreateDirectory(srcDir);
 
-        // First run: stale file-based exports (simulating old behavior)
+        // Existing package.json with user-defined custom export
         File.WriteAllText(
             Path.Combine(tempDir, "package.json"),
             """
             {
               "name": "test-pkg",
               "exports": {
-                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-                "./item": { "types": "./dist/item.d.ts", "import": "./dist/item.js" }
+                "./custom": { "types": "./dist/custom.d.ts", "import": "./dist/custom.js" }
               }
             }
             """
@@ -324,10 +323,148 @@ public class EmitPackageTests
         var pkg = ReadJson(tempDir);
         var exports = pkg["exports"] as JsonObject;
         await Assert.That(exports).IsNotNull();
-        // Stale "./item" entry must be gone — only barrel "." remains
-        await Assert.That(exports!.Count).IsEqualTo(1);
-        await Assert.That(exports.ContainsKey(".")).IsTrue();
-        await Assert.That(exports.ContainsKey("./item")).IsFalse();
+        // Transpiler barrel entry added
+        await Assert.That(exports!.ContainsKey(".")).IsTrue();
+        // User-defined entry preserved
+        await Assert.That(exports.ContainsKey("./custom")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Imports_MergedWithUserDefinedEntries()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // Existing package.json with user-defined custom import alias
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "test-pkg",
+              "imports": {
+                "#custom/*": "./lib/*.ts"
+              }
+            }
+            """
+        );
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+        // Transpiler entries added
+        await Assert.That(imports!.ContainsKey("#/*")).IsTrue();
+        await Assert.That(imports.ContainsKey("#")).IsTrue();
+        // User-defined entry preserved
+        await Assert.That(imports.ContainsKey("#custom/*")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_SubdirectoryOutput_IncludesPrefix()
+    {
+        var tempDir = CreateTempDir();
+        // Output to src/domain/ — a subdirectory of the source root
+        var srcDir = Path.Combine(tempDir, "src", "domain");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("users/index.ts", [], ""),
+            new TsSourceFile("users/user.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        // Subpaths include "domain" prefix
+        await Assert.That(exports!.ContainsKey("./domain")).IsTrue();
+        await Assert.That(exports.ContainsKey("./domain/users")).IsTrue();
+        // Root "." must NOT exist (output is not at source root)
+        await Assert.That(exports.ContainsKey(".")).IsFalse();
+        // Dist paths include the prefix
+        var rootEntry = exports["./domain"] as JsonObject;
+        await Assert
+            .That(rootEntry!["types"]?.GetValue<string>())
+            .IsEqualTo("./dist/domain/index.d.ts");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Imports_SubdirectoryOutput_DistPathsIncludePrefix()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src", "domain");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+
+        var wildcard = imports!["#/*"] as JsonObject;
+        await Assert.That(wildcard).IsNotNull();
+        // Dist paths include "domain/" prefix
+        await Assert.That(wildcard!["types"]?.GetValue<string>()).IsEqualTo("./dist/domain/*.d.ts");
+        await Assert.That(wildcard["import"]?.GetValue<string>()).IsEqualTo("./dist/domain/*.js");
+        // Source paths use the full srcRelative (unchanged)
+        await Assert.That(wildcard["default"]?.GetValue<string>()).IsEqualTo("./src/domain/*.ts");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_ExplicitSrcRoot_OverridesDefault()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "lib", "models");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg",
+            srcRoot: "lib"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        // srcRoot = "lib", srcRelative = "lib/models" → prefix = "models"
+        await Assert.That(exports!.ContainsKey("./models")).IsTrue();
+        await Assert.That(exports.ContainsKey(".")).IsFalse();
 
         Directory.Delete(tempDir, recursive: true);
     }

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -288,50 +288,6 @@ public class EmitPackageTests
     }
 
     [Test]
-    public async Task Exports_MergedWithUserDefinedEntries()
-    {
-        var tempDir = CreateTempDir();
-        var srcDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-
-        // Existing package.json with user-defined custom export
-        File.WriteAllText(
-            Path.Combine(tempDir, "package.json"),
-            """
-            {
-              "name": "test-pkg",
-              "exports": {
-                "./custom": { "types": "./dist/custom.d.ts", "import": "./dist/custom.js" }
-              }
-            }
-            """
-        );
-
-        var files = new[]
-        {
-            new TsSourceFile("index.ts", [], ""),
-            new TsSourceFile("item.ts", [], ""),
-        };
-
-        PackageJsonWriter.UpdateOrCreate(
-            tempDir,
-            srcDir,
-            files,
-            authoritativePackageName: "test-pkg"
-        );
-
-        var pkg = ReadJson(tempDir);
-        var exports = pkg["exports"] as JsonObject;
-        await Assert.That(exports).IsNotNull();
-        // Transpiler barrel entry added
-        await Assert.That(exports!.ContainsKey(".")).IsTrue();
-        // User-defined entry preserved
-        await Assert.That(exports.ContainsKey("./custom")).IsTrue();
-
-        Directory.Delete(tempDir, recursive: true);
-    }
-
-    [Test]
     public async Task Imports_MergedWithUserDefinedEntries()
     {
         var tempDir = CreateTempDir();
@@ -366,6 +322,98 @@ public class EmitPackageTests
         // Transpiler entries added
         await Assert.That(imports!.ContainsKey("#/*")).IsTrue();
         await Assert.That(imports.ContainsKey("#")).IsTrue();
+        // User-defined entry preserved
+        await Assert.That(imports.ContainsKey("#custom/*")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_StaleEntriesRemovedOnRegeneration()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // Existing package.json with stale exports from a previous run
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "test-pkg",
+              "exports": {
+                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+                "./old-barrel": { "types": "./dist/old-barrel/index.d.ts", "import": "./dist/old-barrel/index.js" }
+              }
+            }
+            """
+        );
+
+        // Current generation only has root barrel — old-barrel was removed
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("item.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        // Current barrel preserved
+        await Assert.That(exports!.ContainsKey(".")).IsTrue();
+        // Stale entry removed
+        await Assert.That(exports.ContainsKey("./old-barrel")).IsFalse();
+        await Assert.That(exports!.Count).IsEqualTo(1);
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Imports_StaleRootAliasRemovedWhenBarrelDisappears()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // Existing package.json with "#" root alias from a previous run that had index.ts
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "test-pkg",
+              "imports": {
+                "#": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "default": "./src/index.ts" },
+                "#/*": { "types": "./dist/*.d.ts", "import": "./dist/*.js", "default": "./src/*.ts" },
+                "#custom/*": "./lib/*.ts"
+              }
+            }
+            """
+        );
+
+        // Current generation has no root barrel (no index.ts)
+        var files = new[] { new TsSourceFile("item.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+        // Stale "#" alias removed (no root barrel in current generation)
+        await Assert.That(imports!.ContainsKey("#")).IsFalse();
+        // "#/*" still present (always generated)
+        await Assert.That(imports.ContainsKey("#/*")).IsTrue();
         // User-defined entry preserved
         await Assert.That(imports.ContainsKey("#custom/*")).IsTrue();
 


### PR DESCRIPTION
## Summary

- Add `--src-root` CLI parameter (`MetanoSrcRoot` MSBuild property) to specify the TypeScript source root relative to the package root
- When output targets a subdirectory (e.g., `src/domain/`), the output prefix (`domain`) is applied to dist paths and export subpaths
- Change imports/exports to **merge** into existing objects instead of overwriting — user-defined entries for other subpaths survive untouched
- Update FR-030 spec and feature matrix

### Example

With `MetanoOutputDir = src/domain/`:

**Before (wrong):**
```json
"exports": { ".": { "types": "./dist/index.d.ts" } }
```

**After (correct):**
```json
"exports": { "./domain": { "types": "./dist/domain/index.d.ts" } }
```

## Test plan

- [x] 5 new/modified tests in EmitPackageTests (subdirectory prefix, merge behavior, explicit srcRoot)
- [x] 351 .NET tests pass
- [x] sample-todo: 18 JS tests pass
- [x] sample-issue-tracker: 65 JS tests pass
- [x] sample-todo-service: 19 JS tests pass
- [x] Existing sample package.json exports unchanged (backward compatible)

Closes #50