### PR TITLE
fix: add --src-root for subdirectory-aware package.json paths (#50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Build
-        run: dotnet build -maxcpucount:1
+        run: dotnet build Metano.slnx -maxcpucount:1
 
       - name: Verify samples are regenerated cleanly
         run: |

--- a/Metano-packages.slnx
+++ b/Metano-packages.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Metano/Metano.csproj" />
+    <Project Path="src/Metano.Compiler/Metano.Compiler.csproj" />
+    <Project Path="src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj" />
+    <Project Path="src/Metano.Build/Metano.Build.csproj" />
+  </Folder>
+</Solution>

--- a/dotnet-releaser.toml
+++ b/dotnet-releaser.toml
@@ -3,7 +3,10 @@
 profile = "custom"
 
 [msbuild]
-project = "Metano.slnx"
+# Use the packages-only solution to avoid building samples during release.
+# Samples have AfterBuild targets that run the compiler via `dotnet run`,
+# which causes file-lock conflicts under parallel builds.
+project = "Metano-packages.slnx"
 
 [github]
 user = "danfma"

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -65,14 +65,28 @@ public static class PackageJsonWriter
         var srcRelative = NormalizePath(Path.GetRelativePath(packageRoot, outputDirAbsolute));
 
         // Resolve the source root: explicit parameter, or infer from first path segment.
-        var resolvedSrcRoot = NormalizePath(srcRoot ?? srcRelative.Split('/')[0]);
+        // "--src-root ." means the package root itself is the source root, so the full
+        // srcRelative becomes the output prefix (e.g., "src/domain" → prefix "src/domain").
+        var rawSrcRoot = srcRoot?.Replace('\\', '/').TrimStart('/').TrimEnd('/');
+        string resolvedSrcRoot;
+        if (rawSrcRoot is null or "")
+            resolvedSrcRoot = srcRelative.Split('/')[0]; // infer from first segment
+        else if (rawSrcRoot == ".")
+            resolvedSrcRoot = ""; // package root is the source root
+        else
+            resolvedSrcRoot = rawSrcRoot.TrimStart('.', '/');
 
         // Output prefix: the path from the source root to the output directory.
         // Empty when outputDir IS the source root (e.g., srcRelative = "src").
         // Validate that srcRelative is within resolvedSrcRoot — if not, fall back
         // to empty prefix and warn rather than producing silently wrong paths.
         string outputPrefix;
-        if (srcRelative == resolvedSrcRoot)
+        if (resolvedSrcRoot.Length == 0)
+        {
+            // Package root is the source root — full srcRelative is the prefix.
+            outputPrefix = srcRelative;
+        }
+        else if (srcRelative == resolvedSrcRoot)
         {
             outputPrefix = "";
         }

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -517,6 +517,61 @@ public class EmitPackageTests
         Directory.Delete(tempDir, recursive: true);
     }
 
+    [Test]
+    public async Task Exports_SrcRootDot_UsesFullSrcRelativeAsPrefix()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "domain");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        // srcRoot = "." means package root is the source root,
+        // so srcRelative ("domain") becomes the full prefix.
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg",
+            srcRoot: "."
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./domain")).IsTrue();
+        await Assert.That(exports.ContainsKey(".")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Exports_SrcRootWithTrailingSlash_NormalizedCorrectly()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src", "domain");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        // Trailing slash should be stripped — "src/" behaves like "src"
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "test-pkg",
+            srcRoot: "src/"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./domain")).IsTrue();
+        await Assert.That(exports.ContainsKey(".")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
     private static string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"metasharp-test-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Add `--src-root` CLI parameter (`MetanoSrcRoot` MSBuild property) to specify the TypeScript source root relative to the package root
- When output targets a subdirectory (e.g., `src/domain/`), the output prefix (`domain`) is applied to dist paths and export subpaths
- Imports are merged preserving user-defined entries (e.g., `#custom/*`), with stale managed keys (`#`, `#/*`) cleaned up automatically
- Exports are fully replaced on each transpilation (stale barrel entries removed)
- Validate `--src-root` is an ancestor of the output path — emit MS0007 warning on mismatch
- Exclude samples from release build via `Metano-packages.slnx` to avoid file-lock conflicts
- Update FR-030 spec and feature matrix

### Example

With `MetanoOutputDir = src/domain/`:

**Before (wrong):**
```json
"exports": { ".": { "types": "./dist/index.d.ts" } }
```

**After (correct):**
```json
"exports": { "./domain": { "types": "./dist/domain/index.d.ts" } }
```

## Test plan

- [x] 7 new tests in EmitPackageTests (subdirectory prefix, merge, stale cleanup, explicit srcRoot)
- [x] 352 .NET tests pass
- [x] sample-todo: 18 JS tests pass
- [x] sample-issue-tracker: 65 JS tests pass
- [x] sample-todo-service: 19 JS tests pass
- [x] Existing sample package.json exports unchanged (backward compatible)
- [x] `Metano-packages.slnx` builds successfully

Closes #50