### PR TITLE
chore: auto-install Husky.Net git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --group pre-commit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --group pre-push

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,25 @@
+<Project>
+  <!--
+    Auto-install Husky.Net git hooks once per machine.
+
+    Runs after `dotnet restore` (which `dotnet build` triggers implicitly)
+    so a fresh clone gets the pre-commit / pre-push checks wired up
+    without any extra step. The marker file under `obj/` makes the
+    install idempotent across rebuilds, and the IsCrossTargetingBuild
+    guard keeps it out of multi-TFM inner builds. CI bypasses it via
+    HUSKY=0 so build agents don't waste time on hook setup.
+  -->
+  <Target
+    Name="HuskyInstall"
+    AfterTargets="Restore"
+    Condition="'$(HUSKY)' != '0' AND '$(IsCrossTargetingBuild)' != 'true' AND !Exists('$(MSBuildThisFileDirectory)obj/.husky-installed')"
+  >
+    <Exec
+      Command="dotnet husky install"
+      WorkingDirectory="$(MSBuildThisFileDirectory)"
+      IgnoreExitCode="true"
+    />
+    <MakeDir Directories="$(MSBuildThisFileDirectory)obj" />
+    <Touch Files="$(MSBuildThisFileDirectory)obj/.husky-installed" AlwaysCreate="true" />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary

- Versions `.husky/pre-commit` and `.husky/pre-push` (generated by `dotnet husky add`), both delegating to the Husky.Net task runner groups already declared in `.husky/task-runner.json` (csharpier format + biome fix on commit; csharpier check + biome check on push).
- Adds `Directory.Build.targets` with a `HuskyInstall` target that runs `dotnet husky install` after `Restore`. A marker file under `obj/` makes it idempotent across rebuilds; `HUSKY=0` in CI skips it.

The `.husky/task-runner.json` already declared the hook groups, but the scripts weren't versioned and nothing ran `dotnet husky install` on clone — so the hooks simply weren't wired locally. This lands independently of the larger shared-IR refactor so `main` gets the checks ahead of the big-bang merge.

## Test plan

- [x] `dotnet build Metano.slnx` clean on main + this commit
- [x] `dotnet husky install` produces `.git/config core.hooksPath=.husky`
- [x] Touching a C# file + `git commit` triggers csharpier-format via the hook
- [x] Idempotent: second `dotnet build` skips the install (marker present)