### PR TITLE
docs(adr): add ADR-0013 + refresh 5 legacy ADRs post shared-IR refactor

### DIFF
--- a/docs/adr/0002-handler-decomposition.md
+++ b/docs/adr/0002-handler-decomposition.md
@@ -84,3 +84,33 @@ Representative handlers extracted:
 - `src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs`
   — the immutable shared state handed to every handler
 - 30+ handler files under `src/Metano.Compiler.TypeScript/Transformation/`
+
+## Post-refactor note (2026-04)
+
+The handler decomposition pattern survives intact — it's still the shape
+of the TypeScript target — but the handlers migrated from consuming
+Roslyn directly to consuming the shared IR introduced by
+[ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md). The
+TS-specific "transformer" classes listed above were either renamed to
+`IrTo*Bridge` and relocated to `src/Metano.Compiler.TypeScript/Bridge/`,
+or folded into `IrToTsClassEmitter` (the surviving orchestrator):
+
+| Retired class | Replacement |
+| --- | --- |
+| `EnumTransformer` | `IrToTsEnumBridge` |
+| `InterfaceTransformer` | `IrToTsInterfaceBridge` |
+| `ExceptionTransformer` | `IrToTsExceptionBridge` |
+| `InlineWrapperTransformer` | `IrToTsInlineWrapperBridge` |
+| `ModuleTransformer` | `IrToTsModuleBridge` |
+| `RecordClassTransformer` | `IrToTsClassEmitter` (orchestrator) + `IrToTsClassBridge` (helpers) |
+| `RecordSynthesizer` | `IrToTsRecordSynthesisBridge` |
+| `OverloadDispatcherBuilder` | `IrToTsOverloadDispatcherBridge` + `IrToTsConstructorDispatcherBridge` |
+| `TypeCheckGenerator` | `IrTypeCheckBuilder` |
+| `BclMapper` | `IrToTsBclMapper` |
+| `TypeMapper` | `IrToTsTypeMapper` |
+| `ExpressionTransformer` + 13 child handlers | `IrToTsExpressionBridge` + `IrToTsStatementBridge` |
+
+The decision recorded here (decompose over monolith, compose via parent
+properties, no formal Visitor) was ratified by the Dart target — the same
+shape now lives in `src/Metano.Compiler.Dart/Bridge/` with no TypeScript
+contamination.

--- a/docs/adr/0003-declarative-bcl-mappings.md
+++ b/docs/adr/0003-declarative-bcl-mappings.md
@@ -90,6 +90,20 @@ Dictionaries, Sets, Linq — roughly 140 declarations total.
 - `src/Metano/Annotations/MapMethodAttribute.cs`,
   `src/Metano/Annotations/MapPropertyAttribute.cs`
 - `src/Metano/Runtime/` — all default mappings by area
-- `src/Metano.Compiler.TypeScript/Transformation/BclMapper.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsBclMapper.cs`
 - `src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRegistry.cs`
-- `tests/Metano.Tests/DeclarativeMappingTests.cs`
+- `tests/Metano.Tests/IR/IrToTsBclMapperTests.cs`
+
+## Post-refactor note (2026-04)
+
+The decision here — declarative assembly-level mappings driving a
+per-compilation registry — is unchanged. The consumer moved from
+`BclMapper` (Roslyn-walking) to `IrToTsBclMapper` in
+`src/Metano.Compiler.TypeScript/Bridge/`, which takes IR call expressions
+and member accesses and renders `TsTemplate` / `TsCallExpression` nodes.
+The `DeclarativeMappingRegistry` grew full-name-keyed secondary indices
+(`GetStableFullName` / `CSharpErrorMessageFormat`) so the IR lookup is
+symbol-free and deterministic. The Dart target will consume the same
+registry through its own bridge when per-target templates are added.
+See [ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md)
+for the wider IR architecture.

--- a/docs/adr/0004-cross-project-references-via-roslyn.md
+++ b/docs/adr/0004-cross-project-references-via-roslyn.md
@@ -113,11 +113,29 @@ will feed into the same `_crossAssemblyTypeMap` — additive, not a rewrite.
 
 - `src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs` —
   `DiscoverCrossAssemblyTypes`
-- `src/Metano.Compiler.TypeScript/Transformation/TypeMapper.cs` —
-  populates `TsNamedType.Origin`
+- `src/Metano.Compiler.TypeScript/Transformation/IrTypeOriginResolverFactory.cs` —
+  populates `IrTypeOrigin` on every `IrNamedTypeRef` during extraction
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs` — propagates
+  `IrTypeOrigin` onto `TsNamedType.Origin` during lowering
 - `src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypeOrigin.cs`
 - `src/Metano/Annotations/TranspileAssemblyAttribute.cs`
 - `src/Metano/Annotations/EmitPackageAttribute.cs`
 - `tests/Metano.Tests/CrossPackageImportTests.cs`
 - Related: [ADR-0011](0011-emit-package-ssot.md) (`[EmitPackage]` as
   package.json SSoT + auto-deps merge — planned)
+
+## Post-refactor note (2026-04)
+
+Roslyn is still the front-end (and still carries the cross-assembly
+metadata that makes this decision cheap), but the flow now goes through
+the shared IR. The Roslyn `Compilation` is walked by extractors in
+`src/Metano.Compiler/Extraction/` which stamp `IrTypeOrigin(PackageId,
+Namespace, VersionHint?)` on every `IrNamedTypeRef`; the target bridges
+read it without touching Roslyn symbols. `TypeMapper` is retired
+(replaced by `IrToTsTypeMapper`), and the alternative "Custom IR + ..."
+path listed above has partially materialized: the IR is the canonical
+representation, Roslyn is just the loader. See
+[ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md). A
+follow-up will physically separate the C# frontend so `Metano.Compiler`
+stops referencing `Microsoft.CodeAnalysis.*`, opening the door to
+non-Roslyn front-ends.

--- a/docs/adr/0005-inline-wrapper-branded-types.md
+++ b/docs/adr/0005-inline-wrapper-branded-types.md
@@ -118,11 +118,26 @@ also protects BCL identifiers that cross the TS boundary.
 ## References
 
 - `src/Metano/Annotations/InlineWrapperAttribute.cs`
-- `src/Metano.Compiler.TypeScript/Transformation/InlineWrapperTransformer.cs`
-- `src/Metano.Compiler.TypeScript/Transformation/TypeMapper.cs` — `Guid`
-  → `UUID` mapping
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsInlineWrapperBridge.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs` —
+  `IrPrimitive.Guid` → `UUID` mapping
 - `targets/js/metano-runtime/src/system/uuid.ts` — runtime-provided branded type
 - `samples/SampleIssueTracker` — `UserId`, `IssueId` as inline wrappers
 - `tests/Metano.Tests/InlineWrapperTranspileTests.cs`
 - Related: [ADR-0003](0003-declarative-bcl-mappings.md) — how the
   `Guid` → `UUID` mapping is declared.
+
+## Post-refactor note (2026-04)
+
+`InlineWrapperTransformer.cs` and `TypeMapper.cs` listed above were
+retired. The inline-wrapper shape is now lowered by
+`IrToTsInlineWrapperBridge` (under `src/Metano.Compiler.TypeScript/Bridge/`),
+which consumes an `IrClassDeclaration` whose
+`IrTypeSemantics.IsInlineWrapper` + `InlineWrappedType` were populated by
+the IR extractor in `src/Metano.Compiler/Extraction/IrClassExtractor.cs`.
+The `Guid` → `UUID` runtime helper discovery moved from the old `TypeMapper`
+to `IrRuntimeRequirementScanner` (adds `("UUID", BrandedType)` to the
+module's requirement set), which `IrRuntimeRequirementToTsImport.Convert`
+translates into the concrete `import { UUID } from "metano-runtime"`. See
+[ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md) for
+the wider context.

--- a/docs/adr/0005-inline-wrapper-branded-types.md
+++ b/docs/adr/0005-inline-wrapper-branded-types.md
@@ -129,14 +129,15 @@ also protects BCL identifiers that cross the TS boundary.
 
 ## Post-refactor note (2026-04)
 
-`InlineWrapperTransformer.cs` and `TypeMapper.cs` listed above were
-retired. The inline-wrapper shape is now lowered by
-`IrToTsInlineWrapperBridge` (under `src/Metano.Compiler.TypeScript/Bridge/`),
-which consumes an `IrClassDeclaration` whose
-`IrTypeSemantics.IsInlineWrapper` + `InlineWrappedType` were populated by
-the IR extractor in `src/Metano.Compiler/Extraction/IrClassExtractor.cs`.
-The `Guid` → `UUID` runtime helper discovery moved from the old `TypeMapper`
-to `IrRuntimeRequirementScanner` (adds `("UUID", BrandedType)` to the
+`InlineWrapperTransformer.cs` and `TypeMapper.cs` were the legacy
+transformer types and have been retired. The inline-wrapper shape is now
+lowered by `IrToTsInlineWrapperBridge` (under
+`src/Metano.Compiler.TypeScript/Bridge/`), which consumes an
+`IrClassDeclaration` whose `IrTypeSemantics.IsInlineWrapper` +
+`InlineWrappedType` were populated by the IR extractor in
+`src/Metano.Compiler/Extraction/IrClassExtractor.cs`. The `Guid` → `UUID`
+runtime helper discovery moved from the old `TypeMapper` to
+`IrRuntimeRequirementScanner` (adds `("UUID", BrandedType)` to the
 module's requirement set), which `IrRuntimeRequirementToTsImport.Convert`
 translates into the concrete `import { UUID } from "metano-runtime"`. See
 [ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md) for

--- a/docs/adr/0008-overload-dispatch.md
+++ b/docs/adr/0008-overload-dispatch.md
@@ -118,13 +118,38 @@ with the pre-dispatch code path.
 
 ## References
 
-- `src/Metano.Compiler.TypeScript/Transformation/OverloadDispatcherBuilder.cs`
-- `src/Metano.Compiler.TypeScript/Transformation/TypeCheckGenerator.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsOverloadDispatcherBridge.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsConstructorDispatcherBridge.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrTypeCheckBuilder.cs`
 - `src/Metano.Compiler.TypeScript/TypeScript/AST/TsConstructorOverload.cs`
 - `tests/Metano.Tests/MethodOverloadTests.cs`,
-  `ConstructorOverloadTests.cs`, `MethodOverloadFastPathTests.cs`
+  `ConstructorOverloadTests.cs`, `MethodOverloadFastPathTests.cs`,
+  `tests/Metano.Tests/IR/IrToTsOverloadDispatcherBridgeTests.cs`
 - Related: [ADR-0009](0009-type-guards.md) for the runtime type check
   functions the dispatcher uses; static-known fast-path optimization
   and the other overload follow-ups (constructor factories, inheritance
   with overloads) are tracked as
   [issue #25](https://github.com/danfma/metano/issues/25).
+
+## Post-refactor note (2026-04)
+
+`OverloadDispatcherBuilder.cs` and `TypeCheckGenerator.cs` listed above
+were retired. The dispatch strategy documented here is unchanged: a
+dispatcher method with a widened `(...args)` signature, per-overload
+branches gated by runtime type checks, with a static-known fast-path for
+call sites where the compiler can prove which overload is targeted. The
+implementation now lives under `src/Metano.Compiler.TypeScript/Bridge/`
+as three related types:
+
+- `IrToTsOverloadDispatcherBridge` — method overload dispatcher.
+- `IrToTsConstructorDispatcherBridge` — constructor overload dispatcher
+  (declares `const <name> = args[i] as <Type>` per branch so the lowered
+  body and `super(...)` resolve).
+- `IrTypeCheckBuilder` — emits the runtime type guards
+  (`isInt32`, `instanceof T`, `typeof === "object"`, exhaustive string
+  enum checks, etc.) consumed by both dispatchers.
+
+Overload groups are produced by the IR extractor folding siblings onto
+`IrMethodDeclaration.Overloads` and `IrConstructorDeclaration.Overloads`
+— backends consume them directly. See
+[ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md).

--- a/docs/adr/0008-overload-dispatch.md
+++ b/docs/adr/0008-overload-dispatch.md
@@ -133,8 +133,9 @@ with the pre-dispatch code path.
 
 ## Post-refactor note (2026-04)
 
-`OverloadDispatcherBuilder.cs` and `TypeCheckGenerator.cs` listed above
-were retired. The dispatch strategy documented here is unchanged: a
+The previously referenced legacy transformer types
+`OverloadDispatcherBuilder.cs` and `TypeCheckGenerator.cs` were
+retired. The dispatch strategy documented here is unchanged: a
 dispatcher method with a widened `(...args)` signature, per-overload
 branches gated by runtime type checks, with a static-known fast-path for
 call sites where the compiler can prove which overload is targeted. The

--- a/docs/adr/0013-shared-ir-as-canonical-semantic-representation.md
+++ b/docs/adr/0013-shared-ir-as-canonical-semantic-representation.md
@@ -13,7 +13,7 @@ Dart/Flutter second — re-walked the Roslyn semantic model itself. Record
 shape detection, nullable lowering, overload folding, BCL mapping origins,
 runtime helper discovery, the `[PlainObject]` / `[InlineWrapper]` / `[Emit]`
 gates — each one lived inline in TS-specific handlers (`RecordClassTransformer`
-at 1.529 lines, `ExpressionTransformer` + 13 child handlers, `TypeMapper`
+at 1,529 lines, `ExpressionTransformer` + 13 child handlers, `TypeMapper`
 with five `[ThreadStatic]` fields feeding 40+ call sites). A Dart target
 written in the same shape would have had to re-derive the same Roslyn
 heuristics, silently drifting from the TypeScript answer on any edge case.

--- a/docs/adr/0013-shared-ir-as-canonical-semantic-representation.md
+++ b/docs/adr/0013-shared-ir-as-canonical-semantic-representation.md
@@ -1,0 +1,129 @@
+# ADR-0013 — Shared IR as canonical semantic representation
+
+**Status:** Accepted
+**Date:** 2026-04-16
+
+## Context
+
+After [ADR-0001](0001-target-agnostic-core.md) split the core from the
+TypeScript target and [ADR-0002](0002-handler-decomposition.md) broke the
+TypeScript transformers into focused handlers, the next problem surfaced:
+every target that wanted to consume Metano's output — TypeScript first,
+Dart/Flutter second — re-walked the Roslyn semantic model itself. Record
+shape detection, nullable lowering, overload folding, BCL mapping origins,
+runtime helper discovery, the `[PlainObject]` / `[InlineWrapper]` / `[Emit]`
+gates — each one lived inline in TS-specific handlers (`RecordClassTransformer`
+at 1.529 lines, `ExpressionTransformer` + 13 child handlers, `TypeMapper`
+with five `[ThreadStatic]` fields feeding 40+ call sites). A Dart target
+written in the same shape would have had to re-derive the same Roslyn
+heuristics, silently drifting from the TypeScript answer on any edge case.
+
+Two paths forward:
+
+- **Continue with one transformer tree per target.** Every new backend
+  reproduces the semantic lowering from scratch over Roslyn.
+- **Introduce a target-agnostic intermediate representation** between
+  Roslyn and the target ASTs, owning every semantic decision once.
+
+## Decision
+
+Introduce a **shared intermediate representation** in
+`src/Metano.Compiler/IR/` as the single canonical semantic layer between
+the front-end (Roslyn today) and every target backend. The IR captures
+modules, type declarations, members, constructors, expressions,
+statements, type references, semantic annotations (`IrTypeSemantics`,
+`IrMethodSemantics`, `IrNamedTypeSemantics`), and runtime helper facts
+(`IrRuntimeRequirement`, `IrTypeOrigin`) as immutable records. Extractors
+in `src/Metano.Compiler/Extraction/` convert Roslyn symbols + syntax into
+IR; per-target bridges under `src/Metano.Compiler.{Target}/Bridge/` render
+IR into target AST nodes.
+
+Every IR addition is validated against the **anti-target-shaped checklist**:
+
+| Rule | Good | Bad |
+| --- | --- | --- |
+| Semantic names | `IrPrimitive.Guid` | `IrPrimitive.UUID` |
+| No import paths | `IrTypeOrigin("sample-todo", "Models")` | `IrTypeOrigin("sample-todo/src/models")` |
+| No naming policy | `PropertyName = "FirstName"` | `PropertyName = "firstName"` |
+| No emit flags | (absent) | `IsExported = true` |
+| Semantic annotations | `IsRecord = true` | `HasEquals = true, HasHashCode = true` |
+
+Pipeline realized today:
+
+```
+C# source → Roslyn compilation → IR extractors → Shared IR
+                                                    │
+                          ┌─────────────────────────┼─────────────────────────┐
+                          ▼                         ▼                         ▼
+                    TS bridges              Dart bridges             (future target)
+                    ↓                       ↓
+                    TS AST                  Dart AST
+                    ↓                       ↓
+                    .ts files               .dart files
+```
+
+The legacy transformers from [ADR-0002](0002-handler-decomposition.md) — the
+TS-specific ones — are retired in favor of bridges over IR. The handler
+decomposition pattern survives; the handlers just consume IR instead of
+Roslyn directly.
+
+## Consequences
+
+- (+) **Multi-target lowering without drift.** A second target (Dart) lands
+  with ~14 bridge files instead of cloning the entire TypeScript handler
+  tree. Any regression in a semantic decision surfaces in both targets at
+  once.
+- (+) **Anti-target-shaped checklist is enforceable.** Every IR record is
+  reviewed against the five rules above; Phase 7 (the Dart pilot) served
+  as forcing function — every time the IR had a TS bias, the Dart bridge
+  surfaced it.
+- (+) **Bridges stay thin.** `IrToTsClassEmitter` walks
+  `IrClassDeclaration.Members` and routes to per-shape bridges; no Roslyn
+  symbol lookup in the hot path.
+- (+) **Base for a second front-end.** The IR is Roslyn-free at the data
+  level. A new `ISourceFrontend` (e.g., a future Metano-native language
+  parser) can feed the same IR. See follow-up work on physically isolating
+  the C# frontend (`Metano.Compiler.Frontend.CSharp`).
+- (+) **Runtime helper requirements are data, not heuristics.**
+  `IrRuntimeRequirement` produced by the scanner replaces the
+  post-generation `ImportCollector` walk for IR-originated declarations.
+- (−) **Extraction is single-pass.** Adding a C# construct means extending
+  the extractor first, then every target bridge that cares. More surface
+  area on day one.
+- (−) **IR design overhead.** The checklist above is a permanent review
+  tax — the temptation to ship a target-specific shortcut on the IR is
+  real, especially under deadline pressure.
+- (−) **File-count growth.** `IR/` + `Extraction/` add ~40 files to the
+  core. Worth the cost given multi-target; would be overkill for a
+  single-target transpiler.
+
+## Alternatives considered
+
+- **Keep handlers per target.** Rejected on the evidence above: Dart
+  would have doubled the Roslyn-walking code and silently diverged on
+  every edge case. The checklist-enforced IR is the cheaper long-term
+  shape.
+- **Target IR as "smaller TS AST".** Rejected. A TS-shaped IR would have
+  forced the Dart backend to carry target-agnostic concepts through
+  TS-flavored records; every Dart bridge would fight the anti-target-shaped
+  rules. The IR has to own the semantic model, not the emission model.
+- **Roslyn as the IR.** Rejected. Roslyn symbols carry binding information,
+  nullability flow state, and SDK-specific types that no target needs; the
+  backend would pay for Roslyn transitively, and a future non-C# front-end
+  would have to synthesize fake `ISymbol` instances. The IR is a trimmed,
+  backend-observable surface, not Roslyn wrapped.
+
+## References
+
+- `src/Metano.Compiler/IR/` — IR records (modules, declarations, members,
+  expressions, statements, type references, semantic annotations, runtime
+  requirements, diagnostics)
+- `src/Metano.Compiler/Extraction/` — Roslyn → IR extractors
+- `src/Metano.Compiler.TypeScript/Bridge/` — TS bridges and
+  `IrToTsClassEmitter`
+- `src/Metano.Compiler.Dart/Bridge/` — Dart bridges
+- [ADR-0001](0001-target-agnostic-core.md) — the core/target split this
+  decision builds on
+- [ADR-0002](0002-handler-decomposition.md) — the handler pattern that
+  survives, now consuming IR
+- `docs/architecture.md` — pipeline reference, bridge catalog, anti-target-shaped rules

--- a/spec/11-adr-cross-reference.md
+++ b/spec/11-adr-cross-reference.md
@@ -19,6 +19,7 @@ shape the current product.
 | `ADR-0010` | Diagnostics and stable codes | Supports FR-038, FR-039, and diagnostic catalog rules. |
 | `ADR-0011` | `[EmitPackage]` as SSOT | Supports FR-030 and FR-031. |
 | `ADR-0012` | LINQ eager wrapper strategy | Supports FR-017 and runtime support assumptions. |
+| `ADR-0013` | Shared IR as canonical semantic representation | Supports NFR maintainability and multi-target extensibility; foundation for additional source frontends. |
 
 ## Guidance
 


### PR DESCRIPTION
## Summary

Phase A of the ADR refresh + frontend separation plan.

- **New: `ADR-0013 — Shared IR as canonical semantic representation`.** Records the decision that `src/Metano.Compiler/IR/` owns every semantic decision, with the anti-target-shaped checklist as the review tax. Makes explicit what the refactor already did.
- **Post-refactor notes appended to 5 existing ADRs** (0002, 0003, 0004, 0005, 0008) — they all mentioned transformers retired by the IR refactor (`RecordClassTransformer`, `OverloadDispatcherBuilder`, `BclMapper`, `TypeMapper`, `InlineWrapperTransformer`, `TypeCheckGenerator`, …). The decisions still hold; the consumers moved onto bridges (`IrToTs*Bridge`, `IrToTsClassEmitter`, `IrRuntimeRequirementScanner`, `IrTypeCheckBuilder`). Statuses stay `Accepted`.
- **`spec/11-adr-cross-reference.md`** gains an ADR-0013 row pointing at NFR maintainability + multi-target extensibility.

## Test plan

Docs-only change. Verification:
- [x] `dotnet build Metano.slnx` clean
- [x] `git diff --stat -- targets/ samples/` empty (no code touched)
- [x] Pre-commit (csharpier + biome) passed on commit