### PR TITLE
feat(core): add IrCompilation + ISourceFrontend foundation types (Phase B.1)

### DIFF
--- a/src/Metano.Compiler/IR/IrBclExport.cs
+++ b/src/Metano.Compiler/IR/IrBclExport.cs
@@ -10,5 +10,7 @@ namespace Metano.Compiler.IR;
 /// <param name="FromPackage">Package name the identifier is imported
 /// from.</param>
 /// <param name="Version">Semver specifier the backend merges into its
-/// package manifest.</param>
-public sealed record IrBclExport(string ExportedName, string FromPackage, string Version);
+/// package manifest, or <see langword="null"/> when the
+/// <c>[ExportFromBcl]</c> attribute did not specify a version (backends
+/// should skip the dependency rather than emit an empty range).</param>
+public sealed record IrBclExport(string ExportedName, string FromPackage, string? Version);

--- a/src/Metano.Compiler/IR/IrBclExport.cs
+++ b/src/Metano.Compiler/IR/IrBclExport.cs
@@ -1,0 +1,14 @@
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// A <c>[ExportFromBcl]</c> entry declared on a referenced assembly. Lets a
+/// BCL type (<c>decimal</c>, …) map to a concrete library package in every
+/// target that consumes the assembly — e.g., decimal → <c>Decimal</c> from
+/// <c>decimal.js</c> on the TypeScript target.
+/// </summary>
+/// <param name="ExportedName">Identifier emitted in the target source.</param>
+/// <param name="FromPackage">Package name the identifier is imported
+/// from.</param>
+/// <param name="Version">Semver specifier the backend merges into its
+/// package manifest.</param>
+public sealed record IrBclExport(string ExportedName, string FromPackage, string Version);

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -1,9 +1,8 @@
-using Metano.Compiler.Diagnostics;
-
 // Pulled in so the `<see cref="ISourceFrontend"/>` and
 // `<see cref="SymbolHelper.GetStableFullName"/>` references below resolve
 // from this nested namespace without needing fully-qualified names.
 using Metano.Compiler;
+using Metano.Compiler.Diagnostics;
 
 namespace Metano.Compiler.IR;
 

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -1,5 +1,10 @@
 using Metano.Compiler.Diagnostics;
 
+// Pulled in so the `<see cref="ISourceFrontend"/>` and
+// `<see cref="SymbolHelper.GetStableFullName"/>` references below resolve
+// from this nested namespace without needing fully-qualified names.
+using Metano.Compiler;
+
 namespace Metano.Compiler.IR;
 
 /// <summary>
@@ -31,11 +36,15 @@ namespace Metano.Compiler.IR;
 /// assemblies that declared <c>[TranspileAssembly]</c> + <c>[EmitPackage]</c>.
 /// The backend reads these to populate cross-package imports without
 /// emitting their content.</param>
-/// <param name="CrossAssemblyOrigins">Dictionary keyed by
-/// <see cref="SymbolHelper.GetStableFullName"/> giving the
+/// <param name="CrossAssemblyOrigins">Dictionary keyed by the stable full
+/// name produced during extraction (see
+/// <see cref="SymbolHelper.GetStableFullName"/>) giving the
 /// <see cref="IrTypeOrigin"/> for every referenced type that belongs to a
-/// transpilable assembly. Backends look up the origin for an
-/// <see cref="IrNamedTypeRef"/> directly — no delegate, no Roslyn.</param>
+/// transpilable assembly. Consumers should use this registry only when
+/// they already have that stable key available from frontend-produced
+/// metadata; <see cref="IrNamedTypeRef"/> alone is not a direct lookup
+/// key — the origin travels via <see cref="IrNamedTypeRef.Origin"/> when
+/// available.</param>
 /// <param name="ExternalImports">Dictionary keyed by type name (both source
 /// and emitted) giving the <see cref="IrExternalImport"/> to emit for
 /// <c>[Import]</c>-annotated types.</param>

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -1,0 +1,63 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// Target-agnostic result of a source frontend's extraction pass. Carries
+/// every piece of data a backend needs to emit its target without going
+/// back to the source language: the <see cref="Modules"/> it should emit
+/// (one per output file group), the referenced modules it can import from,
+/// and the registry tables that drive cross-package resolution and BCL
+/// mapping.
+/// <para>
+/// A frontend implementing <see cref="ISourceFrontend"/> builds an
+/// <see cref="IrCompilation"/> once per transpile run. All backend-specific
+/// state (naming policy, package managers, emit flags) stays inside the
+/// backend; the compilation record is source-language-agnostic and
+/// target-language-agnostic.
+/// </para>
+/// </summary>
+/// <param name="AssemblyName">Logical name of the source unit being
+/// transpiled (e.g., the C# assembly name).</param>
+/// <param name="PackageName">Declared <c>[assembly: EmitPackage]</c> value
+/// for the target, if any. Backends that publish to a package registry
+/// (npm, pub) use this as the package identity.</param>
+/// <param name="AssemblyWideTranspile">When <c>true</c>, the source unit
+/// declared <c>[TranspileAssembly]</c> — public types without
+/// <c>[Transpile]</c> should be treated as transpilable by default.</param>
+/// <param name="Modules">Every module the backend should emit. Grouping
+/// (e.g., <c>[EmitInFile]</c>) is already resolved by the frontend.</param>
+/// <param name="ReferencedModules">Modules discovered in referenced
+/// assemblies that declared <c>[TranspileAssembly]</c> + <c>[EmitPackage]</c>.
+/// The backend reads these to populate cross-package imports without
+/// emitting their content.</param>
+/// <param name="CrossAssemblyOrigins">Dictionary keyed by
+/// <see cref="SymbolHelper.GetStableFullName"/> giving the
+/// <see cref="IrTypeOrigin"/> for every referenced type that belongs to a
+/// transpilable assembly. Backends look up the origin for an
+/// <see cref="IrNamedTypeRef"/> directly — no delegate, no Roslyn.</param>
+/// <param name="ExternalImports">Dictionary keyed by type name (both source
+/// and emitted) giving the <see cref="IrExternalImport"/> to emit for
+/// <c>[Import]</c>-annotated types.</param>
+/// <param name="BclExports">Dictionary keyed by BCL identifier (e.g.,
+/// <c>"decimal"</c>) giving the <see cref="IrBclExport"/> the target should
+/// substitute.</param>
+/// <param name="AssembliesNeedingEmitPackage">Set of assembly names that
+/// had <c>[TranspileAssembly]</c> but no <c>[EmitPackage]</c> for the
+/// active target. A backend reports <c>MS0007</c> for any cross-package
+/// reference to one of these.</param>
+/// <param name="Diagnostics">Diagnostics raised during extraction (e.g.,
+/// conflicts in <c>[EmitInFile]</c> groupings, malformed
+/// <c>[Import]</c> attributes).</param>
+public sealed record IrCompilation(
+    string AssemblyName,
+    string? PackageName,
+    bool AssemblyWideTranspile,
+    IReadOnlyList<IrModule> Modules,
+    IReadOnlyList<IrModule> ReferencedModules,
+    IReadOnlyDictionary<string, IrTypeOrigin> CrossAssemblyOrigins,
+    IReadOnlyDictionary<string, IrExternalImport> ExternalImports,
+    IReadOnlyDictionary<string, IrBclExport> BclExports,
+    IReadOnlySet<string> AssembliesNeedingEmitPackage,
+    IReadOnlyList<MetanoDiagnostic> Diagnostics
+);

--- a/src/Metano.Compiler/IR/IrExternalImport.cs
+++ b/src/Metano.Compiler/IR/IrExternalImport.cs
@@ -2,9 +2,10 @@ namespace Metano.Compiler.IR;
 
 /// <summary>
 /// An external JS/TS module dependency declared on a C# type via
-/// <c>[Import(name, from, asDefault, version)]</c>. The frontend resolves
-/// every <c>[Import]</c>-annotated type once during extraction and indexes
-/// the result by the type's simple name + the emitted (target) name so
+/// <c>[Import(name, from)]</c>, with optional <c>AsDefault</c> and
+/// <c>Version</c> attribute properties. The frontend resolves every
+/// <c>[Import]</c>-annotated type once during extraction and indexes the
+/// result by the type's simple name + the emitted (target) name so
 /// backends can emit the import without re-walking Roslyn.
 /// </summary>
 /// <param name="Name">Identifier bound in the generated source (may be the

--- a/src/Metano.Compiler/IR/IrExternalImport.cs
+++ b/src/Metano.Compiler/IR/IrExternalImport.cs
@@ -16,9 +16,4 @@ namespace Metano.Compiler.IR;
 /// <param name="Version">Optional semver specifier the backend merges into
 /// its package manifest (npm <c>dependencies</c>, pub <c>dependencies</c>,
 /// …).</param>
-public sealed record IrExternalImport(
-    string Name,
-    string From,
-    bool IsDefault,
-    string? Version
-);
+public sealed record IrExternalImport(string Name, string From, bool IsDefault, string? Version);

--- a/src/Metano.Compiler/IR/IrExternalImport.cs
+++ b/src/Metano.Compiler/IR/IrExternalImport.cs
@@ -1,0 +1,24 @@
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// An external JS/TS module dependency declared on a C# type via
+/// <c>[Import(name, from, asDefault, version)]</c>. The frontend resolves
+/// every <c>[Import]</c>-annotated type once during extraction and indexes
+/// the result by the type's simple name + the emitted (target) name so
+/// backends can emit the import without re-walking Roslyn.
+/// </summary>
+/// <param name="Name">Identifier bound in the generated source (may be the
+/// default export alias).</param>
+/// <param name="From">Module specifier (e.g. npm package name or relative
+/// path).</param>
+/// <param name="IsDefault">When <c>true</c>, the import is the module's
+/// default export.</param>
+/// <param name="Version">Optional semver specifier the backend merges into
+/// its package manifest (npm <c>dependencies</c>, pub <c>dependencies</c>,
+/// …).</param>
+public sealed record IrExternalImport(
+    string Name,
+    string From,
+    bool IsDefault,
+    string? Version
+);

--- a/src/Metano.Compiler/ISourceFrontend.cs
+++ b/src/Metano.Compiler/ISourceFrontend.cs
@@ -1,3 +1,4 @@
+using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 
 namespace Metano.Compiler;
@@ -21,12 +22,15 @@ public interface ISourceFrontend
     string Name { get; }
 
     /// <summary>Asynchronously loads + extracts the project at
-    /// <paramref name="projectPath"/>.</summary>
+    /// <paramref name="projectPath"/>. Never returns <see langword="null"/>
+    /// — frontend-level failures (project not found, compile errors,
+    /// malformed attributes) surface via
+    /// <see cref="IrCompilation.Diagnostics"/> with
+    /// <see cref="MetanoDiagnosticSeverity.Error"/>, and the caller
+    /// decides whether to proceed with the (possibly empty) module
+    /// list.</summary>
     /// <param name="projectPath">Path to the entry source artifact (e.g.,
     /// a <c>.csproj</c> for the C# frontend).</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The extracted compilation, or <c>null</c> if loading
-    /// failed. Frontend-level failures (project not found, compile
-    /// errors) surface via diagnostics and a null result.</returns>
-    Task<IrCompilation?> ExtractAsync(string projectPath, CancellationToken ct = default);
+    Task<IrCompilation> ExtractAsync(string projectPath, CancellationToken ct = default);
 }

--- a/src/Metano.Compiler/ISourceFrontend.cs
+++ b/src/Metano.Compiler/ISourceFrontend.cs
@@ -1,0 +1,32 @@
+using Metano.Compiler.IR;
+
+namespace Metano.Compiler;
+
+/// <summary>
+/// Implemented by each source-language frontend (C# via Roslyn today,
+/// potentially others in the future). Given a project entry point, the
+/// frontend loads the source, discovers transpilable declarations, runs
+/// the semantic extraction pipeline, and produces a target-agnostic
+/// <see cref="IrCompilation"/> every backend can consume.
+/// <para>
+/// A frontend is stateless across invocations — one call per transpile
+/// run. The resulting <see cref="IrCompilation"/> carries all state the
+/// backend needs; no shared context reaches over.
+/// </para>
+/// </summary>
+public interface ISourceFrontend
+{
+    /// <summary>Short identifier for CLI / log messages (e.g.,
+    /// <c>"csharp"</c>).</summary>
+    string Name { get; }
+
+    /// <summary>Asynchronously loads + extracts the project at
+    /// <paramref name="projectPath"/>.</summary>
+    /// <param name="projectPath">Path to the entry source artifact (e.g.,
+    /// a <c>.csproj</c> for the C# frontend).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The extracted compilation, or <c>null</c> if loading
+    /// failed. Frontend-level failures (project not found, compile
+    /// errors) surface via diagnostics and a null result.</returns>
+    Task<IrCompilation?> ExtractAsync(string projectPath, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary

Phase B.1 of the frontend separation plan: introduce the target-agnostic data contract every future backend will consume and every future frontend will produce. **Foundation types only** — nothing references them yet.

Changes:
- **`IR/IrCompilation.cs`** — target-agnostic extraction result. Carries `AssemblyName` / `PackageName` / `AssemblyWideTranspile` flags, the `Modules` the backend must emit, `ReferencedModules` for cross-package imports, a `CrossAssemblyOrigins` lookup keyed by `SymbolHelper.GetStableFullName` (so backends resolve origins without a delegate), the `ExternalImports` / `BclExports` tables, and the set of assemblies still missing `[EmitPackage]` for MS0007.
- **`IR/IrExternalImport.cs`** — record for `[Import]` entries.
- **`IR/IrBclExport.cs`** — record for `[ExportFromBcl]` entries.
- **`ISourceFrontend.cs`** — interface frontends implement (`ExtractAsync(projectPath, ct) → Task<IrCompilation?>`).

## Why split this commit out?

The full Phase B (move discovery from TypeTransformer / DartTransformer into a new `CSharpSourceFrontend`, flip `ITranspilerTarget.Transform(Compilation)` → `Transform(IrCompilation)`, retire the `IrTypeOriginResolver` delegate from the public API) touches ~1500 lines across 10+ files and changes a public contract. Splitting the foundation types out first lets the destructive refactor in B.2–B.4 land on a stable base — the types are reviewable on their own and the downstream PR only has behavioral changes to inspect.

## Plan for follow-up PRs

- **B.2** — Implement `CSharpSourceFrontend.ExtractAsync` (moves `MSBuildWorkspace` loading out of `TranspilerHost`) + `ExtractFromCompilation(CSharpCompilation)` (absorbs discovery + cross-assembly + `[ExportFromBcl]` + grouping). Still not called by anyone.
- **B.3** — Flip `ITranspilerTarget.Transform` to receive `IrCompilation`. Refactor `TypeTransformer` + `DartTransformer` to consume IR instead of chasing Roslyn symbols.
- **B.4** — Retire the `IrTypeOriginResolver` delegate from the public API; origins come pre-resolved on `IrCompilation.CrossAssemblyOrigins`.

## Test plan

- [x] `dotnet build Metano.slnx` clean (types compile in isolation — no consumers)
- [x] 559 .NET tests unchanged — no behavioral code touched