### PR TITLE
refactor(core): CSharpSourceFrontend assumes project loading (Phase B.2 shell)

### DIFF
--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -1,0 +1,132 @@
+using Metano.Compiler.IR;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace Metano.Compiler;
+
+/// <summary>
+/// C# source frontend: opens a <c>.csproj</c> through
+/// <see cref="MSBuildWorkspace"/>, runs Roslyn, and produces an
+/// <see cref="IrCompilation"/> the downstream backends consume.
+/// <para>
+/// This is the first increment on the frontend / core split plan
+/// (ADR-0013 follow-up). The loader is in place; the
+/// <see cref="IrCompilation"/> fields beyond the basics are
+/// deliberately left empty for now — the existing
+/// <c>TypeTransformer</c> and <c>DartTransformer</c> still run their
+/// own discovery + extraction off <see cref="LoadedCompilation"/>.
+/// Subsequent PRs migrate that state onto <see cref="IrCompilation"/>
+/// one field at a time and retire the escape hatch.
+/// </para>
+/// </summary>
+public sealed class CSharpSourceFrontend : ISourceFrontend
+{
+    /// <inheritdoc />
+    public string Name => "csharp";
+
+    /// <summary>
+    /// Compilation produced by the most recent <see cref="ExtractAsync"/>
+    /// call, or <see langword="null"/> if loading failed. Exposed as a
+    /// transitional escape hatch so <see cref="TranspilerHost"/> can pass
+    /// the Roslyn <see cref="Compilation"/> on to the active
+    /// <see cref="ITranspilerTarget"/> while the targets still drive
+    /// their own extraction. Will be removed once every call site
+    /// consumes the <see cref="IrCompilation"/> directly.
+    /// </summary>
+    public Compilation? LoadedCompilation { get; private set; }
+
+    /// <summary>
+    /// Count of Roslyn-level errors surfaced during the most recent
+    /// <see cref="ExtractAsync"/> call. Zero when loading succeeded.
+    /// </summary>
+    public int LoadErrorCount { get; private set; }
+
+    public async Task<IrCompilation> ExtractAsync(
+        string projectPath,
+        CancellationToken ct = default
+    )
+    {
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+
+        var (compilation, errorCount) = await LoadCompilationAsync(projectPath, ct);
+        LoadedCompilation = compilation;
+        LoadErrorCount = errorCount;
+
+        // Fields beyond AssemblyName stay empty during the shell phase.
+        // Downstream targets fall back to `LoadedCompilation` for
+        // discovery / extraction until the follow-up migration wires
+        // them onto `IrCompilation`.
+        return new IrCompilation(
+            AssemblyName: compilation?.AssemblyName ?? assemblyName,
+            PackageName: null,
+            AssemblyWideTranspile: false,
+            Modules: Array.Empty<IrModule>(),
+            ReferencedModules: Array.Empty<IrModule>(),
+            CrossAssemblyOrigins: new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal),
+            ExternalImports: new Dictionary<string, IrExternalImport>(StringComparer.Ordinal),
+            BclExports: new Dictionary<string, IrBclExport>(StringComparer.Ordinal),
+            AssembliesNeedingEmitPackage: new HashSet<string>(StringComparer.Ordinal),
+            Diagnostics: []
+        );
+    }
+
+    /// <summary>
+    /// Opens the project via <see cref="MSBuildWorkspace"/> and returns
+    /// the resulting <see cref="Compilation"/>. Mirrors the previous
+    /// <c>TranspilerHost.LoadCompilationAsync</c>: progress and errors
+    /// go to stdout/stderr; a null result signals "do not proceed" and
+    /// the error count propagates to the CLI exit code.
+    /// </summary>
+    private static async Task<(Compilation? Compilation, int ErrorCount)> LoadCompilationAsync(
+        string projectPath,
+        CancellationToken ct
+    )
+    {
+        if (!File.Exists(projectPath))
+        {
+            Console.Error.WriteLine($"Project not found: {projectPath}");
+            return (null, 1);
+        }
+
+        Console.WriteLine($"Metano: Loading project {Path.GetFileName(projectPath)}...");
+
+        using var workspace = MSBuildWorkspace.Create();
+        workspace.RegisterWorkspaceFailedHandler(e =>
+        {
+            if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+                Console.Error.WriteLine($"  Workspace error: {e.Diagnostic.Message}");
+        });
+
+        Console.WriteLine("  Opening MSBuild project...");
+        var project = await workspace.OpenProjectAsync(projectPath, cancellationToken: ct);
+
+        Console.WriteLine("  Project loaded.");
+        Console.WriteLine("  Creating Roslyn compilation...");
+        var compilation = await project.GetCompilationAsync(ct);
+
+        Console.WriteLine("  Compilation created.");
+
+        if (compilation is null)
+        {
+            Console.Error.WriteLine("Failed to compile project.");
+            return (null, 1);
+        }
+
+        var roslynErrors = compilation
+            .GetDiagnostics(ct)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+
+        if (roslynErrors.Count > 0)
+        {
+            Console.Error.WriteLine($"Compilation has {roslynErrors.Count} error(s):");
+            foreach (var error in roslynErrors.Take(10))
+            {
+                Console.Error.WriteLine($"  {error}");
+            }
+            return (null, roslynErrors.Count);
+        }
+
+        return (compilation, 0);
+    }
+}

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -1,3 +1,4 @@
+using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
@@ -24,21 +25,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// <inheritdoc />
     public string Name => "csharp";
 
-    /// <summary>
-    /// Compilation produced by the most recent <see cref="ExtractAsync"/>
-    /// call, or <see langword="null"/> if loading failed. Exposed as a
-    /// transitional escape hatch so <see cref="TranspilerHost"/> can pass
-    /// the Roslyn <see cref="Compilation"/> on to the active
-    /// <see cref="ITranspilerTarget"/> while the targets still drive
-    /// their own extraction. Will be removed once every call site
-    /// consumes the <see cref="IrCompilation"/> directly.
-    /// </summary>
+    /// <inheritdoc />
     public Compilation? LoadedCompilation { get; private set; }
 
-    /// <summary>
-    /// Count of Roslyn-level errors surfaced during the most recent
-    /// <see cref="ExtractAsync"/> call. Zero when loading succeeded.
-    /// </summary>
+    /// <inheritdoc />
     public int LoadErrorCount { get; private set; }
 
     public async Task<IrCompilation> ExtractAsync(
@@ -47,14 +37,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     )
     {
         var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var diagnostics = new List<MetanoDiagnostic>();
 
-        var (compilation, errorCount) = await LoadCompilationAsync(projectPath, ct);
+        var (compilation, errorCount) = await LoadCompilationAsync(projectPath, diagnostics, ct);
         LoadedCompilation = compilation;
         LoadErrorCount = errorCount;
 
-        // Fields beyond AssemblyName stay empty during the shell phase.
-        // Downstream targets fall back to `LoadedCompilation` for
-        // discovery / extraction until the follow-up migration wires
+        // Fields beyond AssemblyName / Diagnostics stay empty during the
+        // shell phase. Downstream targets fall back to `LoadedCompilation`
+        // for discovery / extraction until the follow-up migration wires
         // them onto `IrCompilation`.
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? assemblyName,
@@ -66,7 +57,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ExternalImports: new Dictionary<string, IrExternalImport>(StringComparer.Ordinal),
             BclExports: new Dictionary<string, IrBclExport>(StringComparer.Ordinal),
             AssembliesNeedingEmitPackage: new HashSet<string>(StringComparer.Ordinal),
-            Diagnostics: []
+            Diagnostics: diagnostics
         );
     }
 
@@ -74,17 +65,29 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// Opens the project via <see cref="MSBuildWorkspace"/> and returns
     /// the resulting <see cref="Compilation"/>. Mirrors the previous
     /// <c>TranspilerHost.LoadCompilationAsync</c>: progress and errors
-    /// go to stdout/stderr; a null result signals "do not proceed" and
-    /// the error count propagates to the CLI exit code.
+    /// also go to stdout/stderr so the CLI trace stays unchanged, but
+    /// every failure is additionally appended to <paramref name="diagnostics"/>
+    /// as a <see cref="DiagnosticCodes.FrontendLoadFailure"/> entry so
+    /// the host (and any future programmatic caller) can react via
+    /// <see cref="IrCompilation.Diagnostics"/>.
     /// </summary>
     private static async Task<(Compilation? Compilation, int ErrorCount)> LoadCompilationAsync(
         string projectPath,
+        List<MetanoDiagnostic> diagnostics,
         CancellationToken ct
     )
     {
         if (!File.Exists(projectPath))
         {
-            Console.Error.WriteLine($"Project not found: {projectPath}");
+            var message = $"Project not found: {projectPath}";
+            Console.Error.WriteLine(message);
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Error,
+                    DiagnosticCodes.FrontendLoadFailure,
+                    message
+                )
+            );
             return (null, 1);
         }
 
@@ -94,7 +97,17 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         workspace.RegisterWorkspaceFailedHandler(e =>
         {
             if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
-                Console.Error.WriteLine($"  Workspace error: {e.Diagnostic.Message}");
+            {
+                var message = $"Workspace error: {e.Diagnostic.Message}";
+                Console.Error.WriteLine($"  {message}");
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.FrontendLoadFailure,
+                        message
+                    )
+                );
+            }
         });
 
         Console.WriteLine("  Opening MSBuild project...");
@@ -108,7 +121,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         if (compilation is null)
         {
-            Console.Error.WriteLine("Failed to compile project.");
+            const string message = "Failed to compile project.";
+            Console.Error.WriteLine(message);
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Error,
+                    DiagnosticCodes.FrontendLoadFailure,
+                    message
+                )
+            );
             return (null, 1);
         }
 
@@ -124,6 +145,19 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             {
                 Console.Error.WriteLine($"  {error}");
             }
+
+            foreach (var error in roslynErrors)
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.FrontendLoadFailure,
+                        error.GetMessage(),
+                        error.Location
+                    )
+                );
+            }
+
             return (null, roslynErrors.Count);
         }
 

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -81,4 +81,9 @@ public static class DiagnosticCodes
     /// file name belong to different namespaces, so the file would have an ambiguous
     /// folder placement.</summary>
     public const string EmitInFileConflict = "MS0008";
+
+    /// <summary>MS0009 — Source frontend failed to load or compile the project (project
+    /// file missing, MSBuild workspace failure, null compilation, or language-level
+    /// errors reported by Roslyn).</summary>
+    public const string FrontendLoadFailure = "MS0009";
 }

--- a/src/Metano.Compiler/ISourceFrontend.cs
+++ b/src/Metano.Compiler/ISourceFrontend.cs
@@ -1,5 +1,6 @@
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
+using Microsoft.CodeAnalysis;
 
 namespace Metano.Compiler;
 
@@ -20,6 +21,36 @@ public interface ISourceFrontend
     /// <summary>Short identifier for CLI / log messages (e.g.,
     /// <c>"csharp"</c>).</summary>
     string Name { get; }
+
+    /// <summary>
+    /// Roslyn <see cref="Compilation"/> produced by the most recent
+    /// <see cref="ExtractAsync"/> call, or <see langword="null"/> if
+    /// loading failed.
+    /// <para>
+    /// <b>Transitional escape hatch.</b> Exposed so
+    /// <see cref="TranspilerHost"/> can hand the Roslyn compilation to
+    /// the active <see cref="ITranspilerTarget"/> while the targets still
+    /// drive their own discovery + extraction. Will be removed in B.3
+    /// once every call site consumes the <see cref="IrCompilation"/>
+    /// directly. Frontends with no Roslyn backing return
+    /// <see langword="null"/>.
+    /// </para>
+    /// </summary>
+    Compilation? LoadedCompilation { get; }
+
+    /// <summary>
+    /// Count of language-level errors surfaced during the most recent
+    /// <see cref="ExtractAsync"/> call (Roslyn diagnostics for the C#
+    /// frontend). Zero when loading succeeded.
+    /// <para>
+    /// <b>Transitional escape hatch.</b> Mirrors
+    /// <see cref="LoadedCompilation"/> — used by
+    /// <see cref="TranspilerHost"/> as the CLI exit code while
+    /// frontend-level failures are also reported via
+    /// <see cref="IrCompilation.Diagnostics"/>. Will be removed in B.3.
+    /// </para>
+    /// </summary>
+    int LoadErrorCount { get; }
 
     /// <summary>Asynchronously loads + extracts the project at
     /// <paramref name="projectPath"/>. Never returns <see langword="null"/>

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -25,7 +25,7 @@ public static class TranspilerHost
     public static async Task<TranspileResult> RunAsync(
         TranspileOptions options,
         ITranspilerTarget target,
-        CSharpSourceFrontend frontend
+        ISourceFrontend frontend
     )
     {
         var projectPath = Path.GetFullPath(options.ProjectPath);
@@ -33,14 +33,21 @@ public static class TranspilerHost
 
         var totalSw = Stopwatch.StartNew();
         var compileSw = Stopwatch.StartNew();
-        _ = await frontend.ExtractAsync(projectPath);
+        var ir = await frontend.ExtractAsync(projectPath);
         var compilation = frontend.LoadedCompilation;
         var roslynErrorCount = frontend.LoadErrorCount;
 
         compileSw.Stop();
 
         if (compilation is null)
-            return new TranspileResult(false, [], 0, roslynErrorCount);
+        {
+            // Surface the frontend's load-failure diagnostics via the
+            // standard reporter so the CLI shows the MS0009 line(s)
+            // alongside the raw stderr trace the frontend already wrote.
+            var (frontendWarnings, frontendErrors) = ReportDiagnostics(ir.Diagnostics);
+            var errors = frontendErrors > 0 ? frontendErrors : roslynErrorCount;
+            return new TranspileResult(false, [], frontendWarnings, errors);
+        }
 
         if (options.ShowTimings)
             Console.WriteLine($"  Compilation: {compileSw.ElapsedMilliseconds}ms");
@@ -53,7 +60,14 @@ public static class TranspilerHost
         if (options.ShowTimings)
             Console.WriteLine($"  Transpilation: {transpileSw.ElapsedMilliseconds}ms");
 
-        var (warningCount, errorCount) = ReportDiagnostics(output.Diagnostics);
+        // Merge frontend diagnostics with target diagnostics so any
+        // warnings raised during extraction are surfaced even on the
+        // happy path.
+        var allDiagnostics =
+            ir.Diagnostics.Count == 0
+                ? output.Diagnostics
+                : ir.Diagnostics.Concat(output.Diagnostics).ToList();
+        var (warningCount, errorCount) = ReportDiagnostics(allDiagnostics);
 
         if (errorCount > 0)
             return new TranspileResult(false, output.Files, warningCount, errorCount);

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -1,40 +1,41 @@
 using System.Diagnostics;
 using Metano.Compiler.Diagnostics;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Metano.Compiler;
 
 /// <summary>
-/// Target-agnostic orchestration for transpilation runs:
-/// loads a C# project via MSBuildWorkspace, runs an <see cref="ITranspilerTarget"/>
-/// against the resulting compilation, prints diagnostics, and writes generated files
-/// to the output directory.
+/// Target-agnostic orchestration for transpilation runs: delegates project
+/// loading + semantic extraction to an <see cref="ISourceFrontend"/>
+/// (the C# frontend by default), runs an <see cref="ITranspilerTarget"/>
+/// against the resulting compilation, prints diagnostics, and writes
+/// generated files to the output directory.
 ///
-/// Each language target (TypeScript, Dart, …) wraps this in its own CLI which adds
-/// target-specific flags (e.g., TypeScript's --dist, --skip-package-json) and any
-/// post-emit work such as writing a package.json.
+/// Each language target (TypeScript, Dart, …) wraps this in its own CLI
+/// which adds target-specific flags (e.g., TypeScript's --dist,
+/// --skip-package-json) and any post-emit work such as writing a
+/// package.json.
 /// </summary>
 public static class TranspilerHost
 {
-    public static async Task<TranspileResult> RunAsync(
+    public static Task<TranspileResult> RunAsync(
         TranspileOptions options,
         ITranspilerTarget target
+    ) => RunAsync(options, target, new CSharpSourceFrontend());
+
+    public static async Task<TranspileResult> RunAsync(
+        TranspileOptions options,
+        ITranspilerTarget target,
+        CSharpSourceFrontend frontend
     )
     {
         var projectPath = Path.GetFullPath(options.ProjectPath);
         var outputDir = Path.GetFullPath(options.OutputDir);
 
-        if (!File.Exists(projectPath))
-        {
-            Console.Error.WriteLine($"Project not found: {projectPath}");
-
-            return new TranspileResult(false, [], 0, 1);
-        }
-
         var totalSw = Stopwatch.StartNew();
         var compileSw = Stopwatch.StartNew();
-        var (compilation, roslynErrorCount) = await LoadCompilationAsync(projectPath);
+        _ = await frontend.ExtractAsync(projectPath);
+        var compilation = frontend.LoadedCompilation;
+        var roslynErrorCount = frontend.LoadErrorCount;
 
         compileSw.Stop();
 
@@ -79,58 +80,6 @@ public static class TranspilerHost
         Console.WriteLine($"Metano: {output.Files.Count} file(s) generated in {outputDir}");
 
         return new TranspileResult(true, output.Files, warningCount, 0);
-    }
-
-    private static async Task<(Compilation? Compilation, int ErrorCount)> LoadCompilationAsync(
-        string projectPath
-    )
-    {
-        Console.WriteLine($"Metano: Loading project {Path.GetFileName(projectPath)}...");
-
-        using var workspace = MSBuildWorkspace.Create();
-
-        workspace.RegisterWorkspaceFailedHandler(e =>
-        {
-            if (e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
-                Console.Error.WriteLine($"  Workspace error: {e.Diagnostic.Message}");
-        });
-
-        Console.WriteLine("  Opening MSBuild project...");
-
-        var proj = await workspace.OpenProjectAsync(projectPath);
-
-        Console.WriteLine("  Project loaded.");
-        Console.WriteLine("  Creating Roslyn compilation...");
-
-        var compilation = await proj.GetCompilationAsync();
-
-        Console.WriteLine("  Compilation created.");
-
-        if (compilation is null)
-        {
-            Console.Error.WriteLine("Failed to compile project.");
-
-            return (null, 1);
-        }
-
-        var roslynErrors = compilation
-            .GetDiagnostics()
-            .Where(d => d.Severity == DiagnosticSeverity.Error)
-            .ToList();
-
-        if (roslynErrors.Count > 0)
-        {
-            Console.Error.WriteLine($"Compilation has {roslynErrors.Count} error(s):");
-
-            foreach (var error in roslynErrors.Take(10))
-            {
-                Console.Error.WriteLine($"  {error}");
-            }
-
-            return (null, roslynErrors.Count);
-        }
-
-        return (compilation, 0);
     }
 
     private static async Task EmitFilesAsync(


### PR DESCRIPTION
## Summary

Phase B.2 shell — first incremental step of the frontend / core split after the type scaffolding in #60.

Moves the MSBuild-backed project loader out of `TranspilerHost` and into the first implementation of `ISourceFrontend`. The host now delegates to a `CSharpSourceFrontend` instance (default or caller-provided) and picks the `Compilation` up via a transitional `LoadedCompilation` escape hatch so the targets keep running their existing discovery + extraction paths unchanged.

Changes:
- **`src/Metano.Compiler/CSharpSourceFrontend.cs`** (new). `ExtractAsync(projectPath)` opens the project via `MSBuildWorkspace`, surfaces Roslyn errors to stderr (same wording as before), and stores the loaded `Compilation` on the instance. `IrCompilation` is returned with only the basics populated; the fields that will replace the targets' duplicated discovery (Modules / ReferencedModules / CrossAssemblyOrigins / ExternalImports / BclExports / AssembliesNeedingEmitPackage) stay empty during this shell phase.
- **`src/Metano.Compiler/TranspilerHost.cs`** — deletes the private `LoadCompilationAsync` (moved verbatim to the frontend). The public `RunAsync(options, target)` forwards to a new `RunAsync(options, target, frontend)` overload. The call sites in `Metano.Compiler.TypeScript` / `Metano.Compiler.Dart` stay unchanged; `target.Transform(compilation)` still sees a raw Roslyn `Compilation` via the escape hatch.

## Why split this out?

The full Phase B (retire `IrTypeOriginResolver` delegate, flip `ITranspilerTarget.Transform(Compilation)` → `Transform(IrCompilation)`, migrate discovery from TypeTransformer/DartTransformer into the frontend) touches ~1500+ lines. Shipping it as a single PR has proven hard to review. Splitting after each stable checkpoint keeps each change easy to verify against the full 559-test + 102-bun suite and preserves byte-identical sample output.

## Plan for follow-up PRs (#62 onward)

- **B.2a** — populate `IrCompilation.BclExports` + `AssembliesNeedingEmitPackage` in the frontend; targets consume them instead of re-scanning.
- **B.2b** — populate `IrCompilation.ExternalImports` in the frontend; targets consume.
- **B.2c** — populate `IrCompilation.CrossAssemblyOrigins` + `ReferencedModules` in the frontend; targets consume.
- **B.2d** — populate `IrCompilation.Modules` by moving `DiscoverTranspilableTypes` + `GroupTypesByFile` + per-type extraction into the frontend; targets iterate IR instead of Roslyn.
- **B.3** — flip `ITranspilerTarget.Transform` to take `IrCompilation`; delete the `LoadedCompilation` escape hatch.
- **B.4** — retire the `IrTypeOriginResolver` delegate from the public API.

## Test plan

- [x] `dotnet build Metano.slnx` clean
- [x] 559 / 559 .NET tests pass
- [x] `git diff --stat -- targets/ samples/` empty — generated output byte-identical
- [x] `dotnet csharpier check .` clean locally before push
- [x] Pre-commit hook ran csharpier + biome successfully