### PR TITLE
refactor(core): CSharpSourceFrontend populates IrCompilation.BclExports (Phase B.2a)

### DIFF
--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -43,22 +43,125 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         LoadedCompilation = compilation;
         LoadErrorCount = errorCount;
 
-        // Fields beyond AssemblyName / Diagnostics stay empty during the
-        // shell phase. Downstream targets fall back to `LoadedCompilation`
-        // for discovery / extraction until the follow-up migration wires
-        // them onto `IrCompilation`.
+        return BuildIrCompilation(
+            compilation,
+            fallbackAssemblyName: assemblyName,
+            diagnostics: diagnostics
+        );
+    }
+
+    /// <summary>
+    /// Builds an <see cref="IrCompilation"/> from an already-loaded Roslyn
+    /// <see cref="Compilation"/>. Used by the test suite (and any future
+    /// in-process caller) so the frontend's extraction can be exercised
+    /// without going through <see cref="MSBuildWorkspace"/>. Mirrors the
+    /// production path: stores the compilation on
+    /// <see cref="LoadedCompilation"/>, resets <see cref="LoadErrorCount"/>
+    /// to <c>0</c>, and returns the populated record.
+    /// </summary>
+    public IrCompilation ExtractFromCompilation(Compilation compilation)
+    {
+        LoadedCompilation = compilation;
+        LoadErrorCount = 0;
+        return BuildIrCompilation(
+            compilation,
+            fallbackAssemblyName: compilation.AssemblyName ?? "",
+            diagnostics: new List<MetanoDiagnostic>()
+        );
+    }
+
+    private static IrCompilation BuildIrCompilation(
+        Compilation? compilation,
+        string fallbackAssemblyName,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        // Fields beyond what's already populated stay empty during the
+        // incremental migration. Downstream targets fall back to
+        // `LoadedCompilation` for the rest until follow-up PRs wire them
+        // onto `IrCompilation`.
         return new IrCompilation(
-            AssemblyName: compilation?.AssemblyName ?? assemblyName,
+            AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: null,
             AssemblyWideTranspile: false,
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal),
             ExternalImports: new Dictionary<string, IrExternalImport>(StringComparer.Ordinal),
-            BclExports: new Dictionary<string, IrBclExport>(StringComparer.Ordinal),
+            BclExports: compilation is null
+                ? new Dictionary<string, IrBclExport>(StringComparer.Ordinal)
+                : BuildBclExports(compilation),
             AssembliesNeedingEmitPackage: new HashSet<string>(StringComparer.Ordinal),
             Diagnostics: diagnostics
         );
+    }
+
+    /// <summary>
+    /// Reads <c>[ExportFromBcl]</c> declarations from every assembly in scope
+    /// (referenced first, current assembly last so user-side overrides win on
+    /// conflict) and returns them keyed by the BCL type's display string.
+    /// Mirrors the legacy <c>TypeTransformer.LoadBclExportMappings</c>; the
+    /// target-side copy stays in place until the contract flip migrates
+    /// consumers onto the IR.
+    /// </summary>
+    private static Dictionary<string, IrBclExport> BuildBclExports(Compilation compilation)
+    {
+        var map = new Dictionary<string, IrBclExport>(StringComparer.Ordinal);
+
+        foreach (var reference in compilation.References)
+        {
+            if (
+                compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol asm
+                && !SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly)
+            )
+                CollectBclExportsFromAssembly(asm, map);
+        }
+        CollectBclExportsFromAssembly(compilation.Assembly, map);
+
+        return map;
+    }
+
+    private static void CollectBclExportsFromAssembly(
+        IAssemblySymbol assembly,
+        Dictionary<string, IrBclExport> sink
+    )
+    {
+        foreach (var attr in assembly.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name is not ("ExportFromBclAttribute" or "ExportFromBcl"))
+                continue;
+
+            if (attr.ConstructorArguments.Length == 0)
+                continue;
+            if (attr.ConstructorArguments[0].Value is not INamedTypeSymbol typeArg)
+                continue;
+
+            var exportedName = "";
+            var fromPackage = "";
+            string? version = null;
+
+            foreach (var namedArg in attr.NamedArguments)
+            {
+                switch (namedArg.Key)
+                {
+                    case "ExportedName":
+                        exportedName = namedArg.Value.Value?.ToString() ?? "";
+                        break;
+                    case "FromPackage":
+                        fromPackage = namedArg.Value.Value?.ToString() ?? "";
+                        break;
+                    case "Version":
+                        var raw = namedArg.Value.Value?.ToString();
+                        version = string.IsNullOrEmpty(raw) ? null : raw;
+                        break;
+                }
+            }
+
+            if (exportedName.Length == 0)
+                continue;
+
+            sink[typeArg.ToDisplayString()] = new IrBclExport(exportedName, fromPackage, version);
+        }
     }
 
     /// <summary>

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -84,6 +84,15 @@ public class CSharpSourceFrontendTests
 
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
 
-        await Assert.That(ir.BclExports.ContainsKey("System.Guid")).IsFalse();
+        // Resolve the same key the production code uses (typeArg.ToDisplayString()) so a
+        // future format change can't accidentally make the assertion pass on the wrong key.
+        var guidType = compilation.GetTypeByMetadataName("System.Guid");
+        await Assert.That(guidType).IsNotNull();
+        await Assert.That(ir.BclExports.ContainsKey(guidType!.ToDisplayString())).IsFalse();
+
+        // Defence-in-depth: nothing else in the map should claim the "uuid" package
+        // either, since the attribute lacked the required ExportedName property.
+        foreach (var entry in ir.BclExports.Values)
+            await Assert.That(entry.FromPackage).IsNotEqualTo("uuid");
     }
 }

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1,0 +1,89 @@
+using Metano.Compiler;
+using Metano.Tests.IR;
+
+namespace Metano.Tests.Frontend;
+
+/// <summary>
+/// Producer-side tests for the bits of <see cref="IrCompilation"/> that
+/// <see cref="CSharpSourceFrontend"/> already populates. Consumers (the
+/// language targets) still build their own copy of this data; these
+/// tests exist so the frontend cannot silently regress while the
+/// migration is in flight.
+/// </summary>
+public class CSharpSourceFrontendTests
+{
+    [Test]
+    public async Task BclExports_AreCollectedFromCurrentAssembly()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: ExportFromBcl(
+                typeof(decimal),
+                FromPackage = "decimal.js",
+                ExportedName = "Decimal",
+                Version = "^10.6.0"
+            )]
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.BclExports).ContainsKey("decimal");
+        var entry = ir.BclExports["decimal"];
+        await Assert.That(entry.ExportedName).IsEqualTo("Decimal");
+        await Assert.That(entry.FromPackage).IsEqualTo("decimal.js");
+        await Assert.That(entry.Version).IsEqualTo("^10.6.0");
+    }
+
+    [Test]
+    public async Task BclExports_OmitVersionWhenAttributeLeavesItEmpty()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: ExportFromBcl(
+                typeof(decimal),
+                FromPackage = "decimal.js",
+                ExportedName = "Decimal"
+            )]
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        var entry = ir.BclExports["decimal"];
+        await Assert.That(entry.Version).IsNull();
+    }
+
+    [Test]
+    public async Task BclExports_PullInDeclarationsFromReferencedAssemblies()
+    {
+        // Metano.Runtime declares [assembly: ExportFromBcl(typeof(decimal), ...)] for
+        // decimal.js. The reference is brought in by IrTestHelper.BaseReferences via
+        // TranspileHelper, so a project that doesn't redeclare the mapping should
+        // still see it.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Marker {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.BclExports).ContainsKey("decimal");
+    }
+
+    [Test]
+    public async Task BclExports_IgnoreAttributesWithoutExportedName()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: ExportFromBcl(typeof(System.Guid), FromPackage = "uuid")]
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.BclExports.ContainsKey("System.Guid")).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Producer half of the BCL-export migration in the Phase B sequence. The
frontend now reads every `[ExportFromBcl]` declaration in scope and
exposes it on `IrCompilation.BclExports`. The TypeScript target still
builds its own `_bclExportMap` — this PR ships the data on the IR so a
future contract flip can switch the consumer side without touching
extraction code.

## Changes

- `CSharpSourceFrontend` gains `BuildBclExports(Compilation)` mirroring
  the legacy `LoadBclExportMappings`: references first, current assembly
  last (so user-side overrides win on conflict).
- New `ExtractFromCompilation(Compilation)` entry point lets the test
  suite drive extraction without `MSBuildWorkspace`.
- New `tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs` covers
  the four observable cases (current assembly, missing version,
  referenced assembly via `Metano.Runtime`, attribute lacking
  `ExportedName`).

## Test plan

- [x] `dotnet build Metano.slnx` ✅
- [x] `dotnet run --project tests/Metano.Tests/` → 563/563 ✅ (559 + 4 new)
- [x] `dotnet csharpier check .` ✅
- [x] Sample regeneration produced byte-identical output (`git status` clean for `targets/`, `samples/`)
- [x] `cd targets/js/sample-todo && bun run build && bun test` → 18/18 ✅
- [x] `cd targets/js/sample-issue-tracker && bun run build && bun test` → 65/65 ✅
- [x] `cd targets/js/sample-todo-service && bun run build && bun test` → 19/19 ✅

Stacked on top of #61 — once that merges, this PR retargets to `main`.

Part of #58