### PR TITLE
refactor(core): CSharpSourceFrontend populates IrCompilation.ExternalImports (Phase B.2b)

### DIFF
--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -87,13 +87,68 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal),
-            ExternalImports: new Dictionary<string, IrExternalImport>(StringComparer.Ordinal),
+            ExternalImports: compilation is null
+                ? new Dictionary<string, IrExternalImport>(StringComparer.Ordinal)
+                : BuildExternalImports(compilation),
             BclExports: compilation is null
                 ? new Dictionary<string, IrBclExport>(StringComparer.Ordinal)
                 : BuildBclExports(compilation),
             AssembliesNeedingEmitPackage: new HashSet<string>(StringComparer.Ordinal),
             Diagnostics: diagnostics
         );
+    }
+
+    /// <summary>
+    /// Walks every public top-level type in the current compilation and
+    /// surfaces those carrying <c>[Import("name", from)]</c> as
+    /// <see cref="IrExternalImport"/> entries keyed by the C# type's simple
+    /// name. Matches what the legacy
+    /// <c>TypeTransformer._externalImportMap</c> populated for the local
+    /// assembly; cross-assembly <c>[Import]</c> aggregation and per-target
+    /// <c>[Name]</c> aliasing stay on the consumer side until later
+    /// migration steps wire them through the IR.
+    /// </summary>
+    private static Dictionary<string, IrExternalImport> BuildExternalImports(
+        Compilation compilation
+    )
+    {
+        var map = new Dictionary<string, IrExternalImport>(StringComparer.Ordinal);
+        var types = new List<INamedTypeSymbol>();
+        CollectPublicTopLevelTypes(compilation.Assembly.GlobalNamespace, types);
+
+        foreach (var type in types)
+        {
+            var import = SymbolHelper.GetImport(type);
+            if (import is null)
+                continue;
+
+            map[type.Name] = new IrExternalImport(
+                Name: import.Name,
+                From: import.From,
+                IsDefault: import.AsDefault,
+                Version: import.Version
+            );
+        }
+
+        return map;
+    }
+
+    private static void CollectPublicTopLevelTypes(INamespaceSymbol ns, List<INamedTypeSymbol> sink)
+    {
+        foreach (var member in ns.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol childNs:
+                    CollectPublicTopLevelTypes(childNs, sink);
+                    break;
+                case INamedTypeSymbol type
+                    when type.ContainingType is null
+                        && type.DeclaredAccessibility == Accessibility.Public:
+                    sink.Add(type);
+                    break;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -80,6 +80,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         // incremental migration. Downstream targets fall back to
         // `LoadedCompilation` for the rest until follow-up PRs wire them
         // onto `IrCompilation`.
+        IReadOnlyDictionary<string, IrExternalImport> externalImports = compilation is null
+            ? new Dictionary<string, IrExternalImport>(StringComparer.Ordinal)
+            : BuildExternalImports(compilation, diagnostics);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: null,
@@ -87,9 +91,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal),
-            ExternalImports: compilation is null
-                ? new Dictionary<string, IrExternalImport>(StringComparer.Ordinal)
-                : BuildExternalImports(compilation),
+            ExternalImports: externalImports,
             BclExports: compilation is null
                 ? new Dictionary<string, IrBclExport>(StringComparer.Ordinal)
                 : BuildBclExports(compilation),
@@ -102,14 +104,20 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// Walks every public top-level type in the current compilation and
     /// surfaces those carrying <c>[Import("name", from)]</c> as
     /// <see cref="IrExternalImport"/> entries keyed by the C# type's simple
-    /// name. Matches what the legacy
-    /// <c>TypeTransformer._externalImportMap</c> populated for the local
-    /// assembly; cross-assembly <c>[Import]</c> aggregation and per-target
-    /// <c>[Name]</c> aliasing stay on the consumer side until later
-    /// migration steps wire them through the IR.
+    /// source name. This intentionally covers only the source-name keys for
+    /// the local assembly that the legacy
+    /// <c>TypeTransformer._externalImportMap</c> exposed; cross-assembly
+    /// <c>[Import]</c> aggregation and per-target <c>[Name]</c> aliasing
+    /// remain on the consumer side until later migration steps wire them
+    /// through the IR. Mirrors the legacy
+    /// <c>TypeTransformer.RegisterExternalImportMapping</c> conflict policy:
+    /// the first mapping wins and any divergent re-registration produces a
+    /// <see cref="DiagnosticCodes.AmbiguousConstruct"/> warning surfaced
+    /// through <see cref="IrCompilation.Diagnostics"/>.
     /// </summary>
     private static Dictionary<string, IrExternalImport> BuildExternalImports(
-        Compilation compilation
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
     )
     {
         var map = new Dictionary<string, IrExternalImport>(StringComparer.Ordinal);
@@ -122,12 +130,33 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             if (import is null)
                 continue;
 
-            map[type.Name] = new IrExternalImport(
+            var entry = new IrExternalImport(
                 Name: import.Name,
                 From: import.From,
                 IsDefault: import.AsDefault,
                 Version: import.Version
             );
+
+            if (map.TryGetValue(type.Name, out var existing))
+            {
+                if (existing == entry)
+                    continue;
+
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Warning,
+                        DiagnosticCodes.AmbiguousConstruct,
+                        $"External import name collision for '{type.Name}'. Keeping "
+                            + $"'{existing.From}' ('{existing.Name}') and ignoring "
+                            + $"conflicting mapping from '{type.ToDisplayString()}' to "
+                            + $"'{entry.From}' ('{entry.Name}').",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+                continue;
+            }
+
+            map[type.Name] = entry;
         }
 
         return map;

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -95,4 +95,56 @@ public class CSharpSourceFrontendTests
         foreach (var entry in ir.BclExports.Values)
             await Assert.That(entry.FromPackage).IsNotEqualTo("uuid");
     }
+
+    [Test]
+    public async Task ExternalImports_CollectImportAttributesFromCurrentAssembly()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [Import("Hono", from: "hono", Version = "^4.0.0")]
+            public class Hono {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("Hono");
+        var entry = ir.ExternalImports["Hono"];
+        await Assert.That(entry.Name).IsEqualTo("Hono");
+        await Assert.That(entry.From).IsEqualTo("hono");
+        await Assert.That(entry.IsDefault).IsFalse();
+        await Assert.That(entry.Version).IsEqualTo("^4.0.0");
+    }
+
+    [Test]
+    public async Task ExternalImports_PreserveAsDefaultFlag()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [Import("React", from: "react", AsDefault = true)]
+            public class React {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        var entry = ir.ExternalImports["React"];
+        await Assert.That(entry.IsDefault).IsTrue();
+        await Assert.That(entry.Version).IsNull();
+    }
+
+    [Test]
+    public async Task ExternalImports_IgnoreTypesWithoutImportAttribute()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Plain {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports.ContainsKey("Plain")).IsFalse();
+    }
 }

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1,4 +1,5 @@
 using Metano.Compiler;
+using Metano.Compiler.Diagnostics;
 using Metano.Tests.IR;
 
 namespace Metano.Tests.Frontend;
@@ -146,5 +147,45 @@ public class CSharpSourceFrontendTests
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
 
         await Assert.That(ir.ExternalImports.ContainsKey("Plain")).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternalImports_NameCollisionKeepsFirstAndWarns()
+    {
+        // Two top-level types share the simple name `Widget` across distinct
+        // namespaces with conflicting [Import] mappings. CollectPublicTopLevelTypes
+        // walks namespaces via INamespaceSymbol.GetMembers(), which Roslyn returns
+        // in declaration/alphabetical order — `Alpha` is visited before `Beta`,
+        // so the Alpha mapping wins and the Beta one becomes a warning.
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Alpha
+            {
+                [Import("Widget", from: "alpha-pkg")]
+                public class Widget {}
+            }
+
+            namespace Beta
+            {
+                [Import("Widget", from: "beta-pkg")]
+                public class Widget {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports.Count).IsEqualTo(1);
+        await Assert.That(ir.ExternalImports).ContainsKey("Widget");
+        var entry = ir.ExternalImports["Widget"];
+        await Assert.That(entry.From).IsEqualTo("alpha-pkg");
+
+        var warning = ir.Diagnostics.SingleOrDefault(d =>
+            d.Severity == MetanoDiagnosticSeverity.Warning
+            && d.Code == DiagnosticCodes.AmbiguousConstruct
+        );
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!.Message).Contains("Widget");
+        await Assert.That(warning.Message).Contains("beta-pkg");
     }
 }


### PR DESCRIPTION
## Summary

Producer half of the external-imports migration. The frontend now reads
`[Import("name", from)]` declarations on every public top-level type in
the current assembly and exposes them via
`IrCompilation.ExternalImports`. The TypeScript target still builds its
own `_externalImportMap` — this PR ships the data on the IR so the
contract flip can switch the consumer side without touching extraction
code.

## Scope decisions

- **Source-name keys only.** The legacy map registers entries under both
  the C# name and the TypeScript-overridden name (from
  `[Name(TypeScript)]`). Per-target aliasing requires target awareness
  in the frontend, which is a separate concern; for now consumers add
  their own aliases at consumption time.
- **Current assembly only.** Cross-assembly `[Import]` aggregation is
  bundled with cross-assembly type discovery and lands together in a
  later PR.

## Test plan

- [x] `dotnet build Metano.slnx` ✅
- [x] `dotnet run --project tests/Metano.Tests/` → 566/566 ✅ (563 + 3 new)
- [x] `dotnet csharpier check .` ✅
- [x] Sample regeneration produced byte-identical output

Stacked on top of #62 (which is stacked on #61). Will retarget once the
chain merges.

Part of #58