### PR TITLE
refactor(core): CSharpSourceFrontend populates cross-assembly origin tables (Phase B.2c)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
@@ -123,31 +123,6 @@ public sealed class PathNaming(string rootNamespace)
     /// Finds the longest common dot-separated namespace prefix across the given list.
     /// Used to discover the project's root namespace at the start of a transpilation run.
     /// </summary>
-    public static string FindCommonNamespacePrefix(IReadOnlyList<string> namespaces)
-    {
-        if (namespaces.Count == 0)
-            return "";
-        if (namespaces.Count == 1)
-            return namespaces[0];
-
-        var parts = namespaces[0].Split('.');
-        var commonLength = parts.Length;
-
-        for (var i = 1; i < namespaces.Count; i++)
-        {
-            var otherParts = namespaces[i].Split('.');
-            commonLength = Math.Min(commonLength, otherParts.Length);
-
-            for (var j = 0; j < commonLength; j++)
-            {
-                if (parts[j] != otherParts[j])
-                {
-                    commonLength = j;
-                    break;
-                }
-            }
-        }
-
-        return string.Join(".", parts.Take(commonLength));
-    }
+    public static string FindCommonNamespacePrefix(IReadOnlyList<string> namespaces) =>
+        NamespaceUtilities.FindCommonPrefix(namespaces);
 }

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -156,7 +156,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             if (!hasTranspileAssembly)
                 continue;
 
-            var packageInfo = SymbolHelper.GetEmitPackageInfo(asm, targetEnumValue: 0);
+            var packageInfo = SymbolHelper.GetEmitPackageInfo(
+                asm,
+                targetEnumValue: (int)EmitTarget.JavaScript
+            );
             if (packageInfo is null)
             {
                 needingPackage.Add(asm.Name);
@@ -166,17 +169,22 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             var assemblyTypes = new List<INamedTypeSymbol>();
             CollectPublicTopLevelTypes(asm.GlobalNamespace, assemblyTypes);
 
-            var rootNamespace = ComputeAssemblyRootNamespace(assemblyTypes);
+            // Filter the same way the legacy CollectTypesFromNamespace does — anything
+            // that wouldn't be discovered for emission must not influence the assembly
+            // root namespace either, otherwise an [NoEmit] type sitting in an unrelated
+            // namespace would silently shrink the prefix used for import subpaths.
+            var emittedAssemblyTypes = assemblyTypes
+                .Where(type =>
+                    SymbolHelper.GetImport(type) is null
+                    && !SymbolHelper.HasNoTranspile(type)
+                    && !SymbolHelper.HasNoEmit(type, TargetLanguage.TypeScript)
+                )
+                .ToList();
 
-            foreach (var type in assemblyTypes)
+            var rootNamespace = ComputeAssemblyRootNamespace(emittedAssemblyTypes);
+
+            foreach (var type in emittedAssemblyTypes)
             {
-                if (SymbolHelper.GetImport(type) is not null)
-                    continue;
-                if (SymbolHelper.HasNoTranspile(type))
-                    continue;
-                if (SymbolHelper.HasNoEmit(type, TargetLanguage.TypeScript))
-                    continue;
-
                 origins[type.GetStableFullName()] = new IrTypeOrigin(
                     PackageId: packageInfo.Name,
                     Namespace: type.ContainingNamespace.IsGlobalNamespace
@@ -201,28 +209,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             namespaces.Add(type.ContainingNamespace.ToDisplayString());
         }
 
-        if (namespaces.Count == 0)
-            return "";
-        if (namespaces.Count == 1)
-            return namespaces[0];
-
-        var parts = namespaces[0].Split('.');
-        var commonLength = parts.Length;
-        for (var i = 1; i < namespaces.Count; i++)
-        {
-            var otherParts = namespaces[i].Split('.');
-            commonLength = Math.Min(commonLength, otherParts.Length);
-            for (var j = 0; j < commonLength; j++)
-            {
-                if (parts[j] != otherParts[j])
-                {
-                    commonLength = j;
-                    break;
-                }
-            }
-        }
-
-        return string.Join(".", parts.Take(commonLength));
+        return NamespaceUtilities.FindCommonPrefix(namespaces);
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
@@ -84,20 +85,144 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? new Dictionary<string, IrExternalImport>(StringComparer.Ordinal)
             : BuildExternalImports(compilation, diagnostics);
 
+        IReadOnlyDictionary<string, IrTypeOrigin> crossAssemblyOrigins;
+        IReadOnlySet<string> assembliesNeedingEmitPackage;
+        if (compilation is null)
+        {
+            crossAssemblyOrigins = new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal);
+            assembliesNeedingEmitPackage = new HashSet<string>(StringComparer.Ordinal);
+        }
+        else
+        {
+            (crossAssemblyOrigins, assembliesNeedingEmitPackage) = BuildCrossAssemblyState(
+                compilation
+            );
+        }
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: null,
             AssemblyWideTranspile: false,
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
-            CrossAssemblyOrigins: new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal),
+            CrossAssemblyOrigins: crossAssemblyOrigins,
             ExternalImports: externalImports,
             BclExports: compilation is null
                 ? new Dictionary<string, IrBclExport>(StringComparer.Ordinal)
                 : BuildBclExports(compilation),
-            AssembliesNeedingEmitPackage: new HashSet<string>(StringComparer.Ordinal),
+            AssembliesNeedingEmitPackage: assembliesNeedingEmitPackage,
             Diagnostics: diagnostics
         );
+    }
+
+    /// <summary>
+    /// Walks <see cref="Compilation.References"/> and partitions every
+    /// referenced assembly that opted into transpilation
+    /// (<c>[TranspileAssembly]</c>) into one of two buckets:
+    /// <list type="bullet">
+    ///   <item>If it also declares <c>[EmitPackage]</c> for the active
+    ///   target, every public top-level type that is not <c>[Import]</c>,
+    ///   <c>[NoEmit]</c>, or <c>[NoTranspile]</c> contributes an
+    ///   <see cref="IrTypeOrigin"/> keyed by
+    ///   <see cref="SymbolHelper.GetStableFullName(ITypeSymbol)"/>.</item>
+    ///   <item>Otherwise the assembly's metadata name is collected so the
+    ///   target can later raise <see cref="DiagnosticCodes.CrossPackageResolution"/>
+    ///   (MS0007) at the consumer site.</item>
+    /// </list>
+    /// The active target is currently hardcoded to TypeScript / JavaScript
+    /// (<c>EmitTarget</c> integer value <c>0</c>) — every consumer of this
+    /// information today is JS-bound; introducing target awareness on the
+    /// frontend is a separate concern bundled with the contract flip.
+    /// </summary>
+    private static (
+        IReadOnlyDictionary<string, IrTypeOrigin> CrossAssemblyOrigins,
+        IReadOnlySet<string> AssembliesNeedingEmitPackage
+    ) BuildCrossAssemblyState(Compilation compilation)
+    {
+        var origins = new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal);
+        var needingPackage = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
+                continue;
+            if (SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly))
+                continue;
+
+            var hasTranspileAssembly = asm.GetAttributes()
+                .Any(a =>
+                    a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
+                );
+            if (!hasTranspileAssembly)
+                continue;
+
+            var packageInfo = SymbolHelper.GetEmitPackageInfo(asm, targetEnumValue: 0);
+            if (packageInfo is null)
+            {
+                needingPackage.Add(asm.Name);
+                continue;
+            }
+
+            var assemblyTypes = new List<INamedTypeSymbol>();
+            CollectPublicTopLevelTypes(asm.GlobalNamespace, assemblyTypes);
+
+            var rootNamespace = ComputeAssemblyRootNamespace(assemblyTypes);
+
+            foreach (var type in assemblyTypes)
+            {
+                if (SymbolHelper.GetImport(type) is not null)
+                    continue;
+                if (SymbolHelper.HasNoTranspile(type))
+                    continue;
+                if (SymbolHelper.HasNoEmit(type, TargetLanguage.TypeScript))
+                    continue;
+
+                origins[type.GetStableFullName()] = new IrTypeOrigin(
+                    PackageId: packageInfo.Name,
+                    Namespace: type.ContainingNamespace.IsGlobalNamespace
+                        ? null
+                        : type.ContainingNamespace.ToDisplayString(),
+                    AssemblyRootNamespace: rootNamespace,
+                    VersionHint: packageInfo.Version
+                );
+            }
+        }
+
+        return (origins, needingPackage);
+    }
+
+    private static string ComputeAssemblyRootNamespace(IReadOnlyList<INamedTypeSymbol> types)
+    {
+        var namespaces = new List<string>(types.Count);
+        foreach (var type in types)
+        {
+            if (type.ContainingNamespace.IsGlobalNamespace)
+                continue;
+            namespaces.Add(type.ContainingNamespace.ToDisplayString());
+        }
+
+        if (namespaces.Count == 0)
+            return "";
+        if (namespaces.Count == 1)
+            return namespaces[0];
+
+        var parts = namespaces[0].Split('.');
+        var commonLength = parts.Length;
+        for (var i = 1; i < namespaces.Count; i++)
+        {
+            var otherParts = namespaces[i].Split('.');
+            commonLength = Math.Min(commonLength, otherParts.Length);
+            for (var j = 0; j < commonLength; j++)
+            {
+                if (parts[j] != otherParts[j])
+                {
+                    commonLength = j;
+                    break;
+                }
+            }
+        }
+
+        return string.Join(".", parts.Take(commonLength));
     }
 
     /// <summary>

--- a/src/Metano.Compiler/NamespaceUtilities.cs
+++ b/src/Metano.Compiler/NamespaceUtilities.cs
@@ -1,0 +1,44 @@
+namespace Metano.Compiler;
+
+/// <summary>
+/// Pure-string helpers for working with C# namespace paths. Lives in the
+/// core so any frontend or backend that needs to reason about namespace
+/// hierarchies (e.g., to compute an assembly's root namespace) can share
+/// the same implementation.
+/// </summary>
+public static class NamespaceUtilities
+{
+    /// <summary>
+    /// Longest dot-separated prefix shared by every entry in
+    /// <paramref name="namespaces"/>. Returns the single entry verbatim
+    /// when the list has one element, and the empty string when the list
+    /// is empty or no segments overlap.
+    /// </summary>
+    public static string FindCommonPrefix(IReadOnlyList<string> namespaces)
+    {
+        if (namespaces.Count == 0)
+            return "";
+        if (namespaces.Count == 1)
+            return namespaces[0];
+
+        var parts = namespaces[0].Split('.');
+        var commonLength = parts.Length;
+
+        for (var i = 1; i < namespaces.Count; i++)
+        {
+            var otherParts = namespaces[i].Split('.');
+            commonLength = System.Math.Min(commonLength, otherParts.Length);
+
+            for (var j = 0; j < commonLength; j++)
+            {
+                if (parts[j] != otherParts[j])
+                {
+                    commonLength = j;
+                    break;
+                }
+            }
+        }
+
+        return string.Join(".", parts.Take(commonLength));
+    }
+}

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -268,6 +268,64 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
+    public async Task CrossAssemblyOrigins_RootNamespaceIgnoresNoEmitAndNoTranspileTypes()
+    {
+        // The reference declares emitted types under Acme.Mixed.* but also has
+        // [NoEmit] / [NoTranspile] types in an unrelated `Zeta.Hidden` namespace.
+        // The legacy discovery filters those out before computing the assembly
+        // root namespace, so the prefix must stay at "Acme.Mixed" — without the
+        // filter it would shrink to "" and break import subpath generation.
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("acme-mixed")]
+
+            namespace Acme.Mixed.Feature
+            {
+                [Transpile]
+                public class Real {}
+            }
+
+            namespace Acme.Mixed.Other
+            {
+                [Transpile]
+                public class Sibling {}
+            }
+
+            namespace Zeta.Hidden
+            {
+                [NoEmit]
+                public class Ambient {}
+
+                [NoTranspile]
+                public class Ignored {}
+            }
+            """,
+            assemblyName: "AcmeMixed"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        var realKey = consumer
+            .GetTypeByMetadataName("Acme.Mixed.Feature.Real")!
+            .GetStableFullName();
+        await Assert.That(ir.CrossAssemblyOrigins).ContainsKey(realKey);
+        await Assert
+            .That(ir.CrossAssemblyOrigins[realKey].AssemblyRootNamespace)
+            .IsEqualTo("Acme.Mixed");
+    }
+
+    [Test]
     public async Task ExternalImports_NameCollisionKeepsFirstAndWarns()
     {
         // Two top-level types share the simple name `Widget` across distinct

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -150,6 +150,124 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
+    public async Task CrossAssemblyOrigins_RegisterTypesFromTranspilableLibrary()
+    {
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("acme-shared")]
+
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                public class Money { public int Amount { get; } }
+            }
+            """,
+            assemblyName: "AcmeShared"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            using Acme.Shared.Domain;
+
+            [Transpile]
+            public class Marker { public Money? M { get; } }
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        var moneyType = consumer.GetTypeByMetadataName("Acme.Shared.Domain.Money");
+        await Assert.That(moneyType).IsNotNull();
+        var key = moneyType!.GetStableFullName();
+
+        await Assert.That(ir.CrossAssemblyOrigins).ContainsKey(key);
+        var origin = ir.CrossAssemblyOrigins[key];
+        await Assert.That(origin.PackageId).IsEqualTo("acme-shared");
+        await Assert.That(origin.Namespace).IsEqualTo("Acme.Shared.Domain");
+        await Assert.That(origin.AssemblyRootNamespace).IsEqualTo("Acme.Shared.Domain");
+    }
+
+    [Test]
+    public async Task AssembliesNeedingEmitPackage_RecordsTranspilableLibraryWithoutEmitPackage()
+    {
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+
+            namespace Orphan
+            {
+                [Transpile]
+                public class Detached {}
+            }
+            """,
+            assemblyName: "OrphanLib"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        await Assert.That(ir.AssembliesNeedingEmitPackage).Contains("OrphanLib");
+        await Assert.That(ir.CrossAssemblyOrigins.Keys).DoesNotContain("Orphan.Detached");
+    }
+
+    [Test]
+    public async Task CrossAssemblyOrigins_SkipsImportAndNoEmitTypes()
+    {
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("acme-mixed")]
+
+            namespace Acme.Mixed
+            {
+                [Transpile]
+                public class Real {}
+
+                [Import("Hono", from: "hono")]
+                public class HonoStub {}
+
+                [NoEmit]
+                public class Ambient {}
+            }
+            """,
+            assemblyName: "AcmeMixed"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        var realKey = consumer.GetTypeByMetadataName("Acme.Mixed.Real")!.GetStableFullName();
+        var honoKey = consumer.GetTypeByMetadataName("Acme.Mixed.HonoStub")!.GetStableFullName();
+        var ambientKey = consumer.GetTypeByMetadataName("Acme.Mixed.Ambient")!.GetStableFullName();
+
+        await Assert.That(ir.CrossAssemblyOrigins).ContainsKey(realKey);
+        await Assert.That(ir.CrossAssemblyOrigins.ContainsKey(honoKey)).IsFalse();
+        await Assert.That(ir.CrossAssemblyOrigins.ContainsKey(ambientKey)).IsFalse();
+    }
+
+    [Test]
     public async Task ExternalImports_NameCollisionKeepsFirstAndWarns()
     {
         // Two top-level types share the simple name `Widget` across distinct


### PR DESCRIPTION
## Summary

Producer half of the cross-assembly migration. The frontend now walks
`Compilation.References` for assemblies that opted into transpilation
and populates two `IrCompilation` fields:

- **`CrossAssemblyOrigins`** — for each referenced assembly with both
  `[TranspileAssembly]` and `[EmitPackage]`, every public top-level
  type contributes an `IrTypeOrigin` entry keyed by
  `SymbolHelper.GetStableFullName()`, carrying the package id,
  namespace, computed assembly root namespace, and version hint.
- **`AssembliesNeedingEmitPackage`** — assembly metadata names of
  references that opted into transpilation but lack `[EmitPackage]`
  for the active target, so the consumer can later raise MS0007.

`[Import]`, `[NoEmit]`, and `[NoTranspile]` types are skipped in the
origin pass.

## Scope decision: target hardcoded to TypeScript

The active target is hardcoded to `EmitTarget = 0` (TypeScript /
JavaScript) for now. Every consumer of this data today is JS-bound;
the Dart prototype doesn't read these fields. Introducing target
awareness on the frontend is bundled with the contract flip.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 570/570 ✅ (567 + 3 new)
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58