### PR TITLE
refactor(core): CSharpSourceFrontend populates PackageName + AssemblyWideTranspile (Phase B.2d-mini)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -104,31 +104,11 @@ public sealed class TypeTransformer(Compilation compilation)
         // Read [ExportFromBcl] assembly-level attributes
         LoadBclExportMappings();
 
-        // Detect [assembly: TranspileAssembly] — MUST happen before DiscoverTranspilableTypes
-        // Check both semantic model (for real projects) and syntax tree (for inline compilation)
-        _assemblyWideTranspile =
-            compilation
-                .Assembly.GetAttributes()
-                .Any(a =>
-                    a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
-                )
-            || compilation.SyntaxTrees.Any(tree =>
-                tree.GetRoot()
-                    .DescendantNodes()
-                    .OfType<AttributeListSyntax>()
-                    .Any(al =>
-                        al.Target?.Identifier.Text == "assembly"
-                        && al.Attributes.Any(a =>
-                        {
-                            var name = a.Name.ToString();
-                            return name
-                                is "TranspileAssembly"
-                                    or "TranspileAssemblyAttribute"
-                                    or "Metano.TranspileAssembly"
-                                    or "Metano.TranspileAssemblyAttribute";
-                        })
-                    )
-            );
+        // Detect [assembly: TranspileAssembly] — MUST happen before DiscoverTranspilableTypes.
+        // SymbolHelper.HasTranspileAssembly handles both the semantic-model (real projects)
+        // and syntax-tree (inline test compilations) checks; shared with the IR producer
+        // so the two paths can't drift.
+        _assemblyWideTranspile = compilation.HasTranspileAssembly();
 
         var transpilableTypes = DiscoverTranspilableTypes();
         // Map by both C# name and TS name (when [Name] override differs)

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -2,6 +2,7 @@ using Metano.Annotations;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Metano.Compiler;
@@ -101,8 +102,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
-            PackageName: null,
-            AssemblyWideTranspile: false,
+            PackageName: compilation is null
+                ? null
+                : SymbolHelper.GetEmitPackage(
+                    compilation.Assembly,
+                    targetEnumValue: (int)EmitTarget.JavaScript
+                ),
+            AssemblyWideTranspile: compilation is not null
+                && DetectAssemblyWideTranspile(compilation),
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: crossAssemblyOrigins,
@@ -113,6 +120,52 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             AssembliesNeedingEmitPackage: assembliesNeedingEmitPackage,
             Diagnostics: diagnostics
         );
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the current assembly opted into wholesale
+    /// transpilation via <c>[assembly: TranspileAssembly]</c>. Mirrors the
+    /// legacy detection in <c>TypeTransformer.TransformAll</c>: the
+    /// semantic-model check covers real MSBuild projects, and the syntax
+    /// fallback covers inline test compilations that may not have rebuilt
+    /// their assembly attributes yet.
+    /// </summary>
+    private static bool DetectAssemblyWideTranspile(Compilation compilation)
+    {
+        var hasSemanticAttr = compilation
+            .Assembly.GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
+            );
+        if (hasSemanticAttr)
+            return true;
+
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var root = tree.GetRoot();
+            foreach (var attrList in root.DescendantNodes().OfType<AttributeListSyntax>())
+            {
+                if (attrList.Target?.Identifier.Text != "assembly")
+                    continue;
+
+                foreach (var attr in attrList.Attributes)
+                {
+                    var name = attr.Name.ToString();
+                    if (
+                        name
+                        is "TranspileAssembly"
+                            or "TranspileAssemblyAttribute"
+                            or "Metano.TranspileAssembly"
+                            or "Metano.TranspileAssemblyAttribute"
+                    )
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -2,7 +2,6 @@ using Metano.Annotations;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Metano.Compiler;
@@ -108,8 +107,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     compilation.Assembly,
                     targetEnumValue: (int)EmitTarget.JavaScript
                 ),
-            AssemblyWideTranspile: compilation is not null
-                && DetectAssemblyWideTranspile(compilation),
+            AssemblyWideTranspile: compilation is not null && compilation.HasTranspileAssembly(),
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: crossAssemblyOrigins,
@@ -120,52 +118,6 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             AssembliesNeedingEmitPackage: assembliesNeedingEmitPackage,
             Diagnostics: diagnostics
         );
-    }
-
-    /// <summary>
-    /// Returns <c>true</c> when the current assembly opted into wholesale
-    /// transpilation via <c>[assembly: TranspileAssembly]</c>. Mirrors the
-    /// legacy detection in <c>TypeTransformer.TransformAll</c>: the
-    /// semantic-model check covers real MSBuild projects, and the syntax
-    /// fallback covers inline test compilations that may not have rebuilt
-    /// their assembly attributes yet.
-    /// </summary>
-    private static bool DetectAssemblyWideTranspile(Compilation compilation)
-    {
-        var hasSemanticAttr = compilation
-            .Assembly.GetAttributes()
-            .Any(a =>
-                a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
-            );
-        if (hasSemanticAttr)
-            return true;
-
-        foreach (var tree in compilation.SyntaxTrees)
-        {
-            var root = tree.GetRoot();
-            foreach (var attrList in root.DescendantNodes().OfType<AttributeListSyntax>())
-            {
-                if (attrList.Target?.Identifier.Text != "assembly")
-                    continue;
-
-                foreach (var attr in attrList.Attributes)
-                {
-                    var name = attr.Name.ToString();
-                    if (
-                        name
-                        is "TranspileAssembly"
-                            or "TranspileAssemblyAttribute"
-                            or "Metano.TranspileAssembly"
-                            or "Metano.TranspileAssemblyAttribute"
-                    )
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -1,5 +1,6 @@
 using Metano.Annotations;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Metano.Compiler;
 
@@ -293,6 +294,53 @@ public static class SymbolHelper
         GetEmitPackageInfo(assembly, targetEnumValue)?.Name;
 
     public sealed record EmitPackageInfo(string Name, string? Version);
+
+    /// <summary>
+    /// Returns <c>true</c> when the compilation declares
+    /// <c>[assembly: TranspileAssembly]</c>. Checks the semantic model
+    /// first (covers MSBuild-driven projects) and falls back to walking
+    /// the syntax trees for inline test compilations whose attribute may
+    /// not yet appear on <see cref="IAssemblySymbol.GetAttributes"/>.
+    /// Single source of truth for both the legacy
+    /// <c>TypeTransformer</c> and the IR <c>CSharpSourceFrontend</c>.
+    /// </summary>
+    public static bool HasTranspileAssembly(this Compilation compilation)
+    {
+        var hasSemanticAttr = compilation
+            .Assembly.GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
+            );
+        if (hasSemanticAttr)
+            return true;
+
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var root = tree.GetRoot();
+            foreach (var attrList in root.DescendantNodes().OfType<AttributeListSyntax>())
+            {
+                if (attrList.Target?.Identifier.Text != "assembly")
+                    continue;
+
+                foreach (var attr in attrList.Attributes)
+                {
+                    var name = attr.Name.ToString();
+                    if (
+                        name
+                        is "TranspileAssembly"
+                            or "TranspileAssemblyAttribute"
+                            or "Metano.TranspileAssembly"
+                            or "Metano.TranspileAssemblyAttribute"
+                    )
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
 
     public static bool HasInlineWrapper(this ISymbol symbol) =>
         HasAttribute(symbol, "InlineWrapper");

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -326,6 +326,69 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
+    public async Task PackageName_ReadsEmitPackageFromCurrentAssembly()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: EmitPackage("my-pkg")]
+
+            [Transpile]
+            public class Marker {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.PackageName).IsEqualTo("my-pkg");
+    }
+
+    [Test]
+    public async Task PackageName_NullWhenAttributeAbsent()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Marker {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.PackageName).IsNull();
+    }
+
+    [Test]
+    public async Task AssemblyWideTranspile_TrueWhenAttributeDeclared()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            public class PublicNoAttribute {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.AssemblyWideTranspile).IsTrue();
+    }
+
+    [Test]
+    public async Task AssemblyWideTranspile_FalseWhenAttributeAbsent()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Marker {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.AssemblyWideTranspile).IsFalse();
+    }
+
+    [Test]
     public async Task ExternalImports_NameCollisionKeepsFirstAndWarns()
     {
         // Two top-level types share the simple name `Widget` across distinct


### PR DESCRIPTION
## Summary

Producer half of the assembly-metadata migration. Two simple assembly-level
attributes now flow through the IR:

- **`PackageName`** — `[assembly: EmitPackage(name, JavaScript)]` via
  `SymbolHelper.GetEmitPackage` with `(int)EmitTarget.JavaScript`.
- **`AssemblyWideTranspile`** — `[assembly: TranspileAssembly]`. The
  detection mirrors the legacy `TypeTransformer.TransformAll` logic:
  semantic model first (covers MSBuild projects), syntax-tree fallback
  for inline test compilations whose attributes may not yet appear on
  `IAssemblySymbol`.

The TypeScript target's `LastEmitPackageName` / `_assemblyWideTranspile`
state stay in place until the contract flip migrates consumers onto the
IR.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 575/575 ✅ (571 + 4 new)
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58