### PR TITLE
refactor(core): ITranspilerTarget.Transform receives IrCompilation (Phase B.3)

### DIFF
--- a/src/Metano.Compiler.Dart/DartTarget.cs
+++ b/src/Metano.Compiler.Dart/DartTarget.cs
@@ -1,4 +1,5 @@
 using Metano.Compiler;
+using Metano.Compiler.IR;
 using Metano.Dart.AST;
 using Metano.Dart.Transformation;
 using Microsoft.CodeAnalysis;
@@ -14,8 +15,13 @@ public sealed class DartTarget : ITranspilerTarget
 
     public IReadOnlyList<DartSourceFile> LastSourceFiles { get; private set; } = [];
 
-    public TargetOutput Transform(Compilation compilation)
+    public TargetOutput Transform(IrCompilation ir, Compilation compilation)
     {
+        // The Dart prototype still drives discovery off the Roslyn compilation;
+        // the IR is accepted to honor the contract and used opportunistically
+        // by helpers as they migrate.
+        _ = ir;
+
         var transformer = new DartTransformer(compilation);
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;

--- a/src/Metano.Compiler.Dart/DartTarget.cs
+++ b/src/Metano.Compiler.Dart/DartTarget.cs
@@ -15,8 +15,15 @@ public sealed class DartTarget : ITranspilerTarget
 
     public IReadOnlyList<DartSourceFile> LastSourceFiles { get; private set; } = [];
 
-    public TargetOutput Transform(IrCompilation ir, Compilation compilation)
+    public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
     {
+        if (compilation is null)
+            throw new NotSupportedException(
+                "DartTarget currently requires a Roslyn-backed source frontend; "
+                    + "compilation was null. The Roslyn dependency will go away once the "
+                    + "Dart transformer reads everything it needs from IrCompilation."
+            );
+
         // The Dart prototype still drives discovery off the Roslyn compilation;
         // the IR is accepted to honor the contract and used opportunistically
         // by helpers as they migrate.

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler;
 using Metano.Compiler.IR;
 using Metano.Transformation;
@@ -50,15 +51,26 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     public bool LastIsExecutable { get; private set; }
 
-    public TargetOutput Transform(IrCompilation ir, Compilation compilation)
+    public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
     {
+        if (compilation is null)
+            throw new NotSupportedException(
+                "TypeScriptTarget currently requires a Roslyn-backed source frontend; "
+                    + "compilation was null. The Roslyn dependency will go away once the "
+                    + "TypeScript transformer reads everything it needs from IrCompilation."
+            );
+
         var transformer = new TypeTransformer(compilation);
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
         // Prefer the frontend-populated package name; the underlying Roslyn read
         // remains as a defensive fallback while every consumer migrates onto IR.
         LastEmitPackageName =
-            ir.PackageName ?? SymbolHelper.GetEmitPackage(compilation.Assembly, targetEnumValue: 0);
+            ir.PackageName
+            ?? SymbolHelper.GetEmitPackage(
+                compilation.Assembly,
+                targetEnumValue: (int)EmitTarget.JavaScript
+            );
         LastCrossPackageDependencies = transformer.CrossPackageDependencies;
         LastIsExecutable = compilation.Options.OutputKind == OutputKind.ConsoleApplication;
 

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -1,4 +1,5 @@
 using Metano.Compiler;
+using Metano.Compiler.IR;
 using Metano.Transformation;
 using Metano.TypeScript;
 using Metano.TypeScript.AST;
@@ -49,13 +50,15 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     public bool LastIsExecutable { get; private set; }
 
-    public TargetOutput Transform(Compilation compilation)
+    public TargetOutput Transform(IrCompilation ir, Compilation compilation)
     {
         var transformer = new TypeTransformer(compilation);
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
-        // Read [EmitPackage] for the JavaScript target (enum value 0).
-        LastEmitPackageName = SymbolHelper.GetEmitPackage(compilation.Assembly, targetEnumValue: 0);
+        // Prefer the frontend-populated package name; the underlying Roslyn read
+        // remains as a defensive fallback while every consumer migrates onto IR.
+        LastEmitPackageName =
+            ir.PackageName ?? SymbolHelper.GetEmitPackage(compilation.Assembly, targetEnumValue: 0);
         LastCrossPackageDependencies = transformer.CrossPackageDependencies;
         LastIsExecutable = compilation.Options.OutputKind == OutputKind.ConsoleApplication;
 

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -1,12 +1,15 @@
+using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
 
 namespace Metano.Compiler;
 
 /// <summary>
 /// Implemented by each language-specific backend (TypeScript, Dart, Kotlin, …).
-/// The host (TranspilerHost) takes care of opening the C# project, running the Roslyn
-/// compilation, and writing files to disk; the target only needs to consume the
-/// Compilation and produce a TargetOutput.
+/// The host (<see cref="TranspilerHost"/>) takes care of opening the source project,
+/// running the C# frontend, and writing files to disk; the target receives both the
+/// shared <see cref="IrCompilation"/> (the canonical, source-language-agnostic input)
+/// and — transitionally — the underlying Roslyn <see cref="Compilation"/> so it can
+/// keep using bits of the legacy code path that have not yet migrated onto the IR.
 /// </summary>
 public interface ITranspilerTarget
 {
@@ -14,8 +17,15 @@ public interface ITranspilerTarget
     string Name { get; }
 
     /// <summary>
-    /// Transforms a Roslyn compilation into a set of generated files plus diagnostics.
-    /// Implementations must NOT perform file I/O — the host writes the returned files.
+    /// Produces the set of files (plus diagnostics) the host should emit. Targets
+    /// SHOULD prefer the data on <paramref name="ir"/> over <paramref name="compilation"/>
+    /// for anything the frontend already populates; the Roslyn compilation is exposed as
+    /// a transitional escape hatch and will be removed once the active targets stop
+    /// reading from it. Implementations must NOT perform file I/O — the host writes
+    /// the returned files.
     /// </summary>
-    TargetOutput Transform(Compilation compilation);
+    /// <param name="ir">Shared IR built by the active <see cref="ISourceFrontend"/>.</param>
+    /// <param name="compilation">Roslyn compilation produced by the C# frontend.
+    /// Transitional escape hatch for legacy code paths.</param>
+    TargetOutput Transform(IrCompilation ir, Compilation compilation);
 }

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -5,11 +5,13 @@ namespace Metano.Compiler;
 
 /// <summary>
 /// Implemented by each language-specific backend (TypeScript, Dart, Kotlin, …).
-/// The host (<see cref="TranspilerHost"/>) takes care of opening the source project,
-/// running the C# frontend, and writing files to disk; the target receives both the
-/// shared <see cref="IrCompilation"/> (the canonical, source-language-agnostic input)
-/// and — transitionally — the underlying Roslyn <see cref="Compilation"/> so it can
-/// keep using bits of the legacy code path that have not yet migrated onto the IR.
+/// The host (<see cref="TranspilerHost"/>) takes care of opening the source
+/// project, running the active <see cref="ISourceFrontend"/>, and writing files
+/// to disk; the target receives the shared <see cref="IrCompilation"/> (the
+/// canonical, source-language-agnostic input) and — transitionally — the
+/// Roslyn <see cref="Compilation"/> when the active frontend is the C# one,
+/// so legacy code paths that have not yet migrated onto the IR can keep
+/// running.
 /// </summary>
 public interface ITranspilerTarget
 {
@@ -19,13 +21,15 @@ public interface ITranspilerTarget
     /// <summary>
     /// Produces the set of files (plus diagnostics) the host should emit. Targets
     /// SHOULD prefer the data on <paramref name="ir"/> over <paramref name="compilation"/>
-    /// for anything the frontend already populates; the Roslyn compilation is exposed as
-    /// a transitional escape hatch and will be removed once the active targets stop
-    /// reading from it. Implementations must NOT perform file I/O — the host writes
-    /// the returned files.
+    /// for anything the active frontend already populates; the Roslyn compilation is
+    /// exposed only as a transitional escape hatch and will be removed once the active
+    /// targets stop reading from it. Implementations must NOT perform file I/O — the
+    /// host writes the returned files.
     /// </summary>
     /// <param name="ir">Shared IR built by the active <see cref="ISourceFrontend"/>.</param>
-    /// <param name="compilation">Roslyn compilation produced by the C# frontend.
-    /// Transitional escape hatch for legacy code paths.</param>
-    TargetOutput Transform(IrCompilation ir, Compilation compilation);
+    /// <param name="compilation">Roslyn compilation, if the active frontend produced one.
+    /// <see langword="null"/> for frontends with no Roslyn backing — IR-only targets can
+    /// ignore the parameter entirely; Roslyn-dependent targets should surface a clear
+    /// diagnostic when it is unavailable.</param>
+    TargetOutput Transform(IrCompilation ir, Compilation? compilation);
 }

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -53,7 +53,7 @@ public static class TranspilerHost
             Console.WriteLine($"  Compilation: {compileSw.ElapsedMilliseconds}ms");
 
         var transpileSw = Stopwatch.StartNew();
-        var output = target.Transform(compilation);
+        var output = target.Transform(ir, compilation);
 
         transpileSw.Stop();
 


### PR DESCRIPTION
## Summary

Adds the shared `IrCompilation` to the `ITranspilerTarget.Transform`
contract as the canonical, source-language-agnostic input. The Roslyn
`Compilation` stays in the signature as a transitional escape hatch so
the existing `TypeTransformer` / `DartTransformer` pipelines run
unchanged — consumer-side migration onto IR fields happens
incrementally on follow-up PRs.

## Changes

- **`ITranspilerTarget.Transform(IrCompilation ir, Compilation compilation)`** —
  contract change with both inputs. Doc explains the migration intent.
- **`TypeScriptTarget`** — already prefers `ir.PackageName` over the
  legacy `SymbolHelper.GetEmitPackage` read; remaining work in the
  transformer keeps using the compilation.
- **`DartTarget`** — accepts the IR but the prototype keeps driving
  discovery off the compilation; no behavioral change.
- **`TranspilerHost`** — passes both arguments through. No other
  callers of `Transform` exist in the codebase.

## Migration plan

1. **(this PR) B.3** — add IR to the contract.
2. **B.4+** — TS / Dart consumers migrate from Roslyn reads onto the
   already-populated IR fields (BclExports, ExternalImports,
   CrossAssemblyOrigins, AssembliesNeedingEmitPackage, PackageName,
   AssemblyWideTranspile).
3. **B.5** — frontend populates `Modules` (discovery + grouping +
   per-type extraction); consumers iterate IR.
4. **B.6** — drop the `Compilation` parameter from `Transform`.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 575/575 ✅
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58