### PR TITLE
refactor(ts): TypeTransformer reads AssemblyWideTranspile from IR (Phase B.4.1)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -13,8 +13,12 @@ namespace Metano.Transformation;
 
 /// <summary>
 /// Transforms C# types annotated with [Transpile] into TypeScript AST source files.
+/// Receives both the shared <see cref="IrCompilation"/> (canonical input from the
+/// active source frontend) and the underlying Roslyn <see cref="Compilation"/> the
+/// legacy bridges still walk. Fields the frontend already populates are read off
+/// the IR; everything else falls back to Roslyn during the incremental migration.
 /// </summary>
-public sealed class TypeTransformer(Compilation compilation)
+public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 {
     private readonly List<MetanoDiagnostic> _diagnostics = [];
 
@@ -104,11 +108,10 @@ public sealed class TypeTransformer(Compilation compilation)
         // Read [ExportFromBcl] assembly-level attributes
         LoadBclExportMappings();
 
-        // Detect [assembly: TranspileAssembly] — MUST happen before DiscoverTranspilableTypes.
-        // SymbolHelper.HasTranspileAssembly handles both the semantic-model (real projects)
-        // and syntax-tree (inline test compilations) checks; shared with the IR producer
-        // so the two paths can't drift.
-        _assemblyWideTranspile = compilation.HasTranspileAssembly();
+        // The frontend already detects [assembly: TranspileAssembly] (semantic model
+        // first, syntax-tree fallback for inline test compilations) — read it off the
+        // IR rather than redoing the same probe.
+        _assemblyWideTranspile = ir.AssemblyWideTranspile;
 
         var transpilableTypes = DiscoverTranspilableTypes();
         // Map by both C# name and TS name (when [Name] override differs)

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -60,7 +60,7 @@ public sealed class TypeScriptTarget : ITranspilerTarget
                     + "TypeScript transformer reads everything it needs from IrCompilation."
             );
 
-        var transformer = new TypeTransformer(compilation);
+        var transformer = new TypeTransformer(ir, compilation);
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
         // Prefer the frontend-populated package name; the underlying Roslyn read

--- a/tests/Metano.Tests/CrossPackageImportTests.cs
+++ b/tests/Metano.Tests/CrossPackageImportTests.cs
@@ -167,7 +167,7 @@ public class CrossPackageImportTests
         var libCompilation = TranspileHelper.CompileLibrary(library);
         var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
 
-        var transformer = new Metano.Transformation.TypeTransformer(consumerCompilation);
+        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
         transformer.TransformAll();
 
         await Assert.That(transformer.CrossPackageDependencies.ContainsKey("@acme/lib")).IsTrue();
@@ -202,7 +202,7 @@ public class CrossPackageImportTests
         var libCompilation = TranspileHelper.CompileLibrary(library);
         var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
 
-        var transformer = new Metano.Transformation.TypeTransformer(consumerCompilation);
+        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
         transformer.TransformAll();
 
         await Assert
@@ -254,7 +254,7 @@ public class CrossPackageImportTests
             """
         );
 
-        var transformer = new Metano.Transformation.TypeTransformer(compilation);
+        var transformer = TranspileHelper.NewTransformer(compilation);
         transformer.TransformAll();
 
         await Assert.That(transformer.CrossPackageDependencies.ContainsKey("hono")).IsTrue();
@@ -280,7 +280,7 @@ public class CrossPackageImportTests
             """
         );
 
-        var transformer = new Metano.Transformation.TypeTransformer(compilation);
+        var transformer = TranspileHelper.NewTransformer(compilation);
         transformer.TransformAll();
 
         await Assert.That(transformer.CrossPackageDependencies.ContainsKey("hono")).IsFalse();
@@ -314,7 +314,7 @@ public class CrossPackageImportTests
         var libCompilation = TranspileHelper.CompileLibrary(library);
         var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
 
-        var transformer = new Metano.Transformation.TypeTransformer(consumerCompilation);
+        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
         var files = transformer.TransformAll();
         var printer = new Printer();
         var output = printer.Print(files.Single(f => f.FileName == "app.ts"));
@@ -373,7 +373,7 @@ public class CrossPackageImportTests
             libBCompilation
         );
 
-        var transformer = new Metano.Transformation.TypeTransformer(consumerCompilation);
+        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
         transformer.TransformAll();
 
         await Assert
@@ -567,7 +567,7 @@ public class CrossPackageImportTests
             """
         );
 
-        var transformer = new Metano.Transformation.TypeTransformer(compilation);
+        var transformer = TranspileHelper.NewTransformer(compilation);
         transformer.TransformAll();
 
         await Assert.That(transformer.CrossPackageDependencies.ContainsKey("decimal.js")).IsTrue();
@@ -603,7 +603,7 @@ public class CrossPackageImportTests
         var libCompilation = TranspileHelper.CompileLibrary(library);
         var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
 
-        var transformer = new Metano.Transformation.TypeTransformer(consumerCompilation);
+        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
         transformer.TransformAll();
 
         await Assert

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -1,4 +1,5 @@
 using Metano.Annotations;
+using Metano.Compiler;
 using Metano.Transformation;
 using Metano.TypeScript;
 using Microsoft.CodeAnalysis;
@@ -97,12 +98,26 @@ public static class TranspileHelper
         return compilation;
     }
 
+    /// <summary>
+    /// Builds a <see cref="TypeTransformer"/> wired to the IR the
+    /// <see cref="CSharpSourceFrontend"/> would produce in production. Lets
+    /// individual tests poke at the transformer's internal state (e.g.,
+    /// <c>CrossPackageDependencies</c>) without having to recreate the IR
+    /// extraction boilerplate.
+    /// </summary>
+    public static TypeTransformer NewTransformer(CSharpCompilation compilation) =>
+        new(new CSharpSourceFrontend().ExtractFromCompilation(compilation), compilation);
+
     private static (
         Dictionary<string, string> Files,
         IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic> Diagnostics
     ) TranspileCore(CSharpCompilation compilation, bool useIrBodies = true)
     {
-        var transformer = new TypeTransformer(compilation) { UseIrBodiesWhenCovered = useIrBodies };
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        var transformer = new TypeTransformer(ir, compilation)
+        {
+            UseIrBodiesWhenCovered = useIrBodies,
+        };
         var files = transformer.TransformAll();
         var printer = new Printer();
         var result = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary

First slice of the consumer-side migration that follows the contract
flip in #66. The TypeScript transformer now takes `IrCompilation` as
its first constructor argument and reads `ir.AssemblyWideTranspile`
instead of re-running `SymbolHelper.HasTranspileAssembly` itself.

The Roslyn `Compilation` stays as the second constructor argument
because the rest of the transformer / bridges still drive discovery
off it. Subsequent PRs migrate the larger maps (BclExports,
ExternalImports, CrossAssemblyOrigins, AssembliesNeedingEmitPackage)
in the same incremental shape.

## Test ergonomics

`TranspileHelper.NewTransformer(compilation)` wires the IR the same
way `TypeScriptTarget` does, so the eight direct constructor calls in
`CrossPackageImportTests` stay one-liners.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 575/575 ✅
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58