### PR TITLE
refactor(ts): TypeTransformer reads BclExports from IR (Phase B.4.2)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
@@ -17,16 +17,18 @@ public interface IrToTsTypeOverrides
 }
 
 /// <summary>
-/// Wraps the legacy <see cref="Metano.Transformation.TypeMappingContext.BclExportMap"/>
+/// Wraps the frontend-populated
+/// <see cref="IrCompilation.BclExports"/> map (carried through
+/// <see cref="Metano.Transformation.TypeMappingContext.BclExportMap"/>)
 /// into the bridge-friendly resolver interface and tracks the package +
 /// version of every override that fires so the package.json writer picks
 /// up the cross-package dependency. Today it only resolves <c>decimal</c>
 /// (the only <c>[ExportFromBcl]</c> entry shipped by
 /// <c>Metano.Runtime</c>); the lookup uses Roslyn's full type name as the
-/// dictionary key, matching the legacy behaviour.
+/// dictionary key, matching what the frontend stores.
 /// </summary>
 public sealed class BclExportTypeOverrides(
-    IReadOnlyDictionary<string, (string ExportedName, string FromPackage, string Version)> map,
+    IReadOnlyDictionary<string, IrBclExport> map,
     Dictionary<string, string> usedCrossPackages
 ) : IrToTsTypeOverrides
 {
@@ -39,8 +41,8 @@ public sealed class BclExportTypeOverrides(
 
         // Mirror TypeMapper.Map: every BCL hit records its package name and
         // version so the package.json writer surfaces the dependency.
-        if (entry.FromPackage.Length > 0 && entry.Version.Length > 0)
-            usedCrossPackages[entry.FromPackage] = entry.Version;
+        if (entry.FromPackage.Length > 0 && entry.Version is { Length: > 0 } version)
+            usedCrossPackages[entry.FromPackage] = version;
         return new TsNamedType(entry.ExportedName);
     }
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
@@ -24,8 +24,12 @@ public interface IrToTsTypeOverrides
 /// version of every override that fires so the package.json writer picks
 /// up the cross-package dependency. Today it only resolves <c>decimal</c>
 /// (the only <c>[ExportFromBcl]</c> entry shipped by
-/// <c>Metano.Runtime</c>); the lookup uses Roslyn's full type name as the
-/// dictionary key, matching what the frontend stores.
+/// <c>Metano.Runtime</c>); the dictionary is keyed by the C# display
+/// string of the <c>typeof(...)</c> argument (i.e.,
+/// <c>ITypeSymbol.ToDisplayString()</c> with the default format —
+/// <c>"decimal"</c> rather than <c>"System.Decimal"</c>), which is
+/// exactly what <c>BclKey</c> below produces for each
+/// <see cref="IrPrimitive"/>.
 /// </summary>
 public sealed class BclExportTypeOverrides(
     IReadOnlyDictionary<string, IrBclExport> map,

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -26,10 +26,7 @@ public sealed class ImportCollector(
         string,
         (string Name, string From, bool IsDefault, string? Version)
     > externalImportMap,
-    IReadOnlyDictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > bclExportMap,
+    IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
     PathNaming pathNaming,
     TypeMappingContext typeMappingContext,
@@ -42,10 +39,7 @@ public sealed class ImportCollector(
         string,
         (string Name, string From, bool IsDefault, string? Version)
     > _externalImportMap = externalImportMap;
-    private readonly IReadOnlyDictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > _bclExportMap = bclExportMap;
+    private readonly IReadOnlyDictionary<string, IrBclExport> _bclExportMap = bclExportMap;
     private readonly IReadOnlyDictionary<string, string> _guardNameToTypeMap = guardNameToTypeMap;
     private readonly PathNaming _pathNaming = pathNaming;
     private readonly TypeMappingContext _typeMappingContext = typeMappingContext;
@@ -269,7 +263,7 @@ public sealed class ImportCollector(
             // and the cross-package merge strategy doesn't apply here.
             var bclEntry = _bclExportMap.Values.FirstOrDefault(e => e.ExportedName == typeName);
             if (
-                bclEntry.ExportedName is not null
+                bclEntry is not null
                 && bclEntry.FromPackage.Length > 0
                 && importedNames.Add(typeName)
             )

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
@@ -1,3 +1,4 @@
+using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
 
 namespace Metano.Transformation;
@@ -11,7 +12,7 @@ namespace Metano.Transformation;
 /// <see cref="CrossPackageMisses"/> accumulate data during transformation.
 /// </summary>
 public sealed class TypeMappingContext(
-    Dictionary<string, (string ExportedName, string FromPackage, string Version)> bclExportMap,
+    IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     Dictionary<ISymbol, CrossAssemblyEntry> crossAssemblyTypeMap,
     HashSet<IAssemblySymbol> assembliesNeedingEmitPackage,
     HashSet<string>? crossPackageMisses = null,
@@ -25,12 +26,13 @@ public sealed class TypeMappingContext(
     /// simply not resolve.
     /// </summary>
     public static TypeMappingContext Empty { get; } =
-        new([], new(SymbolEqualityComparer.Default), new(SymbolEqualityComparer.Default));
+        new(
+            new Dictionary<string, IrBclExport>(),
+            new(SymbolEqualityComparer.Default),
+            new(SymbolEqualityComparer.Default)
+        );
 
-    public Dictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > BclExportMap { get; } = bclExportMap;
+    public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
 
     public Dictionary<ISymbol, CrossAssemblyEntry> CrossAssemblyTypeMap { get; } =
         crossAssemblyTypeMap;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -34,10 +34,7 @@ public sealed class TypeScriptTransformContext(
         string,
         (string Name, string From, bool IsDefault, string? Version)
     > externalImportMap,
-    IReadOnlyDictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > bclExportMap,
+    IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
     PathNaming pathNaming,
     DeclarativeMappingRegistry declarativeMappings,
@@ -53,10 +50,7 @@ public sealed class TypeScriptTransformContext(
         string,
         (string Name, string From, bool IsDefault, string? Version)
     > ExternalImportMap { get; } = externalImportMap;
-    public IReadOnlyDictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > BclExportMap { get; } = bclExportMap;
+    public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
     public IReadOnlyDictionary<string, string> GuardNameToTypeMap { get; } = guardNameToTypeMap;
     public PathNaming PathNaming { get; } = pathNaming;
     public DeclarativeMappingRegistry DeclarativeMappings { get; } = declarativeMappings;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -105,9 +105,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     {
         _currentAssembly = compilation.Assembly;
 
-        // Read [ExportFromBcl] assembly-level attributes
-        LoadBclExportMappings();
-
         // The frontend already detects [assembly: TranspileAssembly] (semantic model
         // first, syntax-tree fallback for inline test compilations) — read it off the
         // IR rather than redoing the same probe.
@@ -161,7 +158,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         var crossPackageMisses = new HashSet<string>();
         var usedCrossPackages = new Dictionary<string, string>();
         var typeMappingContext = new TypeMappingContext(
-            _bclExportMap,
+            ir.BclExports,
             _crossAssemblyTypeMap,
             _assembliesNeedingEmitPackage,
             crossPackageMisses,
@@ -199,7 +196,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             _assemblyWideTranspile,
             _transpilableTypeMap,
             _externalImportMap,
-            _bclExportMap,
+            ir.BclExports,
             _guardNameToTypeMap,
             _pathNaming,
             declarativeMappings,
@@ -283,10 +280,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         string,
         (string Name, string From, bool IsDefault, string? Version)
     > _externalImportMap = [];
-    private Dictionary<
-        string,
-        (string ExportedName, string FromPackage, string Version)
-    > _bclExportMap = [];
 
     /// <summary>
     /// Types discovered in referenced assemblies that declare both
@@ -516,70 +509,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         }
 
         return types;
-    }
-
-    private void LoadBclExportMappings()
-    {
-        _bclExportMap =
-            new Dictionary<string, (string ExportedName, string FromPackage, string Version)>();
-
-        // Read [ExportFromBcl] from the current assembly first, then from every
-        // referenced assembly so that built-in mappings (e.g., decimal → Decimal from
-        // decimal.js, declared in Metano/Runtime/Decimal.cs) flow through without
-        // the user having to redeclare them in their own project. The current assembly
-        // is processed last so user overrides win on conflict.
-        foreach (var reference in compilation.References)
-        {
-            if (
-                compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol asm
-                && !SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly)
-            )
-                LoadBclExportFromAssembly(asm);
-        }
-        LoadBclExportFromAssembly(compilation.Assembly);
-
-        // _bclExportMap is passed to TypeMappingContext by reference — no static needed.
-    }
-
-    private void LoadBclExportFromAssembly(IAssemblySymbol assembly)
-    {
-        foreach (var attr in assembly.GetAttributes())
-        {
-            if (attr.AttributeClass?.Name is not ("ExportFromBclAttribute" or "ExportFromBcl"))
-                continue;
-
-            // Constructor arg is typeof(Type)
-            if (attr.ConstructorArguments.Length == 0)
-                continue;
-            var typeArg = attr.ConstructorArguments[0].Value as INamedTypeSymbol;
-            if (typeArg is null)
-                continue;
-
-            var exportedName = "";
-            var fromPackage = "";
-            var version = "";
-
-            foreach (var namedArg in attr.NamedArguments)
-            {
-                switch (namedArg.Key)
-                {
-                    case "ExportedName":
-                        exportedName = namedArg.Value.Value?.ToString() ?? "";
-                        break;
-                    case "FromPackage":
-                        fromPackage = namedArg.Value.Value?.ToString() ?? "";
-                        break;
-                    case "Version":
-                        version = namedArg.Value.Value?.ToString() ?? "";
-                        break;
-                }
-            }
-
-            if (exportedName.Length > 0)
-            {
-                _bclExportMap[typeArg.ToDisplayString()] = (exportedName, fromPackage, version);
-            }
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Second slice of the consumer-side migration after #67. The TypeScript
pipeline now consumes `ir.BclExports` directly instead of rebuilding
its own copy from `[ExportFromBcl]` attributes.

## Changes

- `TypeMappingContext`, `TypeScriptTransformContext`, `ImportCollector`,
  and `BclExportTypeOverrides` switch their tuple-based storage to
  `IReadOnlyDictionary<string, IrBclExport>`.
- `BclExportTypeOverrides` handles the IR's nullable `Version` property
  (the legacy tuple defaulted to `""`).
- `TypeTransformer` drops `_bclExportMap`, `LoadBclExportMappings`, and
  `LoadBclExportFromAssembly` (~60 lines removed) — the frontend owns
  this map.

Net delta: **+22 / -101** lines. Same data, single producer.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 575/575 ✅
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58