### PR TITLE
refactor(ts): TypeTransformer seeds ExternalImports from IR (Phase B.4.3)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -22,10 +22,7 @@ namespace Metano.Transformation;
 /// </summary>
 public sealed class ImportCollector(
     IReadOnlyDictionary<string, INamedTypeSymbol> transpilableTypeMap,
-    IReadOnlyDictionary<
-        string,
-        (string Name, string From, bool IsDefault, string? Version)
-    > externalImportMap,
+    IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
     PathNaming pathNaming,
@@ -35,10 +32,8 @@ public sealed class ImportCollector(
 {
     private readonly IReadOnlyDictionary<string, INamedTypeSymbol> _transpilableTypeMap =
         transpilableTypeMap;
-    private readonly IReadOnlyDictionary<
-        string,
-        (string Name, string From, bool IsDefault, string? Version)
-    > _externalImportMap = externalImportMap;
+    private readonly IReadOnlyDictionary<string, IrExternalImport> _externalImportMap =
+        externalImportMap;
     private readonly IReadOnlyDictionary<string, IrBclExport> _bclExportMap = bclExportMap;
     private readonly IReadOnlyDictionary<string, string> _guardNameToTypeMap = guardNameToTypeMap;
     private readonly PathNaming _pathNaming = pathNaming;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -30,10 +30,7 @@ public sealed class TypeScriptTransformContext(
     IAssemblySymbol? currentAssembly,
     bool assemblyWideTranspile,
     IReadOnlyDictionary<string, INamedTypeSymbol> transpilableTypeMap,
-    IReadOnlyDictionary<
-        string,
-        (string Name, string From, bool IsDefault, string? Version)
-    > externalImportMap,
+    IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
     PathNaming pathNaming,
@@ -46,10 +43,8 @@ public sealed class TypeScriptTransformContext(
     public bool AssemblyWideTranspile { get; } = assemblyWideTranspile;
     public IReadOnlyDictionary<string, INamedTypeSymbol> TranspilableTypeMap { get; } =
         transpilableTypeMap;
-    public IReadOnlyDictionary<
-        string,
-        (string Name, string From, bool IsDefault, string? Version)
-    > ExternalImportMap { get; } = externalImportMap;
+    public IReadOnlyDictionary<string, IrExternalImport> ExternalImportMap { get; } =
+        externalImportMap;
     public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
     public IReadOnlyDictionary<string, string> GuardNameToTypeMap { get; } = guardNameToTypeMap;
     public PathNaming PathNaming { get; } = pathNaming;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -121,30 +121,32 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                 _transpilableTypeMap[tsName] = t;
         }
 
-        // Register [Import] types as external (no .ts file generated, but importable)
-        _externalImportMap =
-            new Dictionary<string, (string Name, string From, bool IsDefault, string? Version)>();
-        foreach (var t in transpilableTypes.ToList())
+        // Seed the external-import map from the frontend. The IR already covers
+        // current-assembly [Import] types keyed by C# simple name (and emits
+        // MS0003 on collisions before the host merges its diagnostics with ours).
+        // The TS-name aliasing below is a target concern that stays here until
+        // the frontend gains target awareness.
+        _externalImportMap = new Dictionary<string, IrExternalImport>(ir.ExternalImports);
+        foreach (var t in transpilableTypes)
         {
             var import = SymbolHelper.GetImport(t);
-            if (import is not null)
-            {
-                var entry = (import.Name, import.From, import.AsDefault, import.Version);
-                RegisterExternalImportMapping(
-                    t.Name,
-                    entry,
-                    t.ToDisplayString(),
-                    t.Locations.FirstOrDefault()
-                );
-                var tsName = GetTsTypeName(t);
-                if (tsName != t.Name)
-                    RegisterExternalImportMapping(
-                        tsName,
-                        entry,
-                        t.ToDisplayString(),
-                        t.Locations.FirstOrDefault()
-                    );
-            }
+            if (import is null)
+                continue;
+            var tsName = GetTsTypeName(t);
+            if (tsName == t.Name)
+                continue;
+            var entry = new IrExternalImport(
+                Name: import.Name,
+                From: import.From,
+                IsDefault: import.AsDefault,
+                Version: import.Version
+            );
+            RegisterExternalImportMapping(
+                tsName,
+                entry,
+                t.ToDisplayString(),
+                t.Locations.FirstOrDefault()
+            );
         }
 
         // Discover transpilable types from referenced assemblies (those that declare
@@ -276,10 +278,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// </summary>
     private IMethodSymbol? _syntheticEntryPoint;
     private Dictionary<string, INamedTypeSymbol> _transpilableTypeMap = [];
-    private Dictionary<
-        string,
-        (string Name, string From, bool IsDefault, string? Version)
-    > _externalImportMap = [];
+    private Dictionary<string, IrExternalImport> _externalImportMap = [];
 
     /// <summary>
     /// Types discovered in referenced assemblies that declare both
@@ -396,7 +395,12 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                 var import = SymbolHelper.GetImport(type);
                 if (import is not null)
                 {
-                    var entry = (import.Name, import.From, import.AsDefault, import.Version);
+                    var entry = new IrExternalImport(
+                        Name: import.Name,
+                        From: import.From,
+                        IsDefault: import.AsDefault,
+                        Version: import.Version
+                    );
                     RegisterExternalImportMapping(
                         type.Name,
                         entry,
@@ -758,7 +762,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
     private void RegisterExternalImportMapping(
         string key,
-        (string Name, string From, bool IsDefault, string? Version) entry,
+        IrExternalImport entry,
         string ownerDisplayName,
         Location? location
     )

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -125,9 +125,16 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         // current-assembly [Import] types keyed by C# simple name (and emits
         // MS0003 on collisions before the host merges its diagnostics with ours).
         // The TS-name aliasing below is a target concern that stays here until
-        // the frontend gains target awareness.
-        _externalImportMap = new Dictionary<string, IrExternalImport>(ir.ExternalImports);
-        foreach (var t in transpilableTypes)
+        // the frontend gains target awareness — it must walk every public
+        // top-level [Import] type (mirroring the frontend's CollectPublicTopLevelTypes
+        // pass), not just `transpilableTypes`, so an [Import] placeholder
+        // without [Transpile] in a project that does not declare
+        // [assembly: TranspileAssembly] still gets its TS-name alias.
+        _externalImportMap = new Dictionary<string, IrExternalImport>(
+            ir.ExternalImports,
+            StringComparer.Ordinal
+        );
+        foreach (var t in EnumeratePublicTopLevelTypes(compilation.Assembly.GlobalNamespace))
         {
             var import = SymbolHelper.GetImport(t);
             if (import is null)
@@ -449,6 +456,34 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                         && !SymbolHelper.HasNoTranspile(type)
                         && !SymbolHelper.HasNoEmit(type, TargetLanguage.TypeScript):
                     sink.Add(type);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Yields every public top-level type reachable from <paramref name="ns"/>,
+    /// without applying the <c>[NoTranspile]</c> / <c>[NoEmit]</c> filters that
+    /// <see cref="CollectTypesFromNamespace"/> uses for emission discovery.
+    /// Mirrors the frontend's <c>CollectPublicTopLevelTypes</c> walk so the
+    /// TS-name aliasing pass can register every <c>[Import]</c> type the IR
+    /// already covers, including placeholders that the user did not mark with
+    /// <c>[Transpile]</c>.
+    /// </summary>
+    private static IEnumerable<INamedTypeSymbol> EnumeratePublicTopLevelTypes(INamespaceSymbol ns)
+    {
+        foreach (var member in ns.GetMembers())
+        {
+            switch (member)
+            {
+                case INamespaceSymbol childNs:
+                    foreach (var nested in EnumeratePublicTopLevelTypes(childNs))
+                        yield return nested;
+                    break;
+                case INamedTypeSymbol type
+                    when type.ContainingType is null
+                        && type.DeclaredAccessibility == Accessibility.Public:
+                    yield return type;
                     break;
             }
         }


### PR DESCRIPTION
## Summary

Third slice of the consumer-side migration after #68. The TypeScript
pipeline now seeds its `_externalImportMap` from `ir.ExternalImports`
instead of walking transpilable types to rebuild the same entries.

## Changes

- `ImportCollector`, `TypeScriptTransformContext`, and `TypeTransformer`
  switch their tuple-based storage to
  `IReadOnlyDictionary<string, IrExternalImport>`.
  `RegisterExternalImportMapping` now takes an `IrExternalImport`.
- The source-name walk over current-assembly transpilable types goes
  away — the IR already covers it (including the MS0003 collision
  warnings which the host already merges through its diagnostic
  reporter).
- The `[Name(TypeScript)]` alias loop stays in the TS target (still a
  target-specific concern) and so does the cross-assembly `[Import]`
  registration in `DiscoverCrossAssemblyTypes`. Both will move once
  the frontend gains target awareness / cross-assembly external
  imports land in the IR.

## Test plan

- [x] dotnet build Metano.slnx ✅
- [x] dotnet run --project tests/Metano.Tests/ → 575/575 ✅
- [x] dotnet csharpier check . ✅
- [x] Sample regeneration produced byte-identical output

Part of #58