### PR TITLE
refactor(ts): TypeTransformer reads LocalRootNamespace from IR (Phase B.4.5)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
@@ -118,11 +118,4 @@ public sealed class PathNaming(string rootNamespace)
 
         return segments.Length > 0 ? string.Join("/", segments) : "";
     }
-
-    /// <summary>
-    /// Finds the longest common dot-separated namespace prefix across the given list.
-    /// Used to discover the project's root namespace at the start of a transpilation run.
-    /// </summary>
-    public static string FindCommonNamespacePrefix(IReadOnlyList<string> namespaces) =>
-        NamespaceUtilities.FindCommonPrefix(namespaces);
 }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -184,15 +184,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             _guardNameToTypeMap[$"is{tsName}"] = tsName;
         }
 
-        // Detect root namespace (longest common prefix)
-        var namespaces = transpilableTypes
-            .Select(PathNaming.GetNamespace)
-            .Where(ns => ns.Length > 0)
-            .ToList();
-
-        _pathNaming = new PathNaming(
-            namespaces.Count > 0 ? PathNaming.FindCommonNamespacePrefix(namespaces) : ""
-        );
+        _pathNaming = new PathNaming(ir.LocalRootNamespace);
 
         // Read declarative [MapMethod]/[MapProperty] from the current assembly + every
         // referenced assembly. The registry is consulted by BclMapper before its hardcoded

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -2,6 +2,8 @@ using Metano.Annotations;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.MSBuild;
 
 namespace Metano.Compiler;
@@ -131,7 +133,9 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// target-side filter (<see cref="SymbolHelper.IsTranspilable"/>) so the
     /// prefix stays identical to what <c>TypeTransformer</c> used to compute
     /// inline — including internal <c>[Transpile]</c> types that would be
-    /// missed by a public-only walker.
+    /// missed by a public-only walker, and the synthetic Program type that
+    /// <c>TypeTransformer.DiscoverTranspilableTypes</c> injects for C# 9+
+    /// top-level statements under <c>[assembly: TranspileAssembly]</c>.
     /// </summary>
     private static string ComputeLocalRootNamespace(
         Compilation compilation,
@@ -139,7 +143,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     )
     {
         var currentAssembly = compilation.Assembly;
-        var transpilable = new List<INamedTypeSymbol>();
+        var transpilable = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
         CollectTopLevelTypes(
             currentAssembly.GlobalNamespace,
             type =>
@@ -148,7 +152,56 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     transpilable.Add(type);
             }
         );
+
+        if (assemblyWideTranspile && TryGetTopLevelProgramType(compilation, out var programType))
+            transpilable.Add(programType);
+
         return ComputeRootNamespaceFromTypes(transpilable);
+    }
+
+    /// <summary>
+    /// Detects C# 9+ top-level statements and returns the compiler-synthesized
+    /// containing type (usually <c>Program</c>) that <c>TypeTransformer</c>
+    /// treats as transpilable under assembly-wide mode. Returns <c>false</c>
+    /// when there are no global statements, when Roslyn reports no entry
+    /// point, or when the program type opts out via
+    /// <c>[ExportedAsModule]</c>.
+    /// </summary>
+    private static bool TryGetTopLevelProgramType(
+        Compilation compilation,
+        out INamedTypeSymbol programType
+    )
+    {
+        if (compilation is not CSharpCompilation csharpComp)
+        {
+            programType = null!;
+            return false;
+        }
+
+        var hasGlobalStatements = compilation.SyntaxTrees.Any(t =>
+            t.GetRoot().DescendantNodes().OfType<GlobalStatementSyntax>().Any()
+        );
+        if (!hasGlobalStatements)
+        {
+            programType = null!;
+            return false;
+        }
+
+        var entryPoint = csharpComp.GetEntryPoint(CancellationToken.None);
+        if (entryPoint?.ContainingType is not { } containingType)
+        {
+            programType = null!;
+            return false;
+        }
+
+        if (SymbolHelper.HasExportedAsModule(containingType))
+        {
+            programType = null!;
+            return false;
+        }
+
+        programType = containingType;
+        return true;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -99,6 +99,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             );
         }
 
+        var assemblyWideTranspile = compilation is not null && compilation.HasTranspileAssembly();
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -107,7 +109,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     compilation.Assembly,
                     targetEnumValue: (int)EmitTarget.JavaScript
                 ),
-            AssemblyWideTranspile: compilation is not null && compilation.HasTranspileAssembly(),
+            AssemblyWideTranspile: assemblyWideTranspile,
             Modules: Array.Empty<IrModule>(),
             ReferencedModules: Array.Empty<IrModule>(),
             CrossAssemblyOrigins: crossAssemblyOrigins,
@@ -116,8 +118,54 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 ? new Dictionary<string, IrBclExport>(StringComparer.Ordinal)
                 : BuildBclExports(compilation),
             AssembliesNeedingEmitPackage: assembliesNeedingEmitPackage,
-            Diagnostics: diagnostics
+            Diagnostics: diagnostics,
+            LocalRootNamespace: compilation is null
+                ? ""
+                : ComputeLocalRootNamespace(compilation, assemblyWideTranspile)
         );
+    }
+
+    /// <summary>
+    /// Computes the longest common namespace prefix of the transpilable types
+    /// declared in <paramref name="compilation"/>'s own assembly. Mirrors the
+    /// target-side filter (<see cref="SymbolHelper.IsTranspilable"/>) so the
+    /// prefix stays identical to what <c>TypeTransformer</c> used to compute
+    /// inline — including internal <c>[Transpile]</c> types that would be
+    /// missed by a public-only walker.
+    /// </summary>
+    private static string ComputeLocalRootNamespace(
+        Compilation compilation,
+        bool assemblyWideTranspile
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        var transpilable = new List<INamedTypeSymbol>();
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+            {
+                if (SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+                    transpilable.Add(type);
+            }
+        );
+        return ComputeRootNamespaceFromTypes(transpilable);
+    }
+
+    /// <summary>
+    /// Longest common namespace prefix across <paramref name="types"/>,
+    /// skipping types declared in the global namespace so a single
+    /// unnamespaced entry cannot collapse the shared root on its own.
+    /// </summary>
+    private static string ComputeRootNamespaceFromTypes(IEnumerable<INamedTypeSymbol> types)
+    {
+        var namespaces = new List<string>();
+        foreach (var type in types)
+        {
+            if (type.ContainingNamespace.IsGlobalNamespace)
+                continue;
+            namespaces.Add(type.ContainingNamespace.ToDisplayString());
+        }
+        return NamespaceUtilities.FindCommonPrefix(namespaces);
     }
 
     /// <summary>
@@ -172,7 +220,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
 
             var assemblyTypes = new List<INamedTypeSymbol>();
-            CollectPublicTopLevelTypes(asm.GlobalNamespace, assemblyTypes);
+            CollectTopLevelTypes(
+                asm.GlobalNamespace,
+                type =>
+                {
+                    if (type.DeclaredAccessibility == Accessibility.Public)
+                        assemblyTypes.Add(type);
+                }
+            );
 
             // Filter the same way the legacy CollectTypesFromNamespace does — anything
             // that wouldn't be discovered for emission must not influence the assembly
@@ -186,7 +241,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 )
                 .ToList();
 
-            var rootNamespace = ComputeAssemblyRootNamespace(emittedAssemblyTypes);
+            var rootNamespace = ComputeRootNamespaceFromTypes(emittedAssemblyTypes);
 
             foreach (var type in emittedAssemblyTypes)
             {
@@ -202,19 +257,6 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         }
 
         return (origins, needingPackage);
-    }
-
-    private static string ComputeAssemblyRootNamespace(IReadOnlyList<INamedTypeSymbol> types)
-    {
-        var namespaces = new List<string>(types.Count);
-        foreach (var type in types)
-        {
-            if (type.ContainingNamespace.IsGlobalNamespace)
-                continue;
-            namespaces.Add(type.ContainingNamespace.ToDisplayString());
-        }
-
-        return NamespaceUtilities.FindCommonPrefix(namespaces);
     }
 
     /// <summary>
@@ -239,7 +281,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     {
         var map = new Dictionary<string, IrExternalImport>(StringComparer.Ordinal);
         var types = new List<INamedTypeSymbol>();
-        CollectPublicTopLevelTypes(compilation.Assembly.GlobalNamespace, types);
+        CollectTopLevelTypes(
+            compilation.Assembly.GlobalNamespace,
+            type =>
+            {
+                if (type.DeclaredAccessibility == Accessibility.Public)
+                    types.Add(type);
+            }
+        );
 
         foreach (var type in types)
         {
@@ -279,19 +328,26 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         return map;
     }
 
-    private static void CollectPublicTopLevelTypes(INamespaceSymbol ns, List<INamedTypeSymbol> sink)
+    /// <summary>
+    /// Recursively walks every top-level type (i.e. non-nested) declared
+    /// under <paramref name="ns"/>, regardless of accessibility, and
+    /// passes each to <paramref name="visit"/>. Callers that only want
+    /// public types (BCL-wide transpile, cross-assembly emission) filter
+    /// via the visitor; callers that need to see internal
+    /// <c>[Transpile]</c> types (local root-namespace computation) leave
+    /// the visitor unfiltered.
+    /// </summary>
+    private static void CollectTopLevelTypes(INamespaceSymbol ns, Action<INamedTypeSymbol> visit)
     {
         foreach (var member in ns.GetMembers())
         {
             switch (member)
             {
                 case INamespaceSymbol childNs:
-                    CollectPublicTopLevelTypes(childNs, sink);
+                    CollectTopLevelTypes(childNs, visit);
                     break;
-                case INamedTypeSymbol type
-                    when type.ContainingType is null
-                        && type.DeclaredAccessibility == Accessibility.Public:
-                    sink.Add(type);
+                case INamedTypeSymbol type when type.ContainingType is null:
+                    visit(type);
                     break;
             }
         }

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -80,5 +80,5 @@ public sealed record IrCompilation(
     IReadOnlyDictionary<string, IrBclExport> BclExports,
     IReadOnlySet<string> AssembliesNeedingEmitPackage,
     IReadOnlyList<MetanoDiagnostic> Diagnostics,
-    string LocalRootNamespace
+    string LocalRootNamespace = ""
 );

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -59,6 +59,16 @@ namespace Metano.Compiler.IR;
 /// <param name="Diagnostics">Diagnostics raised during extraction (e.g.,
 /// conflicts in <c>[EmitInFile]</c> groupings, malformed
 /// <c>[Import]</c> attributes).</param>
+/// <param name="LocalRootNamespace">Longest common namespace prefix of the
+/// transpilable types declared in the source unit, or the empty string when
+/// no types qualify (or when they span unrelated top-level namespaces).
+/// Backends that lay generated files out on disk use this as the root of
+/// the output tree, stripping it from per-type namespaces so relative paths
+/// stay short. This value is target-agnostic provided the target uses
+/// dot-separated namespace segments for file-system layout (TypeScript,
+/// Dart). Targets using alternate layout schemes must compute their own
+/// root independently. Appended at the end of the record so adding new
+/// state cannot shift downstream positional arguments.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -69,5 +79,6 @@ public sealed record IrCompilation(
     IReadOnlyDictionary<string, IrExternalImport> ExternalImports,
     IReadOnlyDictionary<string, IrBclExport> BclExports,
     IReadOnlySet<string> AssembliesNeedingEmitPackage,
-    IReadOnlyList<MetanoDiagnostic> Diagnostics
+    IReadOnlyList<MetanoDiagnostic> Diagnostics,
+    string LocalRootNamespace
 );

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -433,4 +433,167 @@ public class CSharpSourceFrontendTests
         await Assert.That(warning!.Message).Contains("Widget");
         await Assert.That(warning.Message).Contains("beta-pkg");
     }
+
+    [Test]
+    public async Task LocalRootNamespace_EmptyWhenNoTranspilableTypes()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            public class NotMarked {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_ReturnsSingleNamespaceWhenOnlyOneInUse()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                public class Money {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared.Domain");
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_ReturnsLongestCommonPrefixAcrossNamespaces()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                public class Money {}
+            }
+
+            namespace Acme.Shared.Services
+            {
+                [Transpile]
+                public class PaymentProcessor {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared");
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_IgnoresNoTranspileAndNoEmit()
+    {
+        // [NoTranspile] / [NoEmit] types live under a wildly different
+        // namespace. If the filter leaked them, the common prefix would
+        // collapse to the empty string.
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                public class Money {}
+            }
+
+            namespace Unrelated.Zeta
+            {
+                [NoTranspile]
+                public class Ignored {}
+
+                [NoEmit]
+                public class Ambient {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared.Domain");
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_AssemblyWideSkipsNonPublicTypes()
+    {
+        // Assembly-wide mode only transpiles public types; an `internal`
+        // type in an unrelated namespace must not collapse the prefix.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            namespace Acme.Shared
+            {
+                public class Money {}
+            }
+
+            namespace Unrelated.Zeta
+            {
+                internal class Hidden {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared");
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_ExplicitTranspileIncludesInternalTypes()
+    {
+        // [Transpile] overrides the public-only gate, so an internal type
+        // decorated with it must count towards the prefix — matching the
+        // target-side IsTranspilable semantics.
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                internal class Money {}
+            }
+
+            namespace Acme.Shared.Services
+            {
+                [Transpile]
+                public class PaymentProcessor {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared");
+    }
+
+    [Test]
+    public async Task LocalRootNamespace_SkipsGlobalNamespaceTypes()
+    {
+        // A transpilable type declared directly in the global namespace
+        // has no segments to contribute; the prefix is driven purely by
+        // the namespaced transpilable types.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Marker {}
+
+            namespace Acme.Shared.Domain
+            {
+                [Transpile]
+                public class Money {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared.Domain");
+    }
 }

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -574,6 +574,33 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
+    public async Task LocalRootNamespace_IncludesSyntheticProgramFromTopLevelStatements()
+    {
+        // C# 9+ top-level statements inside a namespace compile into a
+        // synthesized `Program` type under that namespace. TypeTransformer
+        // treats it as transpilable under [assembly: TranspileAssembly];
+        // the frontend must contribute its namespace to the common prefix
+        // so the generated file layout matches.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            System.Console.WriteLine("hello");
+
+            namespace Acme.Shared.Services
+            {
+                public class Marker {}
+            }
+            """,
+            outputKind: Microsoft.CodeAnalysis.OutputKind.ConsoleApplication
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared.Services");
+    }
+
+    [Test]
     public async Task LocalRootNamespace_SkipsGlobalNamespaceTypes()
     {
         // A transpilable type declared directly in the global namespace

--- a/tests/Metano.Tests/IR/IrTestHelper.cs
+++ b/tests/Metano.Tests/IR/IrTestHelper.cs
@@ -42,7 +42,10 @@ public static class IrTestHelper
         return IrTypeRefMapper.Map(type);
     }
 
-    public static CSharpCompilation Compile(string csharpSource)
+    public static CSharpCompilation Compile(
+        string csharpSource,
+        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary
+    )
     {
         var source = $"""
             using System;
@@ -63,7 +66,7 @@ public static class IrTestHelper
             "TestAssembly",
             [syntaxTree],
             TranspileHelper.BaseReferences,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            new CSharpCompilationOptions(outputKind)
         );
 
         var errors = compilation


### PR DESCRIPTION
## Summary

Fifth slice of the consumer-side migration after #70. The TypeScript pipeline now consumes `ir.LocalRootNamespace` directly instead of rebuilding the longest-common-namespace prefix in `TransformAll`.

## Changes

- **`IrCompilation`** — adds `LocalRootNamespace` as the last positional parameter (appended, not inserted, so future additions cannot shift downstream positional arguments). The XML doc spells out the target-agnostic assumption (dot-separated namespace segments, which both TypeScript and Dart honor).
- **`CSharpSourceFrontend`** — `BuildIrCompilation` runs `ComputeLocalRootNamespace` once per extraction. The new helper mirrors the target-side `SymbolHelper.IsTranspilable` filter, including internal `[Transpile]` types that a public-only walker would miss. A shared `ComputeRootNamespaceFromTypes(IEnumerable<INamedTypeSymbol>)` replaces the old private `ComputeAssemblyRootNamespace` and is reused for the cross-assembly path.
- **`CollectTopLevelTypes`** — unifies the two previous walkers (`CollectPublicTopLevelTypes` is gone). Callers that need a public-only view filter inline via the visitor, so the traversal code lives in a single place.
- **`TypeTransformer`** — drops the `transpilableTypes → namespaces → FindCommonNamespacePrefix` block in favour of `new PathNaming(ir.LocalRootNamespace)`. The dead `PathNaming.FindCommonNamespacePrefix` wrapper over `NamespaceUtilities.FindCommonPrefix` is deleted.
- **Tests** — seven new frontend cases cover the relevant shapes (empty project, single namespace, common prefix across namespaces, `[NoTranspile]`/`[NoEmit]` exclusion, assembly-wide public filter, explicit `[Transpile]` on an internal type, global-namespace types).

Net delta: **+256 / -41**. No functional change.

## Test plan

- [x] dotnet build Metano.slnx
- [x] dotnet run --project tests/Metano.Tests/ → 582/582
- [x] dotnet csharpier check .
- [x] Sample regeneration produced byte-identical output for sample-todo, sample-todo-service, sample-issue-tracker, and flutter/sample_counter

Part of #58