### PR TITLE
refactor(ts): frontend aggregates cross-assembly [Import] types (Phase B.4.6)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -121,15 +121,17 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                 _transpilableTypeMap[tsName] = t;
         }
 
-        // Seed the external-import map from the frontend. The IR already covers
-        // every [Import] type (local + cross-assembly) keyed by C# simple name,
-        // with MS0003 collisions surfaced through the host's diagnostic merge.
-        // The TS-name aliasing below is a target concern that stays here until
-        // the frontend gains target awareness — it must walk every public
-        // top-level [Import] type (mirroring the frontend's walker), not just
-        // `transpilableTypes`, so an [Import] placeholder without [Transpile]
-        // in a project that does not declare [assembly: TranspileAssembly]
-        // still gets its TS-name alias.
+        // Seed the external-import map from the frontend. The IR covers every
+        // [Import] type from the current assembly, plus those from referenced
+        // assemblies that opt into transpilation ([TranspileAssembly]) and
+        // declare an [EmitPackage] for the active target — keyed by C# simple
+        // name, with MS0003 collisions surfaced through the host's diagnostic
+        // merge. The TS-name aliasing below is a target concern that stays
+        // here until the frontend gains target awareness — it must walk every
+        // public top-level [Import] type (mirroring the frontend's walker),
+        // not just `transpilableTypes`, so an [Import] placeholder without
+        // [Transpile] in a project that does not declare
+        // [assembly: TranspileAssembly] still gets its TS-name alias.
         _externalImportMap = new Dictionary<string, IrExternalImport>(
             ir.ExternalImports,
             StringComparer.Ordinal

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -122,14 +122,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         }
 
         // Seed the external-import map from the frontend. The IR already covers
-        // current-assembly [Import] types keyed by C# simple name (and emits
-        // MS0003 on collisions before the host merges its diagnostics with ours).
+        // every [Import] type (local + cross-assembly) keyed by C# simple name,
+        // with MS0003 collisions surfaced through the host's diagnostic merge.
         // The TS-name aliasing below is a target concern that stays here until
         // the frontend gains target awareness — it must walk every public
-        // top-level [Import] type (mirroring the frontend's CollectPublicTopLevelTypes
-        // pass), not just `transpilableTypes`, so an [Import] placeholder
-        // without [Transpile] in a project that does not declare
-        // [assembly: TranspileAssembly] still gets its TS-name alias.
+        // top-level [Import] type (mirroring the frontend's walker), not just
+        // `transpilableTypes`, so an [Import] placeholder without [Transpile]
+        // in a project that does not declare [assembly: TranspileAssembly]
+        // still gets its TS-name alias.
         _externalImportMap = new Dictionary<string, IrExternalImport>(
             ir.ExternalImports,
             StringComparer.Ordinal
@@ -308,14 +308,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// <summary>
     /// Walks <see cref="Compilation.References"/> and, for each referenced assembly that
     /// declares <em>both</em> <c>[TranspileAssembly]</c> and <c>[EmitPackage(JavaScript)]</c>,
-    /// enumerates its public types and augments <see cref="_externalImportMap"/> with
-    /// any <c>[Import]</c> declarations from those assemblies so consumers can
-    /// transitively reach external bindings declared in a referenced library.
-    /// The non-<c>[Import]</c> cross-assembly origin map is produced by the frontend
-    /// (<see cref="IrCompilation.CrossAssemblyOrigins"/>) and consumed via
-    /// <see cref="TypeMappingContext.CrossAssemblyOrigins"/>; this method stays
-    /// target-specific until the frontend also emits cross-assembly external
-    /// imports keyed by both source and target name.
+    /// registers the TS-name alias for any <c>[Import]</c>-annotated type whose
+    /// <c>[Name(TypeScript)]</c> override differs from the C# source name. The
+    /// C#-source-name keys for cross-assembly <c>[Import]</c> types are produced
+    /// by the frontend via <see cref="IrCompilation.ExternalImports"/>; the
+    /// non-<c>[Import]</c> cross-assembly origin map is likewise frontend-built
+    /// (<see cref="IrCompilation.CrossAssemblyOrigins"/>), so this pass stays
+    /// target-specific only because <c>[Name(TypeScript)]</c> resolution needs
+    /// the active target's naming policy.
     /// </summary>
     private void DiscoverCrossAssemblyTypes()
     {
@@ -323,14 +323,9 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         {
             if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
                 continue;
-            // Skip the assembly currently being compiled.
             if (SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly))
                 continue;
 
-            // Cheap filter: only consider assemblies that opt into transpilation
-            // and have an EmitPackage for the active target — assemblies without
-            // EmitPackage are already surfaced in ir.AssembliesNeedingEmitPackage,
-            // and types they expose are not importable.
             var hasTranspileAssembly = asm.GetAttributes()
                 .Any(a =>
                     a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
@@ -347,13 +342,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             var assemblyTypes = new List<INamedTypeSymbol>();
             CollectTypesFromNamespace(asm.GlobalNamespace, assemblyTypes);
 
-            // Register cross-assembly [Import] types. The cross-assembly origin
-            // map for non-[Import] types is now produced by the frontend and read
-            // off the IR via TypeMappingContext.CrossAssemblyOrigins.
             foreach (var type in assemblyTypes)
             {
                 var import = SymbolHelper.GetImport(type);
                 if (import is null)
+                    continue;
+
+                var tsName = GetTsTypeName(type);
+                if (tsName == type.Name)
                     continue;
 
                 var entry = new IrExternalImport(
@@ -363,19 +359,11 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                     Version: import.Version
                 );
                 RegisterExternalImportMapping(
-                    type.Name,
+                    tsName,
                     entry,
                     type.ToDisplayString(),
                     type.Locations.FirstOrDefault()
                 );
-                var tsName = GetTsTypeName(type);
-                if (tsName != type.Name)
-                    RegisterExternalImportMapping(
-                        tsName,
-                        entry,
-                        type.ToDisplayString(),
-                        type.Locations.FirstOrDefault()
-                    );
             }
         }
     }

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -248,30 +248,13 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         var origins = new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal);
         var needingPackage = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var reference in compilation.References)
+        foreach (
+            var (asm, packageInfo) in EnumerateTranspilableReferencedAssemblies(
+                compilation,
+                onTranspilableWithoutEmitPackage: name => needingPackage.Add(name)
+            )
+        )
         {
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
-                continue;
-            if (SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly))
-                continue;
-
-            var hasTranspileAssembly = asm.GetAttributes()
-                .Any(a =>
-                    a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
-                );
-            if (!hasTranspileAssembly)
-                continue;
-
-            var packageInfo = SymbolHelper.GetEmitPackageInfo(
-                asm,
-                targetEnumValue: (int)EmitTarget.JavaScript
-            );
-            if (packageInfo is null)
-            {
-                needingPackage.Add(asm.Name);
-                continue;
-            }
-
             var assemblyTypes = new List<INamedTypeSymbol>();
             CollectTopLevelTypes(
                 asm.GlobalNamespace,
@@ -313,19 +296,23 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     }
 
     /// <summary>
-    /// Walks every public top-level type in the current compilation and
-    /// surfaces those carrying <c>[Import("name", from)]</c> as
-    /// <see cref="IrExternalImport"/> entries keyed by the C# type's simple
-    /// source name. This intentionally covers only the source-name keys for
-    /// the local assembly that the legacy
-    /// <c>TypeTransformer._externalImportMap</c> exposed; cross-assembly
-    /// <c>[Import]</c> aggregation and per-target <c>[Name]</c> aliasing
-    /// remain on the consumer side until later migration steps wire them
-    /// through the IR. Mirrors the legacy
-    /// <c>TypeTransformer.RegisterExternalImportMapping</c> conflict policy:
-    /// the first mapping wins and any divergent re-registration produces a
+    /// Walks every public top-level type in the current compilation plus
+    /// every referenced assembly that opted into transpilation
+    /// (<c>[TranspileAssembly]</c>) and declared an <c>[EmitPackage]</c>
+    /// for the active target, surfacing those carrying
+    /// <c>[Import("name", from)]</c> as <see cref="IrExternalImport"/>
+    /// entries keyed by the C# type's simple source name. The local
+    /// assembly is walked first so on collision its entry wins, matching
+    /// the legacy ordering in
+    /// <c>TypeTransformer.DiscoverCrossAssemblyTypes</c>. Per-target
+    /// <c>[Name]</c> aliasing remains on the consumer side until later
+    /// migration steps wire it through the IR.
+    /// <para>
+    /// Conflict policy: first mapping wins and any divergent
+    /// re-registration produces a
     /// <see cref="DiagnosticCodes.AmbiguousConstruct"/> warning surfaced
     /// through <see cref="IrCompilation.Diagnostics"/>.
+    /// </para>
     /// </summary>
     private static Dictionary<string, IrExternalImport> BuildExternalImports(
         Compilation compilation,
@@ -333,52 +320,116 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     )
     {
         var map = new Dictionary<string, IrExternalImport>(StringComparer.Ordinal);
-        var types = new List<INamedTypeSymbol>();
-        CollectTopLevelTypes(
-            compilation.Assembly.GlobalNamespace,
-            type =>
-            {
-                if (type.DeclaredAccessibility == Accessibility.Public)
-                    types.Add(type);
-            }
-        );
 
-        foreach (var type in types)
-        {
-            var import = SymbolHelper.GetImport(type);
-            if (import is null)
-                continue;
+        AddImportsFromAssembly(compilation.Assembly, map, diagnostics);
 
-            var entry = new IrExternalImport(
-                Name: import.Name,
-                From: import.From,
-                IsDefault: import.AsDefault,
-                Version: import.Version
-            );
-
-            if (map.TryGetValue(type.Name, out var existing))
-            {
-                if (existing == entry)
-                    continue;
-
-                diagnostics.Add(
-                    new MetanoDiagnostic(
-                        MetanoDiagnosticSeverity.Warning,
-                        DiagnosticCodes.AmbiguousConstruct,
-                        $"External import name collision for '{type.Name}'. Keeping "
-                            + $"'{existing.From}' ('{existing.Name}') and ignoring "
-                            + $"conflicting mapping from '{type.ToDisplayString()}' to "
-                            + $"'{entry.From}' ('{entry.Name}').",
-                        type.Locations.FirstOrDefault()
-                    )
-                );
-                continue;
-            }
-
-            map[type.Name] = entry;
-        }
+        foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation))
+            AddImportsFromAssembly(asm, map, diagnostics);
 
         return map;
+    }
+
+    /// <summary>
+    /// Yields every referenced assembly (excluding the one being compiled)
+    /// that opted into transpilation via <c>[TranspileAssembly]</c> and
+    /// declared an <c>[EmitPackage]</c> for the active target. When
+    /// <paramref name="onTranspilableWithoutEmitPackage"/> is supplied it
+    /// receives the metadata name of every assembly that opted in but
+    /// omitted <c>[EmitPackage]</c> — callers that need to surface that
+    /// case (MS0007 bookkeeping in
+    /// <see cref="BuildCrossAssemblyState"/>) pass a collector; callers
+    /// that just want the fully-configured set (import aggregation) leave
+    /// it null.
+    /// </summary>
+    private static IEnumerable<(
+        IAssemblySymbol Assembly,
+        SymbolHelper.EmitPackageInfo PackageInfo
+    )> EnumerateTranspilableReferencedAssemblies(
+        Compilation compilation,
+        Action<string>? onTranspilableWithoutEmitPackage = null
+    )
+    {
+        foreach (var reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
+                continue;
+            if (SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly))
+                continue;
+
+            var hasTranspileAssembly = asm.GetAttributes()
+                .Any(a =>
+                    a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
+                );
+            if (!hasTranspileAssembly)
+                continue;
+
+            var packageInfo = SymbolHelper.GetEmitPackageInfo(
+                asm,
+                targetEnumValue: (int)EmitTarget.JavaScript
+            );
+            if (packageInfo is null)
+            {
+                onTranspilableWithoutEmitPackage?.Invoke(asm.Name);
+                continue;
+            }
+
+            yield return (asm, packageInfo);
+        }
+    }
+
+    /// <summary>
+    /// Walks <paramref name="assembly"/>'s public top-level types and
+    /// registers any <c>[Import]</c>-annotated entry into
+    /// <paramref name="map"/> under the C# source name. Mirrors the
+    /// legacy <c>TypeTransformer.RegisterExternalImportMapping</c>
+    /// conflict policy (first mapping wins; collisions produce MS0003).
+    /// </summary>
+    private static void AddImportsFromAssembly(
+        IAssemblySymbol assembly,
+        Dictionary<string, IrExternalImport> map,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        CollectTopLevelTypes(
+            assembly.GlobalNamespace,
+            type =>
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public)
+                    return;
+
+                var import = SymbolHelper.GetImport(type);
+                if (import is null)
+                    return;
+
+                var entry = new IrExternalImport(
+                    Name: import.Name,
+                    From: import.From,
+                    IsDefault: import.AsDefault,
+                    Version: import.Version
+                );
+
+                if (map.TryGetValue(type.Name, out var existing))
+                {
+                    if (existing == entry)
+                        return;
+
+                    diagnostics.Add(
+                        new MetanoDiagnostic(
+                            MetanoDiagnosticSeverity.Warning,
+                            DiagnosticCodes.AmbiguousConstruct,
+                            $"External import name collision for '{type.Name}'. Keeping "
+                                + $"'{existing.From}' ('{existing.Name}') and ignoring "
+                                + $"conflicting mapping from '{type.ToDisplayString()}' to "
+                                + $"'{entry.From}' ('{entry.Name}').",
+                            type.Locations.FirstOrDefault()
+                        )
+                    );
+                    return;
+                }
+
+                map[type.Name] = entry;
+            }
+        );
     }
 
     /// <summary>

--- a/tests/Metano.Tests/CrossPackageImportTests.cs
+++ b/tests/Metano.Tests/CrossPackageImportTests.cs
@@ -314,16 +314,17 @@ public class CrossPackageImportTests
         var libCompilation = TranspileHelper.CompileLibrary(library);
         var consumerCompilation = TranspileHelper.CompileConsumer(consumer, libCompilation);
 
-        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
+        var (ir, transformer) = TranspileHelper.NewTransformerWithIr(consumerCompilation);
         var files = transformer.TransformAll();
         var printer = new Printer();
         var output = printer.Print(files.Single(f => f.FileName == "app.ts"));
 
         await Assert.That(output).Contains("import { Moment } from \"local-moment\"");
         await Assert.That(output).DoesNotContain("shared-moment");
+        var mergedDiagnostics = ir.Diagnostics.Concat(transformer.Diagnostics);
         await Assert
             .That(
-                transformer.Diagnostics.Any(d =>
+                mergedDiagnostics.Any(d =>
                     d.Code == DiagnosticCodes.AmbiguousConstruct
                     && d.Message.Contains("Moment")
                     && d.Message.Contains("local-moment")
@@ -373,12 +374,13 @@ public class CrossPackageImportTests
             libBCompilation
         );
 
-        var transformer = TranspileHelper.NewTransformer(consumerCompilation);
+        var (ir, transformer) = TranspileHelper.NewTransformerWithIr(consumerCompilation);
         transformer.TransformAll();
 
+        var mergedDiagnostics = ir.Diagnostics.Concat(transformer.Diagnostics);
         await Assert
             .That(
-                transformer.Diagnostics.Any(d =>
+                mergedDiagnostics.Any(d =>
                     d.Code == DiagnosticCodes.AmbiguousConstruct && d.Message.Contains("Moment")
                 )
             )

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -435,6 +435,158 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
+    public async Task ExternalImports_IncludesCrossAssemblyEntriesByCSharpName()
+    {
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("acme-shared")]
+
+            namespace Acme.Shared.External
+            {
+                [Import("Hono", from: "hono")]
+                public class HonoStub {}
+            }
+            """,
+            assemblyName: "AcmeShared"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("HonoStub");
+        var entry = ir.ExternalImports["HonoStub"];
+        await Assert.That(entry.Name).IsEqualTo("Hono");
+        await Assert.That(entry.From).IsEqualTo("hono");
+    }
+
+    [Test]
+    public async Task ExternalImports_SkipsReferencesWithoutTranspileAssembly()
+    {
+        // A plain C# library without [TranspileAssembly] must NOT contribute
+        // its [Import] types to the consumer — even if an npm package happens
+        // to exist — so unrelated libraries cannot leak bindings.
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            namespace Plain.Library
+            {
+                [Import("Ghost", from: "ghost-pkg")]
+                public class Ghost {}
+            }
+            """,
+            assemblyName: "PlainLib"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        await Assert.That(ir.ExternalImports.ContainsKey("Ghost")).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternalImports_SkipsReferencesWithoutEmitPackage()
+    {
+        // A library that opts into transpilation but omits [EmitPackage]
+        // for the active target is already flagged via
+        // AssembliesNeedingEmitPackage — its [Import] types must not leak
+        // either so the consumer does not quietly pick up half-configured
+        // bindings.
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+
+            namespace Orphan.Library
+            {
+                [Import("Ghost", from: "ghost-pkg")]
+                public class Ghost {}
+            }
+            """,
+            assemblyName: "OrphanLib"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        await Assert.That(ir.ExternalImports.ContainsKey("Ghost")).IsFalse();
+        await Assert.That(ir.AssembliesNeedingEmitPackage).Contains("OrphanLib");
+    }
+
+    [Test]
+    public async Task ExternalImports_LocalEntryWinsOverCrossAssemblyCollision()
+    {
+        // Two [Import("Widget", ...)] attributes collide on the simple name
+        // "Widget" — one in the consumer, one in a transpilable library.
+        // The local mapping must win regardless of enumeration order, so
+        // the consumer can always override bindings shipped by a library.
+        var lib = TranspileHelper.CompileLibrary(
+            """
+            using Metano.Annotations;
+
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("acme-lib")]
+
+            namespace Acme.Lib
+            {
+                [Import("Widget", from: "lib-widget")]
+                public class Widget {}
+            }
+            """,
+            assemblyName: "AcmeLib"
+        );
+
+        var consumer = TranspileHelper.CompileConsumer(
+            """
+            [Import("Widget", from: "local-widget")]
+            public class Widget {}
+
+            [Transpile]
+            public class Marker {}
+            """,
+            lib
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(consumer);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("Widget");
+        var entry = ir.ExternalImports["Widget"];
+        await Assert.That(entry.From).IsEqualTo("local-widget");
+
+        var warning = ir.Diagnostics.SingleOrDefault(d =>
+            d.Code == DiagnosticCodes.AmbiguousConstruct && d.Message.Contains("Widget")
+        );
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!.Message).Contains("local-widget");
+        await Assert.That(warning.Message).Contains("lib-widget");
+    }
+
+    [Test]
     public async Task LocalRootNamespace_EmptyWhenNoTranspilableTypes()
     {
         var compilation = IrTestHelper.Compile(

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -1,5 +1,6 @@
 using Metano.Annotations;
 using Metano.Compiler;
+using Metano.Compiler.IR;
 using Metano.Transformation;
 using Metano.TypeScript;
 using Microsoft.CodeAnalysis;
@@ -106,7 +107,23 @@ public static class TranspileHelper
     /// extraction boilerplate.
     /// </summary>
     public static TypeTransformer NewTransformer(CSharpCompilation compilation) =>
-        new(new CSharpSourceFrontend().ExtractFromCompilation(compilation), compilation);
+        NewTransformerWithIr(compilation).Transformer;
+
+    /// <summary>
+    /// Variant of <see cref="NewTransformer"/> that also returns the
+    /// <see cref="IrCompilation"/> produced by the frontend. Tests that
+    /// inspect diagnostics raised during extraction (for example, cross-
+    /// assembly <c>[Import]</c> collisions) merge <c>ir.Diagnostics</c>
+    /// with <c>transformer.Diagnostics</c> to see what the host would
+    /// ultimately report.
+    /// </summary>
+    public static (IrCompilation Ir, TypeTransformer Transformer) NewTransformerWithIr(
+        CSharpCompilation compilation
+    )
+    {
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        return (ir, new TypeTransformer(ir, compilation));
+    }
 
     private static (
         Dictionary<string, string> Files,


### PR DESCRIPTION
## Summary

Sixth slice of the consumer-side migration after #71. The C# frontend now owns cross-assembly `[Import]` aggregation; the TypeScript target keeps only the TS-name aliasing pass that cannot move until the frontend gains target awareness.

## Changes

- **`CSharpSourceFrontend.BuildExternalImports`** — now walks both the current assembly and every referenced transpilable assembly (with `[TranspileAssembly]` + `[EmitPackage(JS)]`) and registers every `[Import]` entry by C# source name. Local assembly is walked first so on name collision it wins, matching the legacy ordering in `TypeTransformer.DiscoverCrossAssemblyTypes`.
- **`EnumerateTranspilableReferencedAssemblies`** — new private helper that factors out the shared reference-filter loop so `BuildCrossAssemblyState` and `BuildExternalImports` no longer duplicate the `[TranspileAssembly]` + `[EmitPackage]` scan. Optional `onTranspilableWithoutEmitPackage` callback surfaces transpile-without-emit-package names so the MS0007 bookkeeping stays centralized.
- **`TypeTransformer.DiscoverCrossAssemblyTypes`** — drops the C#-source-name registration; its sole job is now the TS-name alias pass for types whose `[Name(TypeScript)]` override differs from the C# name. The transformer still seeds `_externalImportMap` from `ir.ExternalImports`.
- **`TranspileHelper.NewTransformerWithIr`** — returns the `(IrCompilation, TypeTransformer)` pair so tests that inspect frontend diagnostics can merge `ir.Diagnostics` with `transformer.Diagnostics` without re-implementing the extraction boilerplate.
- **`CrossPackageImportTests`** — two collision-detection tests now consume the new helper and merge the two diagnostic sources explicitly.
- **Frontend tests** — four new cases cover cross-assembly `[Import]` aggregation: happy path, skipped when the library lacks `[TranspileAssembly]`, skipped when it lacks `[EmitPackage]`, and local entry wins over a cross-assembly collision.

Net delta: **+315 / -105**. No functional change.

## Test plan

- [x] dotnet build Metano.slnx
- [x] dotnet run --project tests/Metano.Tests/ → 587/587
- [x] dotnet csharpier check .
- [x] Sample regeneration produced byte-identical output for sample-todo, sample-todo-service, sample-issue-tracker, and flutter/sample_counter

Part of #58