### PR TITLE
refactor(core): frontend owns declarative BCL mappings (Phase B.4.7)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRegistry.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRegistry.cs
@@ -31,6 +31,10 @@ public sealed class DeclarativeMappingRegistry
     > _propertiesByFullName;
     private readonly IReadOnlyDictionary<string, IReadOnlySet<string>> _chainMethodsByWrapper;
 
+    // Returned by GetChainMethodNames on a miss so the hot wrap-receiver
+    // detection path does not allocate a fresh HashSet every call.
+    private static readonly IReadOnlySet<string> EmptyChainMethods = new HashSet<string>();
+
     private DeclarativeMappingRegistry(
         IReadOnlyDictionary<
             (string, string),
@@ -80,9 +84,7 @@ public sealed class DeclarativeMappingRegistry
     /// of these names, no re-wrapping is needed.
     /// </summary>
     public IReadOnlySet<string> GetChainMethodNames(string wrapReceiver) =>
-        _chainMethodsByWrapper.TryGetValue(wrapReceiver, out var set)
-            ? set
-            : (IReadOnlySet<string>)new HashSet<string>();
+        _chainMethodsByWrapper.TryGetValue(wrapReceiver, out var set) ? set : EmptyChainMethods;
 
     /// <summary>
     /// Test-only factory: builds a registry directly from hand-written

--- a/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRegistry.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRegistry.cs
@@ -1,130 +1,83 @@
-using Metano.Compiler;
-using Microsoft.CodeAnalysis;
+using Metano.Compiler.IR;
 
 namespace Metano.Transformation;
 
 /// <summary>
-/// One declarative mapping entry from <c>[MapMethod]</c> or <c>[MapProperty]</c>.
-/// Either <see cref="JsName"/> (simple rename) or <see cref="JsTemplate"/> is set, never
-/// both. The reader enforces the mutual exclusivity at registration time.
+/// IR-driven index of declarative BCL mappings surfaced through
+/// <see cref="IrCompilation.DeclarativeMethodMappings"/> /
+/// <see cref="IrCompilation.DeclarativePropertyMappings"/> /
+/// <see cref="IrCompilation.ChainMethodsByWrapper"/>. Built once per
+/// transpile run by <see cref="CSharpSourceFrontend"/> from
+/// <c>[assembly: MapMethod]</c> / <c>[assembly: MapProperty]</c>
+/// attributes on the current and referenced assemblies, consumed by the
+/// TypeScript target's <c>IrToTsBclMapper</c> before its hardcoded
+/// lowering rules.
 ///
-/// <see cref="WhenArg0StringEquals"/> is an optional literal-argument filter: when set,
-/// the entry only matches a call site whose first argument is a TS string literal with
-/// that exact value. Used for literal-aware lowering like <c>Guid.ToString("N")</c>.
-///
-/// <see cref="WrapReceiver"/> is an optional source-receiver wrapping spec: when set,
-/// the call site's receiver is rewritten to <c>WrapReceiver(source)</c> before the
-/// rename/template is applied, unless the receiver is already a chained call from the
-/// same wrapper (LINQ-style). See <see cref="MapMethodAttribute.WrapReceiver"/>.
-///
-/// <see cref="RuntimeImports"/> is an optional runtime-helper identifier the lowered
-/// call site needs imported from <c>metano-runtime</c>. Forwarded to the
-/// generated <see cref="TsTemplate"/> so the import collector can pick it up — the
-/// template body is otherwise opaque text from the walker's perspective.
-/// </summary>
-public sealed record DeclarativeMappingEntry(
-    string? JsName,
-    string? JsTemplate,
-    string? WhenArg0StringEquals = null,
-    string? WrapReceiver = null,
-    string? RuntimeImports = null
-)
-{
-    public bool HasTemplate => JsTemplate is not null;
-
-    public bool HasArgFilter => WhenArg0StringEquals is not null;
-
-    public bool HasWrapReceiver => WrapReceiver is not null;
-
-    // Parsed once per entry and reused across every call-site that expands it —
-    // template-based mappings are hit many times per compilation.
-    private IReadOnlyList<string>? _runtimeImportsList;
-
-    /// <summary>
-    /// Parsed runtime imports (comma-separated identifier list in
-    /// <see cref="RuntimeImports"/>). Empty when the raw value is null/blank.
-    /// </summary>
-    public IReadOnlyList<string> RuntimeImportsList =>
-        _runtimeImportsList ??= DeclarativeMappingRendering.SplitRuntimeImports(RuntimeImports);
-}
-
-/// <summary>
-/// Index of declarative BCL mappings collected from all <c>[assembly: MapMethod]</c> and
-/// <c>[assembly: MapProperty]</c> attributes visible to a Roslyn <see cref="Compilation"/>
-/// (the current assembly + every referenced assembly).
-///
-/// Built once during <see cref="TypeTransformer.TransformAll"/> setup, stored on the
-/// <see cref="TypeScriptTransformContext"/>, and consulted by <see cref="BclMapper"/>
-/// before falling back to its hardcoded lowering rules.
-///
-/// Lookup is keyed by <c>(declaringType.OriginalDefinition, memberName)</c> so that an
-/// entry registered as <c>typeof(List&lt;&gt;)</c> matches every closed instantiation like
-/// <c>List&lt;int&gt;</c> or <c>List&lt;Money&gt;</c>.
+/// Lookup is keyed by
+/// (<see cref="SymbolHelper.GetStableFullName"/>, member-name) so entries
+/// registered against an open generic (e.g.,
+/// <c>System.Collections.Generic.List&lt;T&gt;</c>) match every closed
+/// instantiation from the IR's <c>IrMemberOrigin</c>.
 /// </summary>
 public sealed class DeclarativeMappingRegistry
 {
-    private readonly Dictionary<
-        (INamedTypeSymbol Type, string Name),
-        List<DeclarativeMappingEntry>
-    > _methods;
-    private readonly Dictionary<
-        (INamedTypeSymbol Type, string Name),
-        DeclarativeMappingEntry
-    > _properties;
-    private readonly Dictionary<string, HashSet<string>> _chainMethodsByWrapper;
-
-    // Full-name-keyed view of _methods / _properties (e.g., "System.Collections
-    // .Generic.List<T>") — consumed by the IR-driven BCL mapper. Will replace the
-    // symbol-keyed dicts once BclMapper retires.
-    private readonly Dictionary<
+    private readonly IReadOnlyDictionary<
         (string FullName, string Name),
-        List<DeclarativeMappingEntry>
+        IReadOnlyList<DeclarativeMappingEntry>
     > _methodsByFullName;
-    private readonly Dictionary<
+    private readonly IReadOnlyDictionary<
         (string FullName, string Name),
         DeclarativeMappingEntry
     > _propertiesByFullName;
+    private readonly IReadOnlyDictionary<string, IReadOnlySet<string>> _chainMethodsByWrapper;
 
     private DeclarativeMappingRegistry(
-        Dictionary<(INamedTypeSymbol, string), List<DeclarativeMappingEntry>> methods,
-        Dictionary<(INamedTypeSymbol, string), DeclarativeMappingEntry> properties,
-        Dictionary<string, HashSet<string>> chainMethodsByWrapper,
-        Dictionary<(string, string), List<DeclarativeMappingEntry>> methodsByFullName,
-        Dictionary<(string, string), DeclarativeMappingEntry> propertiesByFullName
+        IReadOnlyDictionary<
+            (string, string),
+            IReadOnlyList<DeclarativeMappingEntry>
+        > methodsByFullName,
+        IReadOnlyDictionary<(string, string), DeclarativeMappingEntry> propertiesByFullName,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> chainMethodsByWrapper
     )
     {
-        _methods = methods;
-        _properties = properties;
-        _chainMethodsByWrapper = chainMethodsByWrapper;
         _methodsByFullName = methodsByFullName;
         _propertiesByFullName = propertiesByFullName;
+        _chainMethodsByWrapper = chainMethodsByWrapper;
     }
 
     /// <summary>
-    /// Empty registry — used when there are no declarative mappings to honor (e.g., the
-    /// compilation does not reference any assembly that defines them).
+    /// Empty registry — used when there are no declarative mappings to
+    /// honor (the compilation does not reference any assembly that
+    /// defines them).
     /// </summary>
     public static DeclarativeMappingRegistry Empty { get; } =
         new(
-            new Dictionary<(INamedTypeSymbol, string), List<DeclarativeMappingEntry>>(
-                SymbolNameKeyComparer.Instance
-            ),
-            new Dictionary<(INamedTypeSymbol, string), DeclarativeMappingEntry>(
-                SymbolNameKeyComparer.Instance
-            ),
-            [],
-            [],
-            []
+            new Dictionary<(string, string), IReadOnlyList<DeclarativeMappingEntry>>(),
+            new Dictionary<(string, string), DeclarativeMappingEntry>(),
+            new Dictionary<string, IReadOnlySet<string>>()
         );
 
-    public int MethodCount => _methods.Values.Sum(list => list.Count);
-    public int PropertyCount => _properties.Count;
+    /// <summary>
+    /// Wraps the IR's declarative mapping tables into the registry shape
+    /// consumed by the TypeScript target's BCL mapper. Null tables on the
+    /// IR are treated as empty so callers can drop in the registry
+    /// without pre-checking.
+    /// </summary>
+    public static DeclarativeMappingRegistry FromIr(IrCompilation ir) =>
+        new(
+            ir.DeclarativeMethodMappings
+                ?? new Dictionary<(string, string), IReadOnlyList<DeclarativeMappingEntry>>(),
+            ir.DeclarativePropertyMappings
+                ?? new Dictionary<(string, string), DeclarativeMappingEntry>(),
+            ir.ChainMethodsByWrapper ?? new Dictionary<string, IReadOnlySet<string>>()
+        );
 
     /// <summary>
-    /// Returns the set of JS method names registered for a given <c>WrapReceiver</c>
-    /// value. Used by <see cref="BclMapper"/> to recognize "already wrapped" sources
-    /// when applying a mapping with a wrapping spec — if the receiver is a call whose
-    /// callee property matches one of these names, no re-wrapping is needed.
+    /// Returns the set of JS method names registered for a given
+    /// <c>WrapReceiver</c> value. Used by the BCL mapper to recognize
+    /// "already wrapped" sources when applying a mapping with a wrapping
+    /// spec — if the receiver is a call whose callee property matches one
+    /// of these names, no re-wrapping is needed.
     /// </summary>
     public IReadOnlySet<string> GetChainMethodNames(string wrapReceiver) =>
         _chainMethodsByWrapper.TryGetValue(wrapReceiver, out var set)
@@ -132,48 +85,10 @@ public sealed class DeclarativeMappingRegistry
             : (IReadOnlySet<string>)new HashSet<string>();
 
     /// <summary>
-    /// Returns all declarative method mapping entries registered for the given containing
-    /// type + method name, in declaration order. Multiple entries are allowed when an
-    /// entry uses the optional <see cref="DeclarativeMappingEntry.WhenArg0StringEquals"/>
-    /// filter to discriminate between literal arg shapes (e.g.,
-    /// <c>Guid.ToString("N")</c> vs <c>Guid.ToString()</c>). Callers walk the list and
-    /// pick the first entry whose filter matches their call site.
-    ///
-    /// The containing type is normalized to its
-    /// <see cref="INamedTypeSymbol.OriginalDefinition"/> so closed generics resolve to
-    /// the open-generic registration.
-    /// </summary>
-    public bool TryGetMethods(
-        INamedTypeSymbol containingType,
-        string methodName,
-        out IReadOnlyList<DeclarativeMappingEntry> entries
-    )
-    {
-        if (_methods.TryGetValue((containingType.OriginalDefinition, methodName), out var list))
-        {
-            entries = list;
-            return true;
-        }
-
-        entries = [];
-        return false;
-    }
-
-    /// <summary>
-    /// Looks up a declarative property mapping by the containing type and the C# property name.
-    /// </summary>
-    public bool TryGetProperty(
-        INamedTypeSymbol containingType,
-        string propertyName,
-        out DeclarativeMappingEntry entry
-    ) => _properties.TryGetValue((containingType.OriginalDefinition, propertyName), out entry!);
-
-    /// <summary>
-    /// Test-only factory: builds a registry directly from hand-written full-name-keyed
-    /// dictionaries, bypassing the compilation-wide attribute scan. The symbol-keyed
-    /// indices stay empty — callers that only exercise the IR-driven lookup
-    /// (<see cref="TryGetMethodsByFullName"/> / <see cref="TryGetPropertyByFullName"/>)
-    /// don't need them.
+    /// Test-only factory: builds a registry directly from hand-written
+    /// full-name-keyed dictionaries, bypassing the IR. Used by the
+    /// <c>IrToTsBclMapper</c> tests to exercise individual mapping shapes
+    /// without spinning up a full Roslyn compilation.
     /// </summary>
     internal static DeclarativeMappingRegistry CreateForTests(
         IReadOnlyDictionary<(string FullName, string Name), DeclarativeMappingEntry> methods,
@@ -181,47 +96,46 @@ public sealed class DeclarativeMappingRegistry
             null
     )
     {
-        var methodsByFullName = new Dictionary<(string, string), List<DeclarativeMappingEntry>>();
+        var methodsByFullName =
+            new Dictionary<(string, string), IReadOnlyList<DeclarativeMappingEntry>>();
         foreach (var (key, entry) in methods)
-            methodsByFullName[key] = [entry];
+            methodsByFullName[key] = new[] { entry };
 
         var propertiesByFullName = new Dictionary<(string, string), DeclarativeMappingEntry>();
         if (properties is not null)
             foreach (var (key, entry) in properties)
                 propertiesByFullName[key] = entry;
 
-        var chainMethods = new Dictionary<string, HashSet<string>>();
+        var chainMethodsMutable = new Dictionary<string, HashSet<string>>();
         foreach (var entry in methods.Values)
         {
             if (entry.WrapReceiver is null || entry.JsName is null)
                 continue;
-            if (!chainMethods.TryGetValue(entry.WrapReceiver, out var set))
+            if (!chainMethodsMutable.TryGetValue(entry.WrapReceiver, out var set))
             {
                 set = [];
-                chainMethods[entry.WrapReceiver] = set;
+                chainMethodsMutable[entry.WrapReceiver] = set;
             }
             set.Add(entry.JsName);
         }
 
+        var chainMethods = chainMethodsMutable.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlySet<string>)kv.Value
+        );
+
         return new DeclarativeMappingRegistry(
-            new Dictionary<(INamedTypeSymbol, string), List<DeclarativeMappingEntry>>(
-                SymbolNameKeyComparer.Instance
-            ),
-            new Dictionary<(INamedTypeSymbol, string), DeclarativeMappingEntry>(
-                SymbolNameKeyComparer.Instance
-            ),
-            chainMethods,
             methodsByFullName,
-            propertiesByFullName
+            propertiesByFullName,
+            chainMethods
         );
     }
 
     /// <summary>
-    /// IR-driven counterpart to <see cref="TryGetMethods"/>. Keys on the declaring
-    /// type's fully-qualified original-definition name (e.g.,
-    /// <c>System.Collections.Generic.List&lt;T&gt;</c>) so the BCL mapper can look
-    /// up entries from an <see cref="IrMemberOrigin"/> without holding a Roslyn
-    /// symbol.
+    /// Keys on the declaring type's fully-qualified original-definition
+    /// name (e.g., <c>System.Collections.Generic.List&lt;T&gt;</c>) so the
+    /// BCL mapper can look up entries straight from an
+    /// <c>IrMemberOrigin</c> without holding a Roslyn symbol.
     /// </summary>
     public bool TryGetMethodsByFullName(
         string declaringTypeFullName,
@@ -239,216 +153,13 @@ public sealed class DeclarativeMappingRegistry
     }
 
     /// <summary>
-    /// IR-driven counterpart to <see cref="TryGetProperty"/> — see
-    /// <see cref="TryGetMethodsByFullName"/> for the keying rationale.
+    /// Looks up a declarative property mapping by the declaring type's
+    /// stable full name and the property name. Mirrors
+    /// <see cref="TryGetMethodsByFullName"/> for properties.
     /// </summary>
     public bool TryGetPropertyByFullName(
         string declaringTypeFullName,
         string propertyName,
         out DeclarativeMappingEntry entry
     ) => _propertiesByFullName.TryGetValue((declaringTypeFullName, propertyName), out entry!);
-
-    /// <summary>
-    /// Builds a registry by walking the compilation's own assembly and every referenced
-    /// assembly, collecting their assembly-level <c>[MapMethod]</c> and <c>[MapProperty]</c>
-    /// attributes. Mappings whose <c>DeclaringType</c> can't be resolved against the current
-    /// compilation (e.g., a referenced assembly mentions a type the consumer doesn't ship)
-    /// are silently skipped.
-    /// </summary>
-    public static DeclarativeMappingRegistry BuildFromCompilation(Compilation compilation)
-    {
-        var methods = new Dictionary<(INamedTypeSymbol, string), List<DeclarativeMappingEntry>>(
-            SymbolNameKeyComparer.Instance
-        );
-        var properties = new Dictionary<(INamedTypeSymbol, string), DeclarativeMappingEntry>(
-            SymbolNameKeyComparer.Instance
-        );
-
-        // Walk the current assembly + every referenced assembly's attributes
-        var assemblies = new List<IAssemblySymbol> { compilation.Assembly };
-        foreach (var reference in compilation.References)
-        {
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
-                assemblies.Add(assembly);
-        }
-
-        foreach (var assembly in assemblies)
-        {
-            foreach (var attr in assembly.GetAttributes())
-            {
-                var attrName = attr.AttributeClass?.Name;
-                if (attrName is "MapMethodAttribute")
-                    TryRegisterMethod(attr, methods);
-                else if (attrName is "MapPropertyAttribute")
-                    TryRegisterProperty(attr, properties);
-            }
-        }
-
-        // Build the per-wrapper chain method index used by BclMapper to detect
-        // already-wrapped receivers. Every entry that uses WrapReceiver contributes its
-        // JsName (or the inferred wrap-method root) to its wrapper's set.
-        var chainMethodsByWrapper = new Dictionary<string, HashSet<string>>();
-        foreach (var entries in methods.Values)
-        {
-            foreach (var entry in entries)
-            {
-                if (entry.WrapReceiver is null)
-                    continue;
-                if (entry.JsName is null)
-                    continue; // template entries can't be detected by name
-
-                if (!chainMethodsByWrapper.TryGetValue(entry.WrapReceiver, out var set))
-                {
-                    set = [];
-                    chainMethodsByWrapper[entry.WrapReceiver] = set;
-                }
-                set.Add(entry.JsName);
-            }
-        }
-
-        // Mirror the symbol-keyed indices into full-name-keyed ones so IR-driven
-        // lookups don't need to hold onto INamedTypeSymbol references. Use the
-        // shared `GetStableFullName` helper so the join key matches the format
-        // `IrExpressionExtractor` produces for `IrMemberOrigin.DeclaringTypeFullName`
-        // — keying off the same `ToDisplayString` overload across the pipeline.
-        var methodsByFullName = new Dictionary<(string, string), List<DeclarativeMappingEntry>>();
-        foreach (var ((type, name), list) in methods)
-            methodsByFullName[(type.GetStableFullName(), name)] = list;
-        var propertiesByFullName = new Dictionary<(string, string), DeclarativeMappingEntry>();
-        foreach (var ((type, name), entry) in properties)
-            propertiesByFullName[(type.GetStableFullName(), name)] = entry;
-
-        return new DeclarativeMappingRegistry(
-            methods,
-            properties,
-            chainMethodsByWrapper,
-            methodsByFullName,
-            propertiesByFullName
-        );
-    }
-
-    /// <summary>
-    /// Reads one [MapMethod] attribute and appends it to the per-key list in the target
-    /// dictionary. Multiple entries per key are allowed when filters like
-    /// <c>WhenArg0StringEquals</c> are used to discriminate between literal arg shapes.
-    /// Entries are appended in walk order (current assembly first, then references), so
-    /// the consumer's source order within an assembly is preserved.
-    /// </summary>
-    private static void TryRegisterMethod(
-        AttributeData attr,
-        Dictionary<(INamedTypeSymbol, string), List<DeclarativeMappingEntry>> target
-    )
-    {
-        var entry = ReadEntry(attr, "JsMethod");
-        if (entry is null)
-            return;
-
-        var declaringType = (INamedTypeSymbol)attr.ConstructorArguments[0].Value!;
-        var memberName = (string)attr.ConstructorArguments[1].Value!;
-        var key = (declaringType.OriginalDefinition, memberName);
-
-        if (!target.TryGetValue(key, out var list))
-        {
-            list = [];
-            target[key] = list;
-        }
-        list.Add(entry);
-    }
-
-    /// <summary>
-    /// Reads one [MapProperty] attribute and stores it in the target dictionary. Property
-    /// mappings don't use literal-argument filters (properties have no arguments), so
-    /// the storage stays single-entry-per-key with last-write-wins semantics.
-    /// </summary>
-    private static void TryRegisterProperty(
-        AttributeData attr,
-        Dictionary<(INamedTypeSymbol, string), DeclarativeMappingEntry> target
-    )
-    {
-        var entry = ReadEntry(attr, "JsProperty");
-        if (entry is null)
-            return;
-
-        var declaringType = (INamedTypeSymbol)attr.ConstructorArguments[0].Value!;
-        var memberName = (string)attr.ConstructorArguments[1].Value!;
-        var key = (declaringType.OriginalDefinition, memberName);
-
-        target[key] = entry;
-    }
-
-    /// <summary>
-    /// Reads the body of a [MapMethod]/[MapProperty] AttributeData into a
-    /// <see cref="DeclarativeMappingEntry"/>, returning null when the constructor args
-    /// are missing or when neither <c>JsMethod</c>/<c>JsProperty</c> nor <c>JsTemplate</c>
-    /// is provided.
-    /// </summary>
-    private static DeclarativeMappingEntry? ReadEntry(AttributeData attr, string renameNamedArg)
-    {
-        if (attr.ConstructorArguments.Length < 2)
-            return null;
-        if (attr.ConstructorArguments[0].Value is not INamedTypeSymbol)
-            return null;
-        if (attr.ConstructorArguments[1].Value is not string)
-            return null;
-
-        string? jsName = null;
-        string? jsTemplate = null;
-        string? whenArg0StringEquals = null;
-        string? wrapReceiver = null;
-        string? runtimeImports = null;
-        foreach (var named in attr.NamedArguments)
-        {
-            switch (named.Key)
-            {
-                case var k when k == renameNamedArg:
-                    jsName = named.Value.Value as string;
-                    break;
-                case "JsTemplate":
-                    jsTemplate = named.Value.Value as string;
-                    break;
-                case "WhenArg0StringEquals":
-                    whenArg0StringEquals = named.Value.Value as string;
-                    break;
-                case "WrapReceiver":
-                    wrapReceiver = named.Value.Value as string;
-                    break;
-                case "RuntimeImports":
-                    runtimeImports = named.Value.Value as string;
-                    break;
-            }
-        }
-
-        if (jsName is null && jsTemplate is null)
-            return null;
-
-        return new DeclarativeMappingEntry(
-            jsName,
-            jsTemplate,
-            whenArg0StringEquals,
-            wrapReceiver,
-            runtimeImports
-        );
-    }
-
-    /// <summary>
-    /// Equality comparer for the (declaringType, memberName) lookup key. Uses
-    /// <see cref="SymbolEqualityComparer.Default"/> for the symbol part so that two
-    /// references to the same generic definition (e.g., from different syntax trees)
-    /// hash and compare equal.
-    /// </summary>
-    private sealed class SymbolNameKeyComparer
-        : IEqualityComparer<(INamedTypeSymbol Type, string Name)>
-    {
-        public static readonly SymbolNameKeyComparer Instance = new();
-
-        public bool Equals(
-            (INamedTypeSymbol Type, string Name) x,
-            (INamedTypeSymbol Type, string Name) y
-        ) => SymbolEqualityComparer.Default.Equals(x.Type, y.Type) && x.Name == y.Name;
-
-        public int GetHashCode((INamedTypeSymbol Type, string Name) obj) =>
-            unchecked(
-                SymbolEqualityComparer.Default.GetHashCode(obj.Type) * 397 ^ obj.Name.GetHashCode()
-            );
-    }
 }

--- a/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRendering.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRendering.cs
@@ -6,10 +6,10 @@ namespace Metano.Transformation;
 /// <summary>
 /// Pure-TS rendering helpers shared by <see cref="BclMapper"/> (legacy Roslyn-driven
 /// path) and <see cref="Metano.TypeScript.Bridge.IrToTsBclMapper"/> (IR-driven path).
-/// Everything here operates only on <see cref="TsExpression"/>s, strings, and
-/// <see cref="DeclarativeMappingRegistry"/>; it is free of any Roslyn or IR
-/// dependency, so both mappers can share the same behavior for arg-literal
-/// matching, wrap-receiver expansion and runtime-import parsing.
+/// Operates on <see cref="TsExpression"/>s, strings, and the IR-backed
+/// <see cref="DeclarativeMappingEntry"/> / <see cref="DeclarativeMappingRegistry"/>;
+/// free of any Roslyn dependency so both mappers can share the same behavior for
+/// arg-literal matching and wrap-receiver expansion.
 /// </summary>
 internal static class DeclarativeMappingRendering
 {

--- a/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRendering.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/DeclarativeMappingRendering.cs
@@ -1,3 +1,4 @@
+using Metano.Compiler.IR;
 using Metano.TypeScript.AST;
 
 namespace Metano.Transformation;
@@ -12,13 +13,6 @@ namespace Metano.Transformation;
 /// </summary>
 internal static class DeclarativeMappingRendering
 {
-    internal static IReadOnlyList<string> SplitRuntimeImports(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw))
-            return [];
-        return raw!.Split(',').Select(s => s.Trim()).Where(s => s.Length > 0).ToList();
-    }
-
     /// <summary>
     /// Whether a mapping entry's optional arg-literal filter matches the given call
     /// site. An entry without a filter matches anything; an entry with

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -188,10 +188,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         _pathNaming = new PathNaming(ir.LocalRootNamespace);
 
-        // Read declarative [MapMethod]/[MapProperty] from the current assembly + every
-        // referenced assembly. The registry is consulted by BclMapper before its hardcoded
-        // lowering rules.
-        var declarativeMappings = DeclarativeMappingRegistry.BuildFromCompilation(compilation);
+        var declarativeMappings = DeclarativeMappingRegistry.FromIr(ir);
 
         _context = new TypeScriptTransformContext(
             compilation,

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -105,7 +105,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         var declarativeMappings = compilation is null
             ? default
-            : BuildDeclarativeMappings(compilation);
+            : BuildDeclarativeMappings(compilation, diagnostics);
 
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
@@ -232,7 +232,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             DeclarativeMappingEntry
         > Properties,
         IReadOnlyDictionary<string, IReadOnlySet<string>> ChainMethodsByWrapper
-    ) BuildDeclarativeMappings(Compilation compilation)
+    ) BuildDeclarativeMappings(Compilation compilation, List<MetanoDiagnostic> diagnostics)
     {
         var methods = new Dictionary<(string, string), List<DeclarativeMappingEntry>>();
         var properties = new Dictionary<(string, string), DeclarativeMappingEntry>();
@@ -251,10 +251,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 switch (attr.AttributeClass?.Name)
                 {
                     case "MapMethodAttribute":
-                        TryRegisterMapping(attr, "JsMethod", methods);
+                        TryRegisterMapping(attr, "JsMethod", methods, diagnostics);
                         break;
                     case "MapPropertyAttribute":
-                        TryRegisterProperty(attr, "JsProperty", properties);
+                        TryRegisterProperty(attr, "JsProperty", properties, diagnostics);
                         break;
                 }
             }
@@ -291,14 +291,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     private static void TryRegisterMapping(
         AttributeData attr,
         string renameNamedArg,
-        Dictionary<(string, string), List<DeclarativeMappingEntry>> target
+        Dictionary<(string, string), List<DeclarativeMappingEntry>> target,
+        List<MetanoDiagnostic> diagnostics
     )
     {
         var key = ReadMappingKey(attr);
         if (key is null)
             return;
 
-        var entry = ReadMappingEntry(attr, renameNamedArg);
+        var entry = ReadMappingEntry(attr, renameNamedArg, diagnostics);
         if (entry is null)
             return;
 
@@ -313,14 +314,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     private static void TryRegisterProperty(
         AttributeData attr,
         string renameNamedArg,
-        Dictionary<(string, string), DeclarativeMappingEntry> target
+        Dictionary<(string, string), DeclarativeMappingEntry> target,
+        List<MetanoDiagnostic> diagnostics
     )
     {
         var key = ReadMappingKey(attr);
         if (key is null)
             return;
 
-        var entry = ReadMappingEntry(attr, renameNamedArg);
+        var entry = ReadMappingEntry(attr, renameNamedArg, diagnostics);
         if (entry is null)
             return;
 
@@ -342,7 +344,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
     private static DeclarativeMappingEntry? ReadMappingEntry(
         AttributeData attr,
-        string renameNamedArg
+        string renameNamedArg,
+        List<MetanoDiagnostic> diagnostics
     )
     {
         string? jsName = null;
@@ -374,6 +377,31 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         if (jsName is null && jsTemplate is null)
             return null;
+
+        // JsName and JsTemplate are mutually exclusive — template takes
+        // precedence (it's the more specific lowering form). Surface MS0004
+        // so a user who meant only one of the two can spot the conflict.
+        if (jsName is not null && jsTemplate is not null)
+        {
+            var target =
+                attr.ConstructorArguments.Length >= 2
+                && attr.ConstructorArguments[0].Value is INamedTypeSymbol owner
+                && attr.ConstructorArguments[1].Value is string memberName
+                    ? $"{owner.ToDisplayString()}.{memberName}"
+                    : attr.AttributeClass?.ToDisplayString() ?? "<unknown>";
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Warning,
+                    DiagnosticCodes.ConflictingAttributes,
+                    $"Declarative mapping on '{target}' sets both "
+                        + $"{renameNamedArg} ('{jsName}') and JsTemplate ('{jsTemplate}') — "
+                        + $"these are mutually exclusive. Keeping JsTemplate and ignoring "
+                        + $"{renameNamedArg}.",
+                    attr.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+                )
+            );
+            jsName = null;
+        }
 
         return new DeclarativeMappingEntry(
             jsName,

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -103,6 +103,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         var assemblyWideTranspile = compilation is not null && compilation.HasTranspileAssembly();
 
+        var declarativeMappings = compilation is null
+            ? default
+            : BuildDeclarativeMappings(compilation);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -123,7 +127,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             Diagnostics: diagnostics,
             LocalRootNamespace: compilation is null
                 ? ""
-                : ComputeLocalRootNamespace(compilation, assemblyWideTranspile)
+                : ComputeLocalRootNamespace(compilation, assemblyWideTranspile),
+            DeclarativeMethodMappings: declarativeMappings.Methods,
+            DeclarativePropertyMappings: declarativeMappings.Properties,
+            ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper
         );
     }
 
@@ -202,6 +209,179 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         programType = containingType;
         return true;
+    }
+
+    /// <summary>
+    /// Reads <c>[assembly: MapMethod]</c> / <c>[assembly: MapProperty]</c>
+    /// declarations from the current assembly plus every referenced
+    /// assembly and indexes them by
+    /// (<see cref="SymbolHelper.GetStableFullName"/>, member-name). Also
+    /// computes the per-wrapper set of mapped JS method names so the target
+    /// can recognize already-wrapped receivers. Mirrors the legacy
+    /// <c>DeclarativeMappingRegistry.BuildFromCompilation</c> attribute
+    /// walk, dropping the symbol-keyed dictionaries whose Roslyn consumers
+    /// retired with ADR-0013.
+    /// </summary>
+    private static (
+        IReadOnlyDictionary<
+            (string DeclaringTypeFullName, string MemberName),
+            IReadOnlyList<DeclarativeMappingEntry>
+        > Methods,
+        IReadOnlyDictionary<
+            (string DeclaringTypeFullName, string MemberName),
+            DeclarativeMappingEntry
+        > Properties,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> ChainMethodsByWrapper
+    ) BuildDeclarativeMappings(Compilation compilation)
+    {
+        var methods = new Dictionary<(string, string), List<DeclarativeMappingEntry>>();
+        var properties = new Dictionary<(string, string), DeclarativeMappingEntry>();
+
+        var assemblies = new List<IAssemblySymbol> { compilation.Assembly };
+        foreach (var reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                assemblies.Add(assembly);
+        }
+
+        foreach (var assembly in assemblies)
+        {
+            foreach (var attr in assembly.GetAttributes())
+            {
+                switch (attr.AttributeClass?.Name)
+                {
+                    case "MapMethodAttribute":
+                        TryRegisterMapping(attr, "JsMethod", methods);
+                        break;
+                    case "MapPropertyAttribute":
+                        TryRegisterProperty(attr, "JsProperty", properties);
+                        break;
+                }
+            }
+        }
+
+        var chainMethodsByWrapper = new Dictionary<string, HashSet<string>>();
+        foreach (var entries in methods.Values)
+        {
+            foreach (var entry in entries)
+            {
+                if (entry.WrapReceiver is null || entry.JsName is null)
+                    continue;
+                if (!chainMethodsByWrapper.TryGetValue(entry.WrapReceiver, out var set))
+                {
+                    set = [];
+                    chainMethodsByWrapper[entry.WrapReceiver] = set;
+                }
+                set.Add(entry.JsName);
+            }
+        }
+
+        var readonlyMethods = methods.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlyList<DeclarativeMappingEntry>)kv.Value
+        );
+        var readonlyChains = chainMethodsByWrapper.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlySet<string>)kv.Value
+        );
+
+        return (readonlyMethods, properties, readonlyChains);
+    }
+
+    private static void TryRegisterMapping(
+        AttributeData attr,
+        string renameNamedArg,
+        Dictionary<(string, string), List<DeclarativeMappingEntry>> target
+    )
+    {
+        var key = ReadMappingKey(attr);
+        if (key is null)
+            return;
+
+        var entry = ReadMappingEntry(attr, renameNamedArg);
+        if (entry is null)
+            return;
+
+        if (!target.TryGetValue(key.Value, out var list))
+        {
+            list = [];
+            target[key.Value] = list;
+        }
+        list.Add(entry);
+    }
+
+    private static void TryRegisterProperty(
+        AttributeData attr,
+        string renameNamedArg,
+        Dictionary<(string, string), DeclarativeMappingEntry> target
+    )
+    {
+        var key = ReadMappingKey(attr);
+        if (key is null)
+            return;
+
+        var entry = ReadMappingEntry(attr, renameNamedArg);
+        if (entry is null)
+            return;
+
+        target[key.Value] = entry;
+    }
+
+    private static (string DeclaringTypeFullName, string MemberName)? ReadMappingKey(
+        AttributeData attr
+    )
+    {
+        if (attr.ConstructorArguments.Length < 2)
+            return null;
+        if (attr.ConstructorArguments[0].Value is not INamedTypeSymbol declaringType)
+            return null;
+        if (attr.ConstructorArguments[1].Value is not string memberName)
+            return null;
+        return (declaringType.GetStableFullName(), memberName);
+    }
+
+    private static DeclarativeMappingEntry? ReadMappingEntry(
+        AttributeData attr,
+        string renameNamedArg
+    )
+    {
+        string? jsName = null;
+        string? jsTemplate = null;
+        string? whenArg0StringEquals = null;
+        string? wrapReceiver = null;
+        string? runtimeImports = null;
+        foreach (var named in attr.NamedArguments)
+        {
+            switch (named.Key)
+            {
+                case var k when k == renameNamedArg:
+                    jsName = named.Value.Value as string;
+                    break;
+                case "JsTemplate":
+                    jsTemplate = named.Value.Value as string;
+                    break;
+                case "WhenArg0StringEquals":
+                    whenArg0StringEquals = named.Value.Value as string;
+                    break;
+                case "WrapReceiver":
+                    wrapReceiver = named.Value.Value as string;
+                    break;
+                case "RuntimeImports":
+                    runtimeImports = named.Value.Value as string;
+                    break;
+            }
+        }
+
+        if (jsName is null && jsTemplate is null)
+            return null;
+
+        return new DeclarativeMappingEntry(
+            jsName,
+            jsTemplate,
+            whenArg0StringEquals,
+            wrapReceiver,
+            runtimeImports
+        );
     }
 
     /// <summary>

--- a/src/Metano.Compiler/IR/DeclarativeMappingEntry.cs
+++ b/src/Metano.Compiler/IR/DeclarativeMappingEntry.cs
@@ -2,9 +2,12 @@ namespace Metano.Compiler.IR;
 
 /// <summary>
 /// One declarative mapping entry extracted from <c>[MapMethod]</c> or
-/// <c>[MapProperty]</c>. Either <see cref="JsName"/> (simple rename) or
-/// <see cref="JsTemplate"/> is set, never both — the frontend enforces the
-/// mutual exclusivity when it reads the attribute.
+/// <c>[MapProperty]</c>. <see cref="JsName"/> represents a simple rename;
+/// <see cref="JsTemplate"/> represents template-based lowering. The two
+/// are mutually exclusive — when both are set on the attribute the
+/// frontend raises <see cref="Diagnostics.DiagnosticCodes.ConflictingAttributes"/>
+/// (MS0004) and keeps <see cref="JsTemplate"/>, so every constructed entry
+/// has at most one of the two populated.
 ///
 /// <see cref="WhenArg0StringEquals"/> is an optional literal-argument filter:
 /// when set, the entry only matches a call site whose first argument is a

--- a/src/Metano.Compiler/IR/DeclarativeMappingEntry.cs
+++ b/src/Metano.Compiler/IR/DeclarativeMappingEntry.cs
@@ -1,0 +1,56 @@
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// One declarative mapping entry extracted from <c>[MapMethod]</c> or
+/// <c>[MapProperty]</c>. Either <see cref="JsName"/> (simple rename) or
+/// <see cref="JsTemplate"/> is set, never both — the frontend enforces the
+/// mutual exclusivity when it reads the attribute.
+///
+/// <see cref="WhenArg0StringEquals"/> is an optional literal-argument filter:
+/// when set, the entry only matches a call site whose first argument is a
+/// target-language string literal with that exact value (e.g.,
+/// <c>Guid.ToString("N")</c>).
+///
+/// <see cref="WrapReceiver"/> is an optional source-receiver wrapping spec:
+/// when set, the target rewrites the call site's receiver to
+/// <c>WrapReceiver(source)</c> before applying the rename/template, unless
+/// the receiver is already a chained call from the same wrapper (LINQ-style).
+///
+/// <see cref="RuntimeImports"/> is an optional comma-separated list of
+/// runtime-helper identifiers the lowered call site must import from the
+/// target's runtime package. The target forwards the list to its import
+/// collector since the template body is otherwise opaque text.
+/// </summary>
+public sealed record DeclarativeMappingEntry(
+    string? JsName,
+    string? JsTemplate,
+    string? WhenArg0StringEquals = null,
+    string? WrapReceiver = null,
+    string? RuntimeImports = null
+)
+{
+    public bool HasTemplate => JsTemplate is not null;
+
+    public bool HasArgFilter => WhenArg0StringEquals is not null;
+
+    public bool HasWrapReceiver => WrapReceiver is not null;
+
+    // Parsed once per entry and reused across every call-site that expands
+    // it — template-based mappings are hit many times per compilation.
+    private IReadOnlyList<string>? _runtimeImportsList;
+
+    /// <summary>
+    /// Parsed runtime imports (comma-separated identifier list in
+    /// <see cref="RuntimeImports"/>). Empty when the raw value is null or
+    /// whitespace.
+    /// </summary>
+    public IReadOnlyList<string> RuntimeImportsList =>
+        _runtimeImportsList ??= ParseRuntimeImports(RuntimeImports);
+
+    private static IReadOnlyList<string> ParseRuntimeImports(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return [];
+        return raw!.Split(',').Select(s => s.Trim()).Where(s => s.Length > 0).ToList();
+    }
+}

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -67,8 +67,24 @@ namespace Metano.Compiler.IR;
 /// stay short. This value is target-agnostic provided the target uses
 /// dot-separated namespace segments for file-system layout (TypeScript,
 /// Dart). Targets using alternate layout schemes must compute their own
-/// root independently. Appended at the end of the record so adding new
-/// state cannot shift downstream positional arguments.</param>
+/// root independently.</param>
+/// <param name="DeclarativeMethodMappings">Index of
+/// <c>[MapMethod]</c> entries keyed by
+/// (<see cref="SymbolHelper.GetStableFullName"/> of the declaring type,
+/// method name). Multiple entries per key are allowed when
+/// <see cref="DeclarativeMappingEntry.WhenArg0StringEquals"/> discriminates
+/// between literal-argument shapes.</param>
+/// <param name="DeclarativePropertyMappings">Index of
+/// <c>[MapProperty]</c> entries keyed the same way as
+/// <paramref name="DeclarativeMethodMappings"/>. Property mappings don't
+/// use literal-argument filters so storage is single-entry-per-key.</param>
+/// <param name="ChainMethodsByWrapper">Per-wrapper set of JS method names
+/// used to recognize "already wrapped" receivers when a mapping with a
+/// <see cref="DeclarativeMappingEntry.WrapReceiver"/> spec is about to be
+/// expanded — if the receiver is a call whose callee property matches one
+/// of the names, no re-wrapping is needed. Appended at the end with
+/// nullable defaults so adding new IR state cannot shift downstream
+/// positional arguments.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -80,5 +96,14 @@ public sealed record IrCompilation(
     IReadOnlyDictionary<string, IrBclExport> BclExports,
     IReadOnlySet<string> AssembliesNeedingEmitPackage,
     IReadOnlyList<MetanoDiagnostic> Diagnostics,
-    string LocalRootNamespace = ""
+    string LocalRootNamespace = "",
+    IReadOnlyDictionary<
+        (string DeclaringTypeFullName, string MemberName),
+        IReadOnlyList<DeclarativeMappingEntry>
+    >? DeclarativeMethodMappings = null,
+    IReadOnlyDictionary<
+        (string DeclaringTypeFullName, string MemberName),
+        DeclarativeMappingEntry
+    >? DeclarativePropertyMappings = null,
+    IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null
 );

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1,5 +1,6 @@
 using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
+using Metano.Compiler.IR;
 using Metano.Tests.IR;
 
 namespace Metano.Tests.Frontend;
@@ -774,5 +775,155 @@ public class CSharpSourceFrontendTests
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
 
         await Assert.That(ir.LocalRootNamespace).IsEqualTo("Acme.Shared.Domain");
+    }
+
+    // Tests below declare their own user types so the assertions aren't
+    // diluted by the many [MapMethod]/[MapProperty] declarations Metano.Runtime
+    // ships for BCL types like List<T>, Guid, Dictionary, etc.
+
+    [Test]
+    public async Task DeclarativeMethodMappings_IndexesCurrentAssemblyMapMethod()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: MapMethod(
+                typeof(AcmeUnique.Mappings.UniqueWidget),
+                "Execute",
+                JsMethod = "run"
+            )]
+
+            namespace AcmeUnique.Mappings
+            {
+                public class UniqueWidget
+                {
+                    public void Execute() {}
+                }
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.DeclarativeMethodMappings).IsNotNull();
+        var key = ("AcmeUnique.Mappings.UniqueWidget", "Execute");
+        await Assert.That(ir.DeclarativeMethodMappings!).ContainsKey(key);
+        var entries = ir.DeclarativeMethodMappings![key];
+        await Assert.That(entries.Count).IsEqualTo(1);
+        await Assert.That(entries[0].JsName).IsEqualTo("run");
+    }
+
+    [Test]
+    public async Task DeclarativeMethodMappings_GroupsOverloadsByLiteralFilter()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Formatter), "Render",
+                JsTemplate = "$0.render($1)")]
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Formatter), "Render",
+                WhenArg0StringEquals = "fast",
+                JsTemplate = "$0.fastRender()")]
+
+            namespace AcmeUnique.Mappings
+            {
+                public class Formatter
+                {
+                    public string Render(string mode) => "";
+                }
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        var key = ("AcmeUnique.Mappings.Formatter", "Render");
+        await Assert.That(ir.DeclarativeMethodMappings!).ContainsKey(key);
+        var entries = ir.DeclarativeMethodMappings![key];
+        await Assert.That(entries.Count).IsEqualTo(2);
+        await Assert.That(entries[0].WhenArg0StringEquals).IsNull();
+        await Assert.That(entries[1].WhenArg0StringEquals).IsEqualTo("fast");
+    }
+
+    [Test]
+    public async Task DeclarativePropertyMappings_IndexesMapProperty()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: MapProperty(
+                typeof(AcmeUnique.Mappings.Container),
+                "ItemCount",
+                JsProperty = "size"
+            )]
+
+            namespace AcmeUnique.Mappings
+            {
+                public class Container
+                {
+                    public int ItemCount => 0;
+                }
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        var key = ("AcmeUnique.Mappings.Container", "ItemCount");
+        await Assert.That(ir.DeclarativePropertyMappings!).ContainsKey(key);
+        var entry = ir.DeclarativePropertyMappings![key];
+        await Assert.That(entry.JsName).IsEqualTo("size");
+    }
+
+    [Test]
+    public async Task ChainMethodsByWrapper_CollectsJsNamesByWrapper()
+    {
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Widget), "Add",
+                JsMethod = "appendThing", WrapReceiver = "uniqueWrap")]
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Widget), "Remove",
+                JsMethod = "dropThing", WrapReceiver = "uniqueWrap")]
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Widget), "Sort",
+                JsTemplate = "$0.reorderThings()", WrapReceiver = "uniqueWrap")]
+
+            namespace AcmeUnique.Mappings
+            {
+                public class Widget
+                {
+                    public void Add() {}
+                    public void Remove() {}
+                    public void Sort() {}
+                }
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ChainMethodsByWrapper).IsNotNull();
+        await Assert.That(ir.ChainMethodsByWrapper!).ContainsKey("uniqueWrap");
+        var names = ir.ChainMethodsByWrapper!["uniqueWrap"];
+        // JsTemplate-only entries are excluded — wrap detection needs a JsName.
+        await Assert.That(names).Contains("appendThing");
+        await Assert.That(names).Contains("dropThing");
+        await Assert.That(names.Contains("reorderThings")).IsFalse();
+    }
+
+    [Test]
+    public async Task DeclarativeMappings_DicionaryHandlesPresentEvenWhenCurrentAssemblyHasNoAttributes()
+    {
+        // Metano.Runtime is on every consumer's reference set, so the
+        // inherited tables are never empty. This test just pins the IR
+        // contract: the dictionaries are always non-null after extraction,
+        // so callers can safely do `ir.DeclarativeMethodMappings ?? empty`.
+        var compilation = IrTestHelper.Compile(
+            """
+            public class Marker {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.DeclarativeMethodMappings).IsNotNull();
+        await Assert.That(ir.DeclarativePropertyMappings).IsNotNull();
+        await Assert.That(ir.ChainMethodsByWrapper).IsNotNull();
     }
 }

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -908,7 +908,44 @@ public class CSharpSourceFrontendTests
     }
 
     [Test]
-    public async Task DeclarativeMappings_DicionaryHandlesPresentEvenWhenCurrentAssemblyHasNoAttributes()
+    public async Task DeclarativeMappings_MutuallyExclusiveJsNameAndJsTemplateWarns()
+    {
+        // Set both JsMethod (rename) and JsTemplate on the same attribute:
+        // the frontend must surface MS0004 and keep JsTemplate, so the
+        // target never sees a mapping entry with both populated.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: MapMethod(typeof(AcmeUnique.Mappings.Conflicted), "Run",
+                JsMethod = "run", JsTemplate = "$0.run()")]
+
+            namespace AcmeUnique.Mappings
+            {
+                public class Conflicted
+                {
+                    public void Run() {}
+                }
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        var warning = ir.Diagnostics.SingleOrDefault(d =>
+            d.Code == DiagnosticCodes.ConflictingAttributes
+            && d.Message.Contains("Conflicted")
+            && d.Message.Contains("Run")
+        );
+        await Assert.That(warning).IsNotNull();
+
+        var key = ("AcmeUnique.Mappings.Conflicted", "Run");
+        await Assert.That(ir.DeclarativeMethodMappings!).ContainsKey(key);
+        var entry = ir.DeclarativeMethodMappings![key][0];
+        await Assert.That(entry.JsName).IsNull();
+        await Assert.That(entry.JsTemplate).IsEqualTo("$0.run()");
+    }
+
+    [Test]
+    public async Task DeclarativeMappings_DictionaryHandlesPresentEvenWhenCurrentAssemblyHasNoAttributes()
     {
         // Metano.Runtime is on every consumer's reference set, so the
         // inherited tables are never empty. This test just pins the IR

--- a/tests/Metano.Tests/IR/IrToTsBodyBridgeTests.cs
+++ b/tests/Metano.Tests/IR/IrToTsBodyBridgeTests.cs
@@ -1,4 +1,5 @@
 using Metano.Compiler.Extraction;
+using Metano.Compiler.IR;
 using Metano.Transformation;
 using Metano.TypeScript;
 using Metano.TypeScript.AST;


### PR DESCRIPTION
## Summary

Seventh slice of the consumer-side migration after #72. The C# frontend now builds the declarative mapping tables (`[MapMethod]`/`[MapProperty]`) once per extraction; the TypeScript target's `DeclarativeMappingRegistry` becomes a thin wrapper over the IR dicts.

## Changes

- **`DeclarativeMappingEntry` record** — moved from the TypeScript target to `src/Metano.Compiler/IR/`. `ParseRuntimeImports` is inlined on the record so the IR carries no target-specific dependency. The unused `DeclarativeMappingRendering.SplitRuntimeImports` helper is retired.
- **`IrCompilation`** — gains three nullable fields: `DeclarativeMethodMappings`, `DeclarativePropertyMappings`, `ChainMethodsByWrapper`. All three default to `null` (treated as empty by consumers) so positional construction stays compatible.
- **`CSharpSourceFrontend.BuildDeclarativeMappings`** — walks the current assembly + every referenced assembly, indexing attributes by (`GetStableFullName`, member-name) and precomputing the per-wrapper chain-method set that the BCL mapper uses to detect already-wrapped receivers.
- **`DeclarativeMappingRegistry`** — rewritten as an IR-only consumer. The dead symbol-keyed dicts (`TryGetMethods` / `TryGetProperty` / `MethodCount` / `PropertyCount`), `SymbolNameKeyComparer`, the compilation-driven `BuildFromCompilation` and its `TryRegisterMethod`/`TryRegisterProperty`/`ReadEntry` helpers are removed — `IrToTsBclMapper` had already migrated to the full-name lookups. `FromIr(ir)` replaces `BuildFromCompilation` on the target side.
- **`TypeTransformer.TransformAll`** — calls `DeclarativeMappingRegistry.FromIr(ir)` in place of the legacy `BuildFromCompilation`.
- **`CreateForTests`** — tightened: the chain-method set is built with a local `HashSet<string>` and only cast to `IReadOnlySet<string>` at the exit point, removing the previous downcast.
- **Tests** — five new frontend cases cover the current-assembly walk, overload grouping via `WhenArg0StringEquals`, property mappings, the per-wrapper chain-method set, and the null-means-empty contract.

Net delta: **+494 / -379**. No functional change.

## Test plan

- [x] dotnet build Metano.slnx
- [x] dotnet run --project tests/Metano.Tests/ → 592/592
- [x] dotnet csharpier check .
- [x] Sample regeneration produced byte-identical output for sample-todo, sample-todo-service, sample-issue-tracker, and flutter/sample_counter

Part of #58