### PR TITLE
refactor(core): frontend target-aware extraction (Phase B.5)

### DIFF
--- a/src/Metano.Compiler.Dart/DartTarget.cs
+++ b/src/Metano.Compiler.Dart/DartTarget.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler;
 using Metano.Compiler.IR;
 using Metano.Dart.AST;
@@ -12,6 +13,8 @@ namespace Metano.Dart;
 public sealed class DartTarget : ITranspilerTarget
 {
     public string Name => "dart";
+
+    public TargetLanguage Language => TargetLanguage.Dart;
 
     public IReadOnlyList<DartSourceFile> LastSourceFiles { get; private set; } = [];
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -124,19 +124,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         // Seed the external-import map from the frontend. The IR covers every
         // [Import] type from the current assembly, plus those from referenced
         // assemblies that opt into transpilation ([TranspileAssembly]) and
-        // declare an [EmitPackage] for the active target — keyed by C# simple
-        // name, with MS0003 collisions surfaced through the host's diagnostic
-        // merge. The TS-name aliasing below is a target concern that stays
-        // here until the frontend gains target awareness — it must walk every
-        // public top-level [Import] type (mirroring the frontend's walker),
-        // not just `transpilableTypes`, so an [Import] placeholder without
-        // [Transpile] in a project that does not declare
-        // [assembly: TranspileAssembly] still gets its TS-name alias.
+        // declare an [EmitPackage] for the active target — keyed by both the
+        // C# source name and, when it differs, the per-target [Name(target, …)]
+        // alias. MS0003 collisions are surfaced through the host's diagnostic
+        // merge.
         _externalImportMap = new Dictionary<string, IrExternalImport>(
             ir.ExternalImports,
             StringComparer.Ordinal
         );
-        RegisterTsNameAliases();
 
         // Build the explicit per-compilation context that replaces TypeMapper statics.
         var crossPackageMisses = new HashSet<string>();
@@ -276,102 +271,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             "TypeScriptTransformContext is not yet initialized — TransformAll() must "
                 + "complete its setup phase before any per-type helper runs."
         );
-
-    /// <summary>
-    /// Registers the <c>[Name(TypeScript)]</c> alias into
-    /// <see cref="_externalImportMap"/> for every <c>[Import]</c>-annotated
-    /// type whose TS name differs from the C# source name. Walks the
-    /// current assembly plus every referenced assembly that opts into
-    /// transpilation via <c>[TranspileAssembly]</c> and declares an
-    /// <c>[EmitPackage]</c> for the active target.
-    /// <para>
-    /// The C#-source-name keys are already produced by the frontend via
-    /// <see cref="IrCompilation.ExternalImports"/>; only TS-name aliasing
-    /// stays on the target side, pending a target-aware frontend.
-    /// </para>
-    /// </summary>
-    private void RegisterTsNameAliases()
-    {
-        RegisterTsNameAliasesForAssembly(compilation.Assembly);
-
-        foreach (var reference in compilation.References)
-        {
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
-                continue;
-            if (SymbolEqualityComparer.Default.Equals(asm, compilation.Assembly))
-                continue;
-
-            var hasTranspileAssembly = asm.GetAttributes()
-                .Any(a =>
-                    a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
-                );
-            if (!hasTranspileAssembly)
-                continue;
-
-            if (
-                SymbolHelper.GetEmitPackageInfo(asm, targetEnumValue: (int)EmitTarget.JavaScript)
-                is null
-            )
-                continue;
-
-            RegisterTsNameAliasesForAssembly(asm);
-        }
-    }
-
-    private void RegisterTsNameAliasesForAssembly(IAssemblySymbol assembly)
-    {
-        foreach (var type in EnumeratePublicTopLevelTypes(assembly.GlobalNamespace))
-        {
-            var import = SymbolHelper.GetImport(type);
-            if (import is null)
-                continue;
-
-            var tsName = GetTsTypeName(type);
-            if (tsName == type.Name)
-                continue;
-
-            var entry = new IrExternalImport(
-                Name: import.Name,
-                From: import.From,
-                IsDefault: import.AsDefault,
-                Version: import.Version
-            );
-            RegisterExternalImportMapping(
-                tsName,
-                entry,
-                type.ToDisplayString(),
-                type.Locations.FirstOrDefault()
-            );
-        }
-    }
-
-    /// <summary>
-    /// Yields every public top-level type reachable from
-    /// <paramref name="ns"/>. Mirrors the frontend's walker so the TS-name
-    /// aliasing pass can register every <c>[Import]</c> type the IR
-    /// already covers, including placeholders that the user did not mark
-    /// with <c>[Transpile]</c>. No <c>[NoTranspile]</c>/<c>[NoEmit]</c>
-    /// filter is applied because an <c>[Import]</c> is an external binding
-    /// — emission gating is irrelevant for its TS-name alias.
-    /// </summary>
-    private static IEnumerable<INamedTypeSymbol> EnumeratePublicTopLevelTypes(INamespaceSymbol ns)
-    {
-        foreach (var member in ns.GetMembers())
-        {
-            switch (member)
-            {
-                case INamespaceSymbol childNs:
-                    foreach (var nested in EnumeratePublicTopLevelTypes(childNs))
-                        yield return nested;
-                    break;
-                case INamedTypeSymbol type
-                    when type.ContainingType is null
-                        && type.DeclaredAccessibility == Accessibility.Public:
-                    yield return type;
-                    break;
-            }
-        }
-    }
 
     private IReadOnlyList<INamedTypeSymbol> DiscoverTranspilableTypes()
     {
@@ -678,34 +577,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         string FileName,
         List<INamedTypeSymbol> Types
     );
-
-    private void RegisterExternalImportMapping(
-        string key,
-        IrExternalImport entry,
-        string ownerDisplayName,
-        Location? location
-    )
-    {
-        if (!_externalImportMap.TryGetValue(key, out var existing))
-        {
-            _externalImportMap[key] = entry;
-            return;
-        }
-
-        if (existing == entry)
-            return;
-
-        _diagnostics.Add(
-            new MetanoDiagnostic(
-                MetanoDiagnosticSeverity.Warning,
-                DiagnosticCodes.AmbiguousConstruct,
-                $"External import name collision for '{key}'. Keeping '{existing.From}' "
-                    + $"('{existing.Name}') and ignoring conflicting mapping from "
-                    + $"'{ownerDisplayName}' to '{entry.From}' ('{entry.Name}').",
-                location
-            )
-        );
-    }
 
     /// <summary>
     /// Returns the TypeScript name for a type. Uses [Name] override if present, otherwise the C# name as-is.

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -21,6 +21,8 @@ public sealed class TypeScriptTarget : ITranspilerTarget
 {
     public string Name => "typescript";
 
+    public TargetLanguage Language => TargetLanguage.TypeScript;
+
     /// <summary>
     /// The TS AST source files produced by the most recent <see cref="Transform"/> call.
     /// Empty until Transform is invoked.

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -36,6 +36,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
     public async Task<IrCompilation> ExtractAsync(
         string projectPath,
+        TargetLanguage target = TargetLanguage.TypeScript,
         CancellationToken ct = default
     )
     {
@@ -49,7 +50,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         return BuildIrCompilation(
             compilation,
             fallbackAssemblyName: assemblyName,
-            diagnostics: diagnostics
+            diagnostics: diagnostics,
+            target: target
         );
     }
 
@@ -62,21 +64,26 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// <see cref="LoadedCompilation"/>, resets <see cref="LoadErrorCount"/>
     /// to <c>0</c>, and returns the populated record.
     /// </summary>
-    public IrCompilation ExtractFromCompilation(Compilation compilation)
+    public IrCompilation ExtractFromCompilation(
+        Compilation compilation,
+        TargetLanguage target = TargetLanguage.TypeScript
+    )
     {
         LoadedCompilation = compilation;
         LoadErrorCount = 0;
         return BuildIrCompilation(
             compilation,
             fallbackAssemblyName: compilation.AssemblyName ?? "",
-            diagnostics: new List<MetanoDiagnostic>()
+            diagnostics: new List<MetanoDiagnostic>(),
+            target: target
         );
     }
 
     private static IrCompilation BuildIrCompilation(
         Compilation? compilation,
         string fallbackAssemblyName,
-        List<MetanoDiagnostic> diagnostics
+        List<MetanoDiagnostic> diagnostics,
+        TargetLanguage target
     )
     {
         // Fields beyond what's already populated stay empty during the
@@ -85,7 +92,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         // onto `IrCompilation`.
         IReadOnlyDictionary<string, IrExternalImport> externalImports = compilation is null
             ? new Dictionary<string, IrExternalImport>(StringComparer.Ordinal)
-            : BuildExternalImports(compilation, diagnostics);
+            : BuildExternalImports(compilation, target, diagnostics);
 
         IReadOnlyDictionary<string, IrTypeOrigin> crossAssemblyOrigins;
         IReadOnlySet<string> assembliesNeedingEmitPackage;
@@ -97,7 +104,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         else
         {
             (crossAssemblyOrigins, assembliesNeedingEmitPackage) = BuildCrossAssemblyState(
-                compilation
+                compilation,
+                target
             );
         }
 
@@ -113,7 +121,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 ? null
                 : SymbolHelper.GetEmitPackage(
                     compilation.Assembly,
-                    targetEnumValue: (int)EmitTarget.JavaScript
+                    targetEnumValue: (int)target.ToEmitTarget()
                 ),
             AssemblyWideTranspile: assemblyWideTranspile,
             Modules: Array.Empty<IrModule>(),
@@ -443,15 +451,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     ///   target can later raise <see cref="DiagnosticCodes.CrossPackageResolution"/>
     ///   (MS0007) at the consumer site.</item>
     /// </list>
-    /// The active target is currently hardcoded to TypeScript / JavaScript
-    /// (<c>EmitTarget</c> integer value <c>0</c>) — every consumer of this
-    /// information today is JS-bound; introducing target awareness on the
-    /// frontend is a separate concern bundled with the contract flip.
+    /// <paramref name="target"/> drives the per-target <c>[NoEmit]</c>
+    /// filter so a Dart-specific <c>[NoEmit]</c> cannot poison the
+    /// TypeScript origin table (and vice versa).
     /// </summary>
     private static (
         IReadOnlyDictionary<string, IrTypeOrigin> CrossAssemblyOrigins,
         IReadOnlySet<string> AssembliesNeedingEmitPackage
-    ) BuildCrossAssemblyState(Compilation compilation)
+    ) BuildCrossAssemblyState(Compilation compilation, TargetLanguage target)
     {
         var origins = new Dictionary<string, IrTypeOrigin>(StringComparer.Ordinal);
         var needingPackage = new HashSet<string>(StringComparer.Ordinal);
@@ -459,6 +466,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         foreach (
             var (asm, packageInfo) in EnumerateTranspilableReferencedAssemblies(
                 compilation,
+                target,
                 onTranspilableWithoutEmitPackage: name => needingPackage.Add(name)
             )
         )
@@ -481,7 +489,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 .Where(type =>
                     SymbolHelper.GetImport(type) is null
                     && !SymbolHelper.HasNoTranspile(type)
-                    && !SymbolHelper.HasNoEmit(type, TargetLanguage.TypeScript)
+                    && !SymbolHelper.HasNoEmit(type, target)
                 )
                 .ToList();
 
@@ -509,12 +517,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// (<c>[TranspileAssembly]</c>) and declared an <c>[EmitPackage]</c>
     /// for the active target, surfacing those carrying
     /// <c>[Import("name", from)]</c> as <see cref="IrExternalImport"/>
-    /// entries keyed by the C# type's simple source name. The local
-    /// assembly is walked first so on collision its entry wins, matching
-    /// the legacy ordering in
-    /// <c>TypeTransformer.DiscoverCrossAssemblyTypes</c>. Per-target
-    /// <c>[Name]</c> aliasing remains on the consumer side until later
-    /// migration steps wire it through the IR.
+    /// entries keyed by the C# type's simple source name <em>and</em> by
+    /// the per-target <c>[Name(target, …)]</c> alias when it differs —
+    /// both keys point at the same <see cref="IrExternalImport"/> value so
+    /// the backend can resolve imports by whichever name it is holding
+    /// (source, emitted, or either after rename). Retires the duplicate
+    /// walker that used to live in <c>TypeTransformer.RegisterTsNameAliases</c>.
+    /// The local assembly is walked first so on collision its entry wins,
+    /// matching the legacy ordering in
+    /// <c>TypeTransformer.DiscoverCrossAssemblyTypes</c>.
     /// <para>
     /// Conflict policy: first mapping wins and any divergent
     /// re-registration produces a
@@ -524,15 +535,16 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// </summary>
     private static Dictionary<string, IrExternalImport> BuildExternalImports(
         Compilation compilation,
+        TargetLanguage target,
         List<MetanoDiagnostic> diagnostics
     )
     {
         var map = new Dictionary<string, IrExternalImport>(StringComparer.Ordinal);
 
-        AddImportsFromAssembly(compilation.Assembly, map, diagnostics);
+        AddImportsFromAssembly(compilation.Assembly, target, map, diagnostics);
 
-        foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation))
-            AddImportsFromAssembly(asm, map, diagnostics);
+        foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation, target))
+            AddImportsFromAssembly(asm, target, map, diagnostics);
 
         return map;
     }
@@ -554,9 +566,11 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         SymbolHelper.EmitPackageInfo PackageInfo
     )> EnumerateTranspilableReferencedAssemblies(
         Compilation compilation,
+        TargetLanguage target,
         Action<string>? onTranspilableWithoutEmitPackage = null
     )
     {
+        var emitTargetValue = (int)target.ToEmitTarget();
         foreach (var reference in compilation.References)
         {
             if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol asm)
@@ -571,10 +585,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             if (!hasTranspileAssembly)
                 continue;
 
-            var packageInfo = SymbolHelper.GetEmitPackageInfo(
-                asm,
-                targetEnumValue: (int)EmitTarget.JavaScript
-            );
+            var packageInfo = SymbolHelper.GetEmitPackageInfo(asm, emitTargetValue);
             if (packageInfo is null)
             {
                 onTranspilableWithoutEmitPackage?.Invoke(asm.Name);
@@ -588,12 +599,19 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// <summary>
     /// Walks <paramref name="assembly"/>'s public top-level types and
     /// registers any <c>[Import]</c>-annotated entry into
-    /// <paramref name="map"/> under the C# source name. Mirrors the
-    /// legacy <c>TypeTransformer.RegisterExternalImportMapping</c>
+    /// <paramref name="map"/> under the C# source name plus, when a
+    /// <c>[Name(target, …)]</c> alias for the active
+    /// <paramref name="target"/> differs from the source name, that alias
+    /// too. Both keys point at the same <see cref="IrExternalImport"/>
+    /// value so the backend can look the import up by whichever name it
+    /// is holding. A <c>[Name(…)]</c> targeted at any language other than
+    /// <paramref name="target"/> is deliberately ignored on this pass.
+    /// Mirrors the legacy <c>TypeTransformer.RegisterExternalImportMapping</c>
     /// conflict policy (first mapping wins; collisions produce MS0003).
     /// </summary>
     private static void AddImportsFromAssembly(
         IAssemblySymbol assembly,
+        TargetLanguage target,
         Dictionary<string, IrExternalImport> map,
         List<MetanoDiagnostic> diagnostics
     )
@@ -616,27 +634,58 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     Version: import.Version
                 );
 
-                if (map.TryGetValue(type.Name, out var existing))
-                {
-                    if (existing == entry)
-                        return;
+                // Register under the C# source name first so it remains
+                // the canonical lookup key for callers that only know the
+                // C# identifier.
+                TryRegisterImport(type.Name, entry, type, map, diagnostics);
 
-                    diagnostics.Add(
-                        new MetanoDiagnostic(
-                            MetanoDiagnosticSeverity.Warning,
-                            DiagnosticCodes.AmbiguousConstruct,
-                            $"External import name collision for '{type.Name}'. Keeping "
-                                + $"'{existing.From}' ('{existing.Name}') and ignoring "
-                                + $"conflicting mapping from '{type.ToDisplayString()}' to "
-                                + $"'{entry.From}' ('{entry.Name}').",
-                            type.Locations.FirstOrDefault()
-                        )
-                    );
-                    return;
-                }
-
-                map[type.Name] = entry;
+                // Additionally register the per-target [Name(target, …)]
+                // alias so the backend can resolve an import by the
+                // emitted identifier without re-reading Roslyn. Skip when
+                // the alias collapses to the source name (no-op) or is
+                // absent.
+                var targetName = SymbolHelper.GetNameOverride(type, target);
+                if (targetName is not null && targetName != type.Name)
+                    TryRegisterImport(targetName, entry, type, map, diagnostics);
             }
+        );
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="entry"/> into <paramref name="map"/> under
+    /// <paramref name="key"/>, enforcing the first-wins conflict policy:
+    /// a value-equal re-registration is a silent no-op (the same
+    /// <see cref="IrExternalImport"/> can legitimately land twice — once
+    /// under the source name and once under its per-target alias), while
+    /// any divergent re-registration is reported as MS0003 and dropped.
+    /// </summary>
+    private static void TryRegisterImport(
+        string key,
+        IrExternalImport entry,
+        INamedTypeSymbol owner,
+        Dictionary<string, IrExternalImport> map,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (!map.TryGetValue(key, out var existing))
+        {
+            map[key] = entry;
+            return;
+        }
+
+        if (existing == entry)
+            return;
+
+        diagnostics.Add(
+            new MetanoDiagnostic(
+                MetanoDiagnosticSeverity.Warning,
+                DiagnosticCodes.AmbiguousConstruct,
+                $"External import name collision for '{key}'. Keeping "
+                    + $"'{existing.From}' ('{existing.Name}') and ignoring "
+                    + $"conflicting mapping from '{owner.ToDisplayString()}' to "
+                    + $"'{entry.From}' ('{entry.Name}').",
+                owner.Locations.FirstOrDefault()
+            )
         );
     }
 

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -36,8 +36,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
     public async Task<IrCompilation> ExtractAsync(
         string projectPath,
-        TargetLanguage target = TargetLanguage.TypeScript,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        TargetLanguage target = TargetLanguage.TypeScript
     )
     {
         var assemblyName = Path.GetFileNameWithoutExtension(projectPath);

--- a/src/Metano.Compiler/ISourceFrontend.cs
+++ b/src/Metano.Compiler/ISourceFrontend.cs
@@ -73,7 +73,7 @@ public interface ISourceFrontend
     /// <param name="ct">Cancellation token.</param>
     Task<IrCompilation> ExtractAsync(
         string projectPath,
-        TargetLanguage target = TargetLanguage.TypeScript,
-        CancellationToken ct = default
+        CancellationToken ct = default,
+        TargetLanguage target = TargetLanguage.TypeScript
     );
 }

--- a/src/Metano.Compiler/ISourceFrontend.cs
+++ b/src/Metano.Compiler/ISourceFrontend.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
@@ -62,6 +63,17 @@ public interface ISourceFrontend
     /// list.</summary>
     /// <param name="projectPath">Path to the entry source artifact (e.g.,
     /// a <c>.csproj</c> for the C# frontend).</param>
+    /// <param name="target">The backend the extraction is being performed
+    /// for. Drives target-specific resolution (per-target <c>[Name]</c>
+    /// aliases, per-target <c>[NoEmit]</c> filters) so the resulting IR
+    /// already carries the names and emission decisions the backend will
+    /// use. Defaults to <see cref="TargetLanguage.TypeScript"/> for
+    /// backwards compatibility with tests and any callers that predate the
+    /// parameter.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<IrCompilation> ExtractAsync(string projectPath, CancellationToken ct = default);
+    Task<IrCompilation> ExtractAsync(
+        string projectPath,
+        TargetLanguage target = TargetLanguage.TypeScript,
+        CancellationToken ct = default
+    );
 }

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -24,9 +24,12 @@ public interface ITranspilerTarget
     /// passes it to the active <see cref="ISourceFrontend"/> so
     /// target-specific resolution (per-target <c>[Name]</c>, per-target
     /// <c>[NoEmit]</c>, …) happens once during extraction instead of being
-    /// duplicated inside every target.
+    /// duplicated inside every target. Default keeps
+    /// <see cref="TargetLanguage.TypeScript"/> so third-party targets that
+    /// predate this member keep compiling until they opt in; in-tree
+    /// targets override with their actual language.
     /// </summary>
-    TargetLanguage Language { get; }
+    TargetLanguage Language => TargetLanguage.TypeScript;
 
     /// <summary>
     /// Produces the set of files (plus diagnostics) the host should emit. Targets

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
 
@@ -17,6 +18,15 @@ public interface ITranspilerTarget
 {
     /// <summary>Short name used in CLI/log messages (e.g., "typescript", "dart").</summary>
     string Name { get; }
+
+    /// <summary>
+    /// The <see cref="TargetLanguage"/> this backend emits for. The host
+    /// passes it to the active <see cref="ISourceFrontend"/> so
+    /// target-specific resolution (per-target <c>[Name]</c>, per-target
+    /// <c>[NoEmit]</c>, …) happens once during extraction instead of being
+    /// duplicated inside every target.
+    /// </summary>
+    TargetLanguage Language { get; }
 
     /// <summary>
     /// Produces the set of files (plus diagnostics) the host should emit. Targets

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -33,7 +33,7 @@ public static class TranspilerHost
 
         var totalSw = Stopwatch.StartNew();
         var compileSw = Stopwatch.StartNew();
-        var ir = await frontend.ExtractAsync(projectPath);
+        var ir = await frontend.ExtractAsync(projectPath, target.Language);
         var compilation = frontend.LoadedCompilation;
         var roslynErrorCount = frontend.LoadErrorCount;
 

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -33,7 +33,7 @@ public static class TranspilerHost
 
         var totalSw = Stopwatch.StartNew();
         var compileSw = Stopwatch.StartNew();
-        var ir = await frontend.ExtractAsync(projectPath, target.Language);
+        var ir = await frontend.ExtractAsync(projectPath, target: target.Language);
         var compilation = frontend.LoadedCompilation;
         var roslynErrorCount = frontend.LoadErrorCount;
 

--- a/src/Metano/Annotations/EmitTarget.cs
+++ b/src/Metano/Annotations/EmitTarget.cs
@@ -17,4 +17,7 @@ public enum EmitTarget
 {
     /// <summary>The TypeScript / JavaScript target (npm package name).</summary>
     JavaScript = 0,
+
+    /// <summary>The Dart / Flutter target (pub.dev package name).</summary>
+    Dart = 1,
 }

--- a/src/Metano/Annotations/TargetLanguage.cs
+++ b/src/Metano/Annotations/TargetLanguage.cs
@@ -10,3 +10,25 @@ public enum TargetLanguage
     TypeScript,
     Dart,
 }
+
+/// <summary>
+/// Maps between the symbolic <see cref="TargetLanguage"/> used by the
+/// compiler pipeline and the <see cref="EmitTarget"/> discriminator
+/// baked into <see cref="EmitPackageAttribute"/>. The two enums stay
+/// separate because <c>[EmitPackage]</c> ships on the consumer's C#
+/// surface and keeps its own attribute-layer discriminator.
+/// </summary>
+public static class TargetLanguageExtensions
+{
+    public static EmitTarget ToEmitTarget(this TargetLanguage target) =>
+        target switch
+        {
+            TargetLanguage.TypeScript => EmitTarget.JavaScript,
+            TargetLanguage.Dart => EmitTarget.Dart,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(target),
+                target,
+                $"No EmitTarget mapping for TargetLanguage.{target}."
+            ),
+        };
+}

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1,3 +1,4 @@
+using Metano.Annotations;
 using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
@@ -148,6 +149,137 @@ public class CSharpSourceFrontendTests
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
 
         await Assert.That(ir.ExternalImports.ContainsKey("Plain")).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternalImports_RegisterTargetSpecificNameAlias()
+    {
+        // The type's C# source identifier is HonoStub but its TS-facing
+        // [Name(TypeScript, "Hono")] alias is what user code emits when the
+        // import is resolved — the frontend must register both keys so the
+        // backend can look the entry up by either name without re-walking
+        // Roslyn for the alias.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Import("Hono", from: "hono")]
+            [Name(TargetLanguage.TypeScript, "Hono")]
+            public class HonoStub {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("HonoStub");
+        await Assert.That(ir.ExternalImports).ContainsKey("Hono");
+        await Assert.That(ir.ExternalImports["HonoStub"]).IsEqualTo(ir.ExternalImports["Hono"]);
+    }
+
+    [Test]
+    public async Task ExternalImports_IgnoreAliasForOtherTarget()
+    {
+        // A [Name(Dart, …)] override must not leak into the TS run — the
+        // frontend is invoked with TargetLanguage.TypeScript (the test
+        // default) so only the C# source name key exists on the map.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Import("Widget", from: "flutter/widgets")]
+            [Name(TargetLanguage.Dart, "FlutterWidget")]
+            public class Widget {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("Widget");
+        await Assert.That(ir.ExternalImports.ContainsKey("FlutterWidget")).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternalImports_UseTargetSpecificAliasWhenExtractingForDart()
+    {
+        // When the frontend is invoked for Dart, the same type's Dart alias
+        // wins and its TS alias is ignored — mirror of the case above so
+        // target awareness is exercised in both directions.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Import("Widget", from: "flutter/widgets")]
+            [Name(TargetLanguage.TypeScript, "TsWidget")]
+            [Name(TargetLanguage.Dart, "FlutterWidget")]
+            public class Widget {}
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(
+            compilation,
+            TargetLanguage.Dart
+        );
+
+        await Assert.That(ir.ExternalImports).ContainsKey("Widget");
+        await Assert.That(ir.ExternalImports).ContainsKey("FlutterWidget");
+        await Assert.That(ir.ExternalImports.ContainsKey("TsWidget")).IsFalse();
+    }
+
+    [Test]
+    public async Task ExternalImports_UntargetedNameAliasRegistersRegardlessOfTarget()
+    {
+        // An untargeted [Name("X")] applies to every target via
+        // SymbolHelper.GetNameOverride's fallback branch, so both a
+        // TypeScript and a Dart extraction must register the same alias
+        // alongside the C# source name.
+        var source = """
+            [Import("Widget", from: "pkg")]
+            [Name("AliasedWidget")]
+            public class Widget {}
+            """;
+
+        var tsIr = new CSharpSourceFrontend().ExtractFromCompilation(IrTestHelper.Compile(source));
+        await Assert.That(tsIr.ExternalImports).ContainsKey("Widget");
+        await Assert.That(tsIr.ExternalImports).ContainsKey("AliasedWidget");
+
+        var dartIr = new CSharpSourceFrontend().ExtractFromCompilation(
+            IrTestHelper.Compile(source),
+            TargetLanguage.Dart
+        );
+        await Assert.That(dartIr.ExternalImports).ContainsKey("Widget");
+        await Assert.That(dartIr.ExternalImports).ContainsKey("AliasedWidget");
+    }
+
+    [Test]
+    public async Task ExternalImports_AliasCollisionRaisesMS0003()
+    {
+        // Two [Import] types collide on the TS alias: the first wins and
+        // the second registration produces MS0003 with the alias key in
+        // the diagnostic message.
+        var compilation = IrTestHelper.Compile(
+            """
+            namespace Alpha
+            {
+                [Import("FirstWidget", from: "alpha")]
+                [Name(TargetLanguage.TypeScript, "SharedWidget")]
+                public class AlphaWidget {}
+            }
+
+            namespace Beta
+            {
+                [Import("SecondWidget", from: "beta")]
+                [Name(TargetLanguage.TypeScript, "SharedWidget")]
+                public class BetaWidget {}
+            }
+            """
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+
+        await Assert.That(ir.ExternalImports).ContainsKey("SharedWidget");
+        // First walker visit wins. CollectTopLevelTypes visits namespaces
+        // in declaration/alphabetical order, so Alpha wins.
+        await Assert.That(ir.ExternalImports["SharedWidget"].From).IsEqualTo("alpha");
+
+        var warning = ir.Diagnostics.SingleOrDefault(d =>
+            d.Code == DiagnosticCodes.AmbiguousConstruct && d.Message.Contains("SharedWidget")
+        );
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!.Message).Contains("beta");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

First consumer-side migration after the B.4.* series (#67-#74). The C# frontend now threads a `TargetLanguage` through extraction so per-target `[Name(target, …)]` alias resolution, `[NoEmit(target)]` filtering, and `[EmitPackage(target)]` selection all run in one place. The TypeScript target retires the four helpers that used to re-walk Roslyn to register the TS-name alias side-band on `_externalImportMap`.

## Changes

- **`EmitTarget` gains `Dart = 1`**; `TargetLanguage` gets a `ToEmitTarget` extension so the frontend and `SymbolHelper.GetEmitPackageInfo` agree on which `[EmitPackage]` to honor. Without this the cross-assembly selector would keep hardcoding JavaScript regardless of the active target.
- **`ITranspilerTarget.Language`** — both `TypeScriptTarget` and `DartTarget` report it. `TranspilerHost` forwards `target.Language` into `ExtractAsync`.
- **`ISourceFrontend.ExtractAsync` / `CSharpSourceFrontend.ExtractFromCompilation`** take an optional `TargetLanguage target = TypeScript` parameter. `BuildIrCompilation` threads it through `BuildExternalImports`, `BuildCrossAssemblyState`, `BuildBclExports` (via `GetEmitPackage`), and the `[NoEmit]` filter.
- **`AddImportsFromAssembly`** resolves `[Name(target, …)]` per-target for every `[Import]` type and registers both the C# source name and the alias under the same `IrExternalImport` via a new `TryRegisterImport` helper that preserves the MS0003 first-wins conflict policy.
- **`EnumerateTranspilableReferencedAssemblies`** now takes `TargetLanguage` and maps it to `EmitTarget` before reading `[EmitPackage]` — a Dart extraction no longer picks up JS-only packages (and vice versa).
- **`TypeTransformer`** drops `RegisterTsNameAliases`, `RegisterTsNameAliasesForAssembly`, `EnumeratePublicTopLevelTypes`, and `RegisterExternalImportMapping`. The target-side `_externalImportMap` is seeded directly from `ir.ExternalImports` — both source and alias keys already resolved.

## Tests

Five new frontend cases: TS alias registers both keys; Dart-only alias does not leak into a TS run; Dart extraction flips the winner; untargeted `[Name("X")]` fallback applies to every target; alias collision raises MS0003 keyed on the alias name.

## Follow-ups (out of scope)

- `TypeTransformer.GetTsTypeName` still exists and is used ~15 places for non-`Import` sites (barrel index, path naming, nested namespaces). Retiring it is the natural Phase B.6 slice once `IrModule` carries pre-resolved target names.
- `ExtractAsync`'s new `TargetLanguage` parameter sits before the existing `CancellationToken`. Consider reordering if downstream callers start passing the token positionally.

## Test plan

- [x] `dotnet build Metano.slnx`
- [x] `dotnet run --project tests/Metano.Tests/` → 598/598
- [x] `dotnet csharpier check .`
- [x] Sample regeneration produced byte-identical output for sample-todo, sample-todo-service, sample-issue-tracker, and flutter/sample_counter

Part of #58