### PR TITLE
refactor(core): retire TypeTransformer.GetTsTypeName (Phase B.6)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
@@ -213,7 +213,7 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
 
         statements.Add(
             new TsClass(
-                TypeTransformer.GetTsTypeName(type),
+                _context.ResolveTsName(type),
                 constructor,
                 classMembers,
                 Extends: extendsType,
@@ -316,7 +316,7 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
         if (opName is null)
             return [];
 
-        var typeName = TypeTransformer.GetTsTypeName(type);
+        var typeName = _context.ResolveTsName(type);
 
         if (irOp.Overloads is { Count: > 0 } siblings)
         {

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsNamingPolicy.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsNamingPolicy.cs
@@ -32,9 +32,10 @@ public static class IrToTsNamingPolicy
     public static string ToParameterName(string irName) => TypeScriptNaming.ToCamelCase(irName);
 
     /// <summary>
-    /// The type name is not renamed — matches <c>TypeTransformer.GetTsTypeName</c>
-    /// which honors <c>[Name]</c> on the symbol. The extractor already places name
-    /// overrides into <see cref="IrAttribute"/> entries; this helper looks them up.
+    /// Resolves the emitted type name from the IR's <see cref="IrAttribute"/>
+    /// entries (which already carry <c>[Name]</c> overrides). Mirrors the
+    /// per-target resolution the frontend now ships via
+    /// <see cref="IrCompilation.TypeNamesBySymbol"/> for Roslyn-keyed paths.
     /// </summary>
     public static string ToTypeName(string irName, IReadOnlyList<IrAttribute>? attributes)
     {

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -25,6 +25,7 @@ public sealed class ImportCollector(
     IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
+    IReadOnlyDictionary<string, string> typeNamesBySymbol,
     PathNaming pathNaming,
     TypeMappingContext typeMappingContext,
     IReadOnlySet<IrRuntimeRequirement>? irRuntimeRequirements = null
@@ -32,6 +33,11 @@ public sealed class ImportCollector(
 {
     private readonly IReadOnlyDictionary<string, INamedTypeSymbol> _transpilableTypeMap =
         transpilableTypeMap;
+    private readonly IReadOnlyDictionary<string, string> _typeNamesBySymbol = typeNamesBySymbol;
+
+    private string ResolveTsName(INamedTypeSymbol type) =>
+        _typeNamesBySymbol.TryGetValue(type.GetCrossAssemblyOriginKey(), out var n) ? n : type.Name;
+
     private readonly IReadOnlyDictionary<string, IrExternalImport> _externalImportMap =
         externalImportMap;
     private readonly IReadOnlyDictionary<string, IrBclExport> _bclExportMap = bclExportMap;
@@ -58,7 +64,7 @@ public sealed class ImportCollector(
             crossPackageOrigins
         );
 
-        var tsTypeName = TypeTransformer.GetTsTypeName(currentType);
+        var tsTypeName = ResolveTsName(currentType);
         referencedTypes.Remove(currentType.Name);
         referencedTypes.Remove(tsTypeName);
         referencedTypes.Remove($"is{tsTypeName}"); // own guard — don't import
@@ -325,7 +331,7 @@ public sealed class ImportCollector(
             if (!importedNames.Add(typeName))
                 continue;
 
-            var targetTsName = TypeTransformer.GetTsTypeName(referencedSymbol);
+            var targetTsName = ResolveTsName(referencedSymbol);
             // Path is computed against the FILE name (not the type name) so multiple
             // types co-located in the same file resolve to the same import path.
             var importPath = _pathNaming.ComputeRelativeImportPath(
@@ -474,13 +480,13 @@ public sealed class ImportCollector(
     /// own TS name (which itself honors <c>[Name]</c>). Used by the import collector
     /// to elide self-imports for types co-located in the same file.
     /// </summary>
-    private static string GetFileName(INamedTypeSymbol type)
+    private string GetFileName(INamedTypeSymbol type)
     {
         var explicitFile = SymbolHelper.GetEmitInFile(type);
         var name =
             explicitFile is not null && explicitFile.Length > 0
                 ? explicitFile
-                : TypeTransformer.GetTsTypeName(type);
+                : ResolveTsName(type);
         return SymbolHelper.ToKebabCase(name);
     }
 

--- a/src/Metano.Compiler.TypeScript/Transformation/JsonSerializerContextTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/JsonSerializerContextTransformer.cs
@@ -61,7 +61,7 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
         // Per-type: private _typeName? field + get typeName() lazy getter
         foreach (var targetType in serializableTypes)
         {
-            var tsTypeName = TypeTransformer.GetTsTypeName(targetType);
+            var tsTypeName = _context.ResolveTsName(targetType);
             var fieldName = "_" + TypeScriptNaming.ToCamelCase(tsTypeName);
             var getterName = TypeScriptNaming.ToCamelCase(tsTypeName);
             var runtimeJsonOrigin = new TsTypeOrigin("metano-runtime", "system/json");
@@ -224,7 +224,7 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
             && SymbolHelper.IsTranspilable(baseType)
         )
         {
-            var baseTsName = TypeTransformer.GetTsTypeName(baseType);
+            var baseTsName = _context.ResolveTsName(baseType);
             var baseGetterName = TypeScriptNaming.ToCamelCase(baseTsName);
             baseProperty = new TsObjectProperty(
                 "base",
@@ -560,7 +560,7 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
                 var tsTypeName =
                     named.ToDisplayString() == "System.Guid"
                         ? "UUID"
-                        : TypeTransformer.GetTsTypeName(named);
+                        : _context.ResolveTsName(named);
                 return new TsObjectLiteral([
                     new TsObjectProperty("kind", new TsStringLiteral("branded")),
                     new TsObjectProperty(
@@ -572,7 +572,7 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
 
             case "enum":
             {
-                var tsTypeName = TypeTransformer.GetTsTypeName((INamedTypeSymbol)type);
+                var tsTypeName = _context.ResolveTsName((INamedTypeSymbol)type);
                 return new TsObjectLiteral([
                     new TsObjectProperty("kind", new TsStringLiteral("enum")),
                     new TsObjectProperty("values", new TsIdentifier(tsTypeName)),
@@ -581,7 +581,7 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
 
             case "numericEnum":
             {
-                var tsTypeName = TypeTransformer.GetTsTypeName((INamedTypeSymbol)type);
+                var tsTypeName = _context.ResolveTsName((INamedTypeSymbol)type);
                 return new TsObjectLiteral([
                     new TsObjectProperty("kind", new TsStringLiteral("numericEnum")),
                     new TsObjectProperty("values", new TsIdentifier(tsTypeName)),

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -44,7 +44,7 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
         if (SymbolHelper.HasImport(type))
             return null;
 
-        var tsName = TypeTransformer.GetTsTypeName(type);
+        var tsName = _context.ResolveTsName(type);
         var guardName = $"is{tsName}";
         var valueParam = new TsParameter("value", new TsNamedType("unknown"));
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -1,3 +1,4 @@
+using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.Extraction;
 using Metano.Compiler.IR;
@@ -33,6 +34,7 @@ public sealed class TypeScriptTransformContext(
     IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> guardNameToTypeMap,
+    IReadOnlyDictionary<string, string> typeNamesBySymbol,
     PathNaming pathNaming,
     DeclarativeMappingRegistry declarativeMappings,
     Action<MetanoDiagnostic> reportDiagnostic
@@ -47,9 +49,23 @@ public sealed class TypeScriptTransformContext(
         externalImportMap;
     public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
     public IReadOnlyDictionary<string, string> GuardNameToTypeMap { get; } = guardNameToTypeMap;
+    public IReadOnlyDictionary<string, string> TypeNamesBySymbol { get; } = typeNamesBySymbol;
     public PathNaming PathNaming { get; } = pathNaming;
     public DeclarativeMappingRegistry DeclarativeMappings { get; } = declarativeMappings;
     public Action<MetanoDiagnostic> ReportDiagnostic { get; } = reportDiagnostic;
+
+    /// <summary>
+    /// Resolves the target-facing TypeScript name for a Roslyn type symbol.
+    /// Reads the frontend-populated <see cref="TypeNamesBySymbol"/> dictionary
+    /// so <c>[Name(TypeScript, …)]</c> overrides are honored; falls back to
+    /// <see cref="ISymbol.Name"/> for BCL types and anything the frontend did
+    /// not precompute (mirrors the legacy <c>TypeTransformer.GetTsTypeName</c>
+    /// contract that this helper replaces).
+    /// </summary>
+    public string ResolveTsName(INamedTypeSymbol type) =>
+        TypeNamesBySymbol.TryGetValue(type.GetCrossAssemblyOriginKey(), out var name)
+            ? name
+            : type.Name;
 
     /// <summary>
     /// Reports MS0001 (UnsupportedFeature) for an IR-pipeline body the bridge

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -175,7 +175,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             _externalImportMap,
             ir.BclExports,
             _guardNameToTypeMap,
-            ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal),
+            typeNamesBySymbol,
             _pathNaming,
             declarativeMappings,
             _diagnostics.Add

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -92,7 +92,11 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         if (members.Count > 0)
         {
             statements.Add(
-                new TsNamespaceDeclaration(GetTsTypeName(parent), Functions: [], Members: members)
+                new TsNamespaceDeclaration(
+                    Context.ResolveTsName(parent),
+                    Functions: [],
+                    Members: members
+                )
             );
         }
     }
@@ -110,13 +114,18 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         // IR rather than redoing the same probe.
         _assemblyWideTranspile = ir.AssemblyWideTranspile;
 
+        var typeNamesBySymbol =
+            ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        string ResolveTsName(INamedTypeSymbol t) =>
+            typeNamesBySymbol.TryGetValue(t.GetCrossAssemblyOriginKey(), out var n) ? n : t.Name;
+
         var transpilableTypes = DiscoverTranspilableTypes();
         // Map by both C# name and TS name (when [Name] override differs)
         _transpilableTypeMap = new Dictionary<string, INamedTypeSymbol>();
         foreach (var t in transpilableTypes)
         {
             _transpilableTypeMap[t.Name] = t;
-            var tsName = GetTsTypeName(t);
+            var tsName = ResolveTsName(t);
             if (tsName != t.Name)
                 _transpilableTypeMap[tsName] = t;
         }
@@ -150,7 +159,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         _guardNameToTypeMap = new Dictionary<string, string>();
         foreach (var t in transpilableTypes)
         {
-            var tsName = GetTsTypeName(t);
+            var tsName = ResolveTsName(t);
             _guardNameToTypeMap[$"is{tsName}"] = tsName;
         }
 
@@ -166,6 +175,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             _externalImportMap,
             ir.BclExports,
             _guardNameToTypeMap,
+            ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal),
             _pathNaming,
             declarativeMappings,
             _diagnostics.Add
@@ -459,6 +469,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             Context.ExternalImportMap,
             Context.BclExportMap,
             Context.GuardNameToTypeMap,
+            Context.TypeNamesBySymbol,
             Context.PathNaming,
             Context.TypeMapping!,
             irRequirements
@@ -534,7 +545,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             var fileName =
                 explicitFile is not null && explicitFile.Length > 0
                     ? SymbolHelper.ToKebabCase(explicitFile)
-                    : SymbolHelper.ToKebabCase(GetTsTypeName(type));
+                    : SymbolHelper.ToKebabCase(Context.ResolveTsName(type));
 
             // MS0008: when a type opts into [EmitInFile], the file name must be unique
             // per namespace. If we've seen the same file name in a different namespace,
@@ -577,14 +588,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         string FileName,
         List<INamedTypeSymbol> Types
     );
-
-    /// <summary>
-    /// Returns the TypeScript name for a type. Uses [Name] override if present, otherwise the C# name as-is.
-    /// </summary>
-    internal static string GetTsTypeName(INamedTypeSymbol type)
-    {
-        return SymbolHelper.GetNameOverride(type, TargetLanguage.TypeScript) ?? type.Name;
-    }
 
     /// <summary>
     /// Lowers an <c>[ExportedAsModule]</c> static class (or any static class

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -227,13 +227,18 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// <summary>
     /// Pre-resolves the target-facing emitted name for every type the
     /// backend may look up by Roslyn symbol. Covers transpilable types
-    /// from the current assembly, transpilable types from referenced
-    /// assemblies that declared <c>[EmitPackage]</c> for the active
-    /// target, and <c>[Import]</c> placeholders from any public top-level
-    /// symbol in scope. The resulting dictionary is keyed by
-    /// <see cref="SymbolHelper.GetStableFullName"/> so backends resolve
-    /// target names through a single code path (a symbol-keyed dict
-    /// lookup) instead of duplicating
+    /// (top-level + nested) from the current assembly, transpilable types
+    /// from referenced assemblies that declared <c>[EmitPackage]</c> for
+    /// the active target, and <c>[Import]</c> placeholders from any public
+    /// top-level symbol in scope. Types carrying <c>[NoTranspile]</c> or
+    /// <c>[NoEmit(target)]</c> are excluded on both sides — the backend
+    /// never asks for their name since they do not participate in emission.
+    /// The resulting dictionary is keyed by
+    /// <see cref="SymbolHelper.GetCrossAssemblyOriginKey"/> (the
+    /// assembly-qualified stable full name) so two referenced assemblies
+    /// that expose types with identical stable full names cannot collapse
+    /// each other's target-name override. Backends resolve target names
+    /// through a single dict lookup instead of duplicating
     /// <see cref="SymbolHelper.GetNameOverride"/> in every bridge.
     /// </summary>
     private static IReadOnlyDictionary<string, string> BuildTypeNamesBySymbol(
@@ -245,22 +250,16 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         var currentAssembly = compilation.Assembly;
 
-        // Keys are assembly-qualified (same shape as
-        // IrCompilation.CrossAssemblyOrigins) so two referenced assemblies
-        // that expose types with identical stable full names cannot
-        // collapse each other's target-name override.
-        void RegisterSymbol(INamedTypeSymbol type)
-        {
-            var key = type.GetCrossAssemblyOriginKey();
-            if (map.ContainsKey(key))
-                return;
-            map[key] = SymbolHelper.GetNameOverride(type, target) ?? type.Name;
-        }
+        void RegisterSymbol(INamedTypeSymbol type) =>
+            map.TryAdd(
+                type.GetCrossAssemblyOriginKey(),
+                SymbolHelper.GetNameOverride(type, target) ?? type.Name
+            );
 
-        // Visits every top-level type and every transpilable nested type so
-        // `[Name(target, …)]` overrides on nested declarations end up in the
-        // map too. Nested types still reach `context.ResolveTsName` via
-        // `TransformNestedTypes` / `IrToTsClassEmitter`.
+        // Visits every top-level type and every nested type so
+        // `[Name(target, …)]` overrides on nested declarations end up in
+        // the map too. The caller's `register` decides which symbols
+        // actually land in the dict.
         void Visit(INamedTypeSymbol type, Action<INamedTypeSymbol> register)
         {
             register(type);
@@ -270,7 +269,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         // Current assembly — every transpilable type (matches the target-side
         // DiscoverTranspilableTypes + nested-emission filter) plus every
-        // `[Import]` placeholder.
+        // `[Import]` placeholder the public-only walker would see.
         CollectTopLevelTypes(
             currentAssembly.GlobalNamespace,
             type =>
@@ -292,9 +291,11 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         );
 
         // Referenced assemblies that opted into transpilation with an
-        // [EmitPackage] for the active target — mirrors the cross-assembly
-        // origin walk so cross-package type references resolve through the
-        // same dict. Recurses into nested types as well.
+        // [EmitPackage] for the active target. Mirrors the
+        // BuildCrossAssemblyState filter so the same set of emittable types
+        // ends up in the dict — [NoTranspile] / [NoEmit(target)] types are
+        // excluded, [Import] placeholders on the referenced side are still
+        // registered so consumers can resolve their alias by symbol.
         foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation, target))
         {
             CollectTopLevelTypes(
@@ -304,8 +305,13 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                         type,
                         sym =>
                         {
-                            if (sym.DeclaredAccessibility == Accessibility.Public)
-                                RegisterSymbol(sym);
+                            if (sym.DeclaredAccessibility != Accessibility.Public)
+                                return;
+                            if (SymbolHelper.HasNoTranspile(sym))
+                                return;
+                            if (SymbolHelper.HasNoEmit(sym, target))
+                                return;
+                            RegisterSymbol(sym);
                         }
                     )
             );

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -115,6 +115,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? default
             : BuildDeclarativeMappings(compilation, diagnostics);
 
+        var typeNamesBySymbol = compilation is null
+            ? null
+            : BuildTypeNamesBySymbol(compilation, target, assemblyWideTranspile);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -138,7 +142,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 : ComputeLocalRootNamespace(compilation, assemblyWideTranspile),
             DeclarativeMethodMappings: declarativeMappings.Methods,
             DeclarativePropertyMappings: declarativeMappings.Properties,
-            ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper
+            ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper,
+            TypeNamesBySymbol: typeNamesBySymbol
         );
     }
 
@@ -217,6 +222,96 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         programType = containingType;
         return true;
+    }
+
+    /// <summary>
+    /// Pre-resolves the target-facing emitted name for every type the
+    /// backend may look up by Roslyn symbol. Covers transpilable types
+    /// from the current assembly, transpilable types from referenced
+    /// assemblies that declared <c>[EmitPackage]</c> for the active
+    /// target, and <c>[Import]</c> placeholders from any public top-level
+    /// symbol in scope. The resulting dictionary is keyed by
+    /// <see cref="SymbolHelper.GetStableFullName"/> so backends resolve
+    /// target names through a single code path (a symbol-keyed dict
+    /// lookup) instead of duplicating
+    /// <see cref="SymbolHelper.GetNameOverride"/> in every bridge.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildTypeNamesBySymbol(
+        Compilation compilation,
+        TargetLanguage target,
+        bool assemblyWideTranspile
+    )
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        var currentAssembly = compilation.Assembly;
+
+        // Keys are assembly-qualified (same shape as
+        // IrCompilation.CrossAssemblyOrigins) so two referenced assemblies
+        // that expose types with identical stable full names cannot
+        // collapse each other's target-name override.
+        void RegisterSymbol(INamedTypeSymbol type)
+        {
+            var key = type.GetCrossAssemblyOriginKey();
+            if (map.ContainsKey(key))
+                return;
+            map[key] = SymbolHelper.GetNameOverride(type, target) ?? type.Name;
+        }
+
+        // Visits every top-level type and every transpilable nested type so
+        // `[Name(target, …)]` overrides on nested declarations end up in the
+        // map too. Nested types still reach `context.ResolveTsName` via
+        // `TransformNestedTypes` / `IrToTsClassEmitter`.
+        void Visit(INamedTypeSymbol type, Action<INamedTypeSymbol> register)
+        {
+            register(type);
+            foreach (var nested in type.GetTypeMembers())
+                Visit(nested, register);
+        }
+
+        // Current assembly — every transpilable type (matches the target-side
+        // DiscoverTranspilableTypes + nested-emission filter) plus every
+        // `[Import]` placeholder.
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+                Visit(
+                    type,
+                    sym =>
+                    {
+                        if (
+                            SymbolHelper.IsTranspilable(sym, assemblyWideTranspile, currentAssembly)
+                        )
+                            RegisterSymbol(sym);
+                        else if (
+                            sym.DeclaredAccessibility == Accessibility.Public
+                            && SymbolHelper.GetImport(sym) is not null
+                        )
+                            RegisterSymbol(sym);
+                    }
+                )
+        );
+
+        // Referenced assemblies that opted into transpilation with an
+        // [EmitPackage] for the active target — mirrors the cross-assembly
+        // origin walk so cross-package type references resolve through the
+        // same dict. Recurses into nested types as well.
+        foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation, target))
+        {
+            CollectTopLevelTypes(
+                asm.GlobalNamespace,
+                type =>
+                    Visit(
+                        type,
+                        sym =>
+                        {
+                            if (sym.DeclaredAccessibility == Accessibility.Public)
+                                RegisterSymbol(sym);
+                        }
+                    )
+            );
+        }
+
+        return map;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -85,6 +85,18 @@ namespace Metano.Compiler.IR;
 /// of the names, no re-wrapping is needed. Appended at the end with
 /// nullable defaults so adding new IR state cannot shift downstream
 /// positional arguments.</param>
+/// <param name="TypeNamesBySymbol">Dictionary keyed by the
+/// assembly-qualified stable full name
+/// (<see cref="SymbolHelper.GetCrossAssemblyOriginKey"/>) giving the
+/// target-facing emitted name for every transpilable type, every nested
+/// transpilable type, and every <c>[Import]</c>-annotated type the
+/// frontend surfaced — resolved once via the active
+/// <see cref="Annotations.TargetLanguage"/>. Backends consult this
+/// dictionary instead of re-reading <c>[Name(target, …)]</c> themselves,
+/// so per-target naming policy stays co-located with the rest of the
+/// extraction pass. Qualifying by assembly prevents two referenced
+/// assemblies that expose types with identical stable full names from
+/// silently overwriting each other's override.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -105,5 +117,6 @@ public sealed record IrCompilation(
         (string DeclaringTypeFullName, string MemberName),
         DeclarativeMappingEntry
     >? DeclarativePropertyMappings = null,
-    IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null
+    IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null,
+    IReadOnlyDictionary<string, string>? TypeNamesBySymbol = null
 );

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1095,4 +1095,87 @@ public class CSharpSourceFrontendTests
         await Assert.That(ir.DeclarativePropertyMappings).IsNotNull();
         await Assert.That(ir.ChainMethodsByWrapper).IsNotNull();
     }
+
+    [Test]
+    public async Task TypeNamesBySymbol_HonorsPerTargetNameOverride()
+    {
+        // TS extraction picks up the TS alias; Dart extraction flips to
+        // the Dart alias. The dict keys off the stable full name so
+        // ResolveTsName on the target side stays a single lookup.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            [Name(TargetLanguage.TypeScript, "TsWidget")]
+            [Name(TargetLanguage.Dart, "DartWidget")]
+            public class Widget {}
+            """
+        );
+
+        var widget = compilation.GetTypeByMetadataName("Widget");
+        await Assert.That(widget).IsNotNull();
+        var key = widget!.GetCrossAssemblyOriginKey();
+
+        var tsIr = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(tsIr.TypeNamesBySymbol).IsNotNull();
+        await Assert.That(tsIr.TypeNamesBySymbol!).ContainsKey(key);
+        await Assert.That(tsIr.TypeNamesBySymbol![key]).IsEqualTo("TsWidget");
+
+        var dartIr = new CSharpSourceFrontend().ExtractFromCompilation(
+            compilation,
+            TargetLanguage.Dart
+        );
+        await Assert.That(dartIr.TypeNamesBySymbol![key]).IsEqualTo("DartWidget");
+    }
+
+    [Test]
+    public async Task TypeNamesBySymbol_FallsBackToSourceNameWhenNoOverride()
+    {
+        // A transpilable type without a [Name] override lands in the dict
+        // under its source name — callers rely on this so they can treat
+        // the dict as the single source of truth for emitted names of
+        // every type the frontend knows about.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Plain {}
+            """
+        );
+
+        var plain = compilation.GetTypeByMetadataName("Plain");
+        await Assert.That(plain).IsNotNull();
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        var key = plain!.GetCrossAssemblyOriginKey();
+
+        await Assert.That(ir.TypeNamesBySymbol!).ContainsKey(key);
+        await Assert.That(ir.TypeNamesBySymbol![key]).IsEqualTo("Plain");
+    }
+
+    [Test]
+    public async Task TypeNamesBySymbol_HonorsNestedTypeNameOverride()
+    {
+        // Nested [Transpile] types with per-target [Name(…)] overrides
+        // must enter the dict too — otherwise the target's ResolveTsName
+        // falls back to the C# name and the rename is silently dropped
+        // at the class emission + guard paths.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public class Outer
+            {
+                [Transpile]
+                [Name(TargetLanguage.TypeScript, "RenamedInner")]
+                public class Inner {}
+            }
+            """
+        );
+
+        var inner = compilation.GetTypeByMetadataName("Outer+Inner");
+        await Assert.That(inner).IsNotNull();
+        var key = inner!.GetCrossAssemblyOriginKey();
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.TypeNamesBySymbol!).ContainsKey(key);
+        await Assert.That(ir.TypeNamesBySymbol![key]).IsEqualTo("RenamedInner");
+    }
 }


### PR DESCRIPTION
## Summary

Second consumer-side migration after Phase B.5 (#75). The frontend ships a pre-resolved target-name dictionary on the IR and the TypeScript backend resolves every per-target name through a single lookup helper. `TypeTransformer.GetTsTypeName` is gone.

## Changes

- **`IrCompilation.TypeNamesBySymbol`** (nullable, defaulted at end) — keyed by the assembly-qualified stable full name (`SymbolHelper.GetCrossAssemblyOriginKey`) so two referenced assemblies exposing types with identical stable full names cannot overwrite each other's target-name override.
- **`CSharpSourceFrontend.BuildTypeNamesBySymbol`** — walks the current assembly (transpilable types + public `[Import]` placeholders) plus every transpilable referenced assembly via `EnumerateTranspilableReferencedAssemblies`. The walker recurses into nested transpilable types so `[Name(target, …)]` overrides on nested declarations enter the map (compiler-man review caught the regression this locks).
- **`TypeScriptTransformContext`** — gains `TypeNamesBySymbol` + `ResolveTsName(INamedTypeSymbol)` with a `type.Name` fallback so BCL types the frontend doesn't precompute still work (matches legacy `GetNameOverride(type, TS) ?? type.Name`).
- **16 call-site flips** — `TypeTransformer` setup uses a local closure (pre-context phase); nested-type emission + `GroupTypesByFile` use `Context.ResolveTsName`; `TypeGuardBuilder`, `JsonSerializerContextTransformer` (5), `IrToTsClassEmitter` (2) route through the context helper; `ImportCollector` takes the dict in its constructor and flips its static `GetFileName` to instance so the three call sites can reach it.
- **`TypeTransformer.GetTsTypeName` deleted.** Stale doc reference in `IrToTsNamingPolicy` updated.

## Tests

Three new frontend cases: target override picked up (TS vs Dart flips winner), source-name fallback when no override, nested-type rename carried into the dict.

## Follow-ups (out of scope)

- `ResolveTsName` exists in three places (context, `ImportCollector`, `TransformAll` closure). The closure is unavoidable before context construction; `ImportCollector` could consume the context directly in a later cleanup.

## Test plan

- [x] `dotnet build Metano.slnx`
- [x] `dotnet run --project tests/Metano.Tests/` → 601/601
- [x] `dotnet csharpier check .`
- [x] Samples byte-identical (sample-todo, sample-todo-service, sample-issue-tracker, flutter/sample_counter)

Part of #58