### PR TITLE
refactor(core): retire _guardNameToTypeMap via IR (Phase B.8)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -285,8 +285,7 @@ public sealed class ImportCollector(
             // and `isCurrency` ends up with a single `import { Currency, isCurrency }`
             // line instead of two.
             if (
-                _context.GuardNameToTypeMap.TryGetValue(typeName, out var guardedTypeName)
-                && _context.TranspilableTypeMap.TryGetValue(guardedTypeName, out var guardedSymbol)
+                _context.TryResolveGuardImport(typeName, out var guardedSymbol)
                 && importedNames.Add(typeName)
             )
             {

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.Extraction;
@@ -33,8 +34,8 @@ public sealed class TypeScriptTransformContext(
     IReadOnlyDictionary<string, INamedTypeSymbol> transpilableTypeMap,
     IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
-    IReadOnlyDictionary<string, string> guardNameToTypeMap,
     IReadOnlyDictionary<string, string> typeNamesBySymbol,
+    IReadOnlySet<string> guardableTypeKeys,
     PathNaming pathNaming,
     DeclarativeMappingRegistry declarativeMappings,
     Action<MetanoDiagnostic> reportDiagnostic
@@ -48,11 +49,38 @@ public sealed class TypeScriptTransformContext(
     public IReadOnlyDictionary<string, IrExternalImport> ExternalImportMap { get; } =
         externalImportMap;
     public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
-    public IReadOnlyDictionary<string, string> GuardNameToTypeMap { get; } = guardNameToTypeMap;
     public IReadOnlyDictionary<string, string> TypeNamesBySymbol { get; } = typeNamesBySymbol;
+    public IReadOnlySet<string> GuardableTypeKeys { get; } = guardableTypeKeys;
     public PathNaming PathNaming { get; } = pathNaming;
     public DeclarativeMappingRegistry DeclarativeMappings { get; } = declarativeMappings;
     public Action<MetanoDiagnostic> ReportDiagnostic { get; } = reportDiagnostic;
+
+    /// <summary>
+    /// Recognizes a referenced identifier as the TypeScript guard
+    /// function for a transpilable type — i.e. an <c>is{Name}</c>
+    /// import where the underlying type is in
+    /// <see cref="GuardableTypeKeys"/>. Returns the guarded type's
+    /// Roslyn symbol so callers can compute file paths / namespaces
+    /// without re-looking it up. The <c>is</c> prefix is the TypeScript
+    /// naming convention and stays target-local; the IR ships only the
+    /// guardable-type set.
+    /// </summary>
+    public bool TryResolveGuardImport(
+        string candidate,
+        [NotNullWhen(true)] out INamedTypeSymbol? guardedSymbol
+    )
+    {
+        guardedSymbol = null;
+        if (!candidate.StartsWith("is", StringComparison.Ordinal) || candidate.Length <= 2)
+            return false;
+        var guessedTsName = candidate[2..];
+        if (!TranspilableTypeMap.TryGetValue(guessedTsName, out var resolved))
+            return false;
+        if (!GuardableTypeKeys.Contains(resolved.GetCrossAssemblyOriginKey()))
+            return false;
+        guardedSymbol = resolved;
+        return true;
+    }
 
     /// <summary>
     /// Resolves the target-facing TypeScript name for a Roslyn type symbol.

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -155,14 +155,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         // All callers now use the explicit TypeMappingContext — no static assignment needed.
 
-        // Build guard name → type name map for cross-file guard imports
-        _guardNameToTypeMap = new Dictionary<string, string>();
-        foreach (var t in transpilableTypes)
-        {
-            var tsName = ResolveTsName(t);
-            _guardNameToTypeMap[$"is{tsName}"] = tsName;
-        }
-
         _pathNaming = new PathNaming(ir.LocalRootNamespace);
 
         var declarativeMappings = DeclarativeMappingRegistry.FromIr(ir);
@@ -174,8 +166,8 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             _transpilableTypeMap,
             _externalImportMap,
             ir.BclExports,
-            _guardNameToTypeMap,
             typeNamesBySymbol,
+            ir.GuardableTypeKeys ?? new HashSet<string>(StringComparer.Ordinal),
             _pathNaming,
             declarativeMappings,
             _diagnostics.Add
@@ -255,12 +247,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     private IMethodSymbol? _syntheticEntryPoint;
     private Dictionary<string, INamedTypeSymbol> _transpilableTypeMap = [];
     private Dictionary<string, IrExternalImport> _externalImportMap = [];
-
-    /// <summary>
-    /// Maps guard function names (e.g., "isCurrency") to the type they guard (e.g., "Currency").
-    /// Used to resolve imports for cross-file guard calls.
-    /// </summary>
-    private Dictionary<string, string> _guardNameToTypeMap = [];
     private PathNaming _pathNaming = new("");
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -119,6 +119,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? null
             : BuildTypeNamesBySymbol(compilation, target, assemblyWideTranspile);
 
+        var guardableTypeKeys = compilation is null
+            ? null
+            : BuildGuardableTypeKeys(compilation, assemblyWideTranspile);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -143,7 +147,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             DeclarativeMethodMappings: declarativeMappings.Methods,
             DeclarativePropertyMappings: declarativeMappings.Properties,
             ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper,
-            TypeNamesBySymbol: typeNamesBySymbol
+            TypeNamesBySymbol: typeNamesBySymbol,
+            GuardableTypeKeys: guardableTypeKeys
         );
     }
 
@@ -318,6 +323,41 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         }
 
         return map;
+    }
+
+    /// <summary>
+    /// Collects the assembly-qualified stable full name of every
+    /// transpilable top-level type in the current assembly that declares
+    /// <c>[GenerateGuard]</c>. Backends pair this set with their own
+    /// guard-naming convention (TypeScript: <c>is{Name}</c>) to decide
+    /// when a referenced identifier is actually a guard import, without
+    /// re-reading the attribute at every call site. Current-assembly /
+    /// top-level only — mirrors the top-level transpilable set the
+    /// legacy <c>_guardNameToTypeMap</c> init loop walked, minus the
+    /// synthetic Program type (C# 9+ top-level statements) which can
+    /// never carry <c>[GenerateGuard]</c>.
+    /// </summary>
+    private static IReadOnlySet<string> BuildGuardableTypeKeys(
+        Compilation compilation,
+        bool assemblyWideTranspile
+    )
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        var currentAssembly = compilation.Assembly;
+
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+            {
+                if (!SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+                    return;
+                if (!SymbolHelper.HasGenerateGuard(type))
+                    return;
+                keys.Add(type.GetCrossAssemblyOriginKey());
+            }
+        );
+
+        return keys;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -97,6 +97,13 @@ namespace Metano.Compiler.IR;
 /// extraction pass. Qualifying by assembly prevents two referenced
 /// assemblies that expose types with identical stable full names from
 /// silently overwriting each other's override.</param>
+/// <param name="GuardableTypeKeys">Set of assembly-qualified stable full
+/// names (same shape as <paramref name="TypeNamesBySymbol"/> keys) for
+/// every transpilable type carrying <c>[GenerateGuard]</c>. Backends pair
+/// this with their own guard-naming convention (TypeScript: <c>is{Name}</c>)
+/// so each target owns the prefix but the set of guardable types stays
+/// source-truth. Current-assembly, top-level only — matches the scope
+/// <c>TypeTransformer</c> used inline.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -118,5 +125,6 @@ public sealed record IrCompilation(
         DeclarativeMappingEntry
     >? DeclarativePropertyMappings = null,
     IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null,
-    IReadOnlyDictionary<string, string>? TypeNamesBySymbol = null
+    IReadOnlyDictionary<string, string>? TypeNamesBySymbol = null,
+    IReadOnlySet<string>? GuardableTypeKeys = null
 );

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -253,4 +253,33 @@ public class TypeGuardTranspileTests
         await Assert.That(output).Contains("typeof v.count === \"number\"");
         await Assert.That(output).Contains("typeof v.name === \"string\"");
     }
+
+    [Test]
+    public async Task Guard_ForRenamedTypeImportedCrossFile_ResolvesViaTsName()
+    {
+        // A type with [Name(TS, "Ticker")] + [GenerateGuard] emits
+        // `isTicker`. A sibling record whose own guard references the
+        // aliased type's guard must import `isTicker` via its alias —
+        // this exercises the dual-keying invariant on
+        // _transpilableTypeMap + GuardableTypeKeys that
+        // TryResolveGuardImport relies on.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App
+            {
+                [Transpile, StringEnum, GenerateGuard]
+                [Name(TargetLanguage.TypeScript, "Ticker")]
+                public enum Symbol { Brl, Usd }
+
+                [Transpile, GenerateGuard]
+                public record Quote(int Cents, Symbol Kind);
+            }
+            """
+        );
+
+        var quoteKey = result.Keys.Single(k => k.EndsWith("quote.ts"));
+        var quote = result[quoteKey];
+        await Assert.That(quote).Contains("isTicker");
+        await Assert.That(quote).Contains("Ticker");
+    }
 }

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -277,7 +277,7 @@ public class TypeGuardTranspileTests
             """
         );
 
-        var quoteKey = result.Keys.Single(k => k.EndsWith("quote.ts"));
+        var quoteKey = result.Keys.Single(k => k.EndsWith("quote.ts", StringComparison.Ordinal));
         var quote = result[quoteKey];
         await Assert.That(quote).Contains("isTicker");
         await Assert.That(quote).Contains("Ticker");


### PR DESCRIPTION
## Summary

Next consumer-side migration after Phase B.7 (#77). The TypeScript target's `_guardNameToTypeMap` dict (`isTsName → TsName`) retires in favor of an IR-level `GuardableTypeKeys` set; the `is` prefix stays target-local inside a single `TryResolveGuardImport` helper on `TypeScriptTransformContext`.

## Changes

- **`IrCompilation.GuardableTypeKeys`** — nullable default, keyed by `GetCrossAssemblyOriginKey` (assembly-qualified, consistent with `TypeNamesBySymbol`).
- **`CSharpSourceFrontend.BuildGuardableTypeKeys`** — walks the current assembly's top-level transpilable types filtered by `HasGenerateGuard`. Tighter than the legacy init loop (which over-registered every transpilable type regardless of `[GenerateGuard]` — harmless, nothing depended on the slack).
- **`TypeScriptTransformContext`** drops `guardNameToTypeMap` / `GuardNameToTypeMap`; gains `guardableTypeKeys` / `GuardableTypeKeys` + `TryResolveGuardImport(string candidate, out INamedTypeSymbol? guardedSymbol)`. The helper returns the Roslyn symbol directly so the caller does not re-look it up via `TranspilableTypeMap`.
- **`TypeTransformer`** — deletes the `_guardNameToTypeMap` field, init loop, and ctor arg; forwards `ir.GuardableTypeKeys` into the context constructor.
- **`ImportCollector`** — two-step lookup collapses to a single `_context.TryResolveGuardImport(...)` call.

## Tests

New `Guard_ForRenamedTypeImportedCrossFile_ResolvesViaTsName` locks the `[Name(TS, …)]` + `[GenerateGuard]` cross-file import contract — the dual-keying on `_transpilableTypeMap` is what makes the helper work for aliased types. 602/602 green; all five samples byte-identical.

## Test plan

- [x] `dotnet build Metano.slnx`
- [x] `dotnet run --project tests/Metano.Tests/` → 602/602
- [x] `dotnet csharpier check .`
- [x] Samples byte-identical (sample-todo, sample-todo-service, sample-issue-tracker, flutter/sample_counter)

Part of #58