### PR TITLE
refactor(ts): unify TS-name resolver via static helper (Phase B.9)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -85,12 +85,12 @@ public sealed class TypeScriptTransformContext(
     /// <summary>
     /// Resolves the target-facing TypeScript name for a Roslyn type
     /// symbol without needing a constructed
-    /// <see cref="TypeScriptTransformContext"/>. Used during the early
-    /// setup phase of <c>TypeTransformer.TransformAll</c> where the
-    /// context does not yet exist; in every other call site prefer the
-    /// instance method so future changes stay in one place.
+    /// <see cref="TypeScriptTransformContext"/> instance. Used during
+    /// the early setup phase of <c>TypeTransformer.TransformAll</c>
+    /// where the context does not yet exist; in every other call site
+    /// prefer the instance method so future changes stay in one place.
     /// </summary>
-    public static string ResolveTsName(
+    internal static string ResolveTsName(
         IReadOnlyDictionary<string, string>? typeNamesBySymbol,
         INamedTypeSymbol type
     ) =>

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -83,6 +83,23 @@ public sealed class TypeScriptTransformContext(
     }
 
     /// <summary>
+    /// Resolves the target-facing TypeScript name for a Roslyn type
+    /// symbol without needing a constructed
+    /// <see cref="TypeScriptTransformContext"/>. Used during the early
+    /// setup phase of <c>TypeTransformer.TransformAll</c> where the
+    /// context does not yet exist; in every other call site prefer the
+    /// instance method so future changes stay in one place.
+    /// </summary>
+    public static string ResolveTsName(
+        IReadOnlyDictionary<string, string>? typeNamesBySymbol,
+        INamedTypeSymbol type
+    ) =>
+        typeNamesBySymbol is not null
+        && typeNamesBySymbol.TryGetValue(type.GetCrossAssemblyOriginKey(), out var name)
+            ? name
+            : type.Name;
+
+    /// <summary>
     /// Resolves the target-facing TypeScript name for a Roslyn type symbol.
     /// Reads the frontend-populated <see cref="TypeNamesBySymbol"/> dictionary
     /// so <c>[Name(TypeScript, …)]</c> overrides are honored; falls back to
@@ -90,10 +107,7 @@ public sealed class TypeScriptTransformContext(
     /// not precompute (mirrors the legacy <c>TypeTransformer.GetTsTypeName</c>
     /// contract that this helper replaces).
     /// </summary>
-    public string ResolveTsName(INamedTypeSymbol type) =>
-        TypeNamesBySymbol.TryGetValue(type.GetCrossAssemblyOriginKey(), out var name)
-            ? name
-            : type.Name;
+    public string ResolveTsName(INamedTypeSymbol type) => ResolveTsName(TypeNamesBySymbol, type);
 
     /// <summary>
     /// Reports MS0001 (UnsupportedFeature) for an IR-pipeline body the bridge

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -116,8 +116,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         var typeNamesBySymbol =
             ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal);
-        string ResolveTsName(INamedTypeSymbol t) =>
-            typeNamesBySymbol.TryGetValue(t.GetCrossAssemblyOriginKey(), out var n) ? n : t.Name;
 
         var transpilableTypes = DiscoverTranspilableTypes();
         // Map by both C# name and TS name (when [Name] override differs)
@@ -125,7 +123,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         foreach (var t in transpilableTypes)
         {
             _transpilableTypeMap[t.Name] = t;
-            var tsName = ResolveTsName(t);
+            var tsName = TypeScriptTransformContext.ResolveTsName(typeNamesBySymbol, t);
             if (tsName != t.Name)
                 _transpilableTypeMap[tsName] = t;
         }


### PR DESCRIPTION
## Summary

Follow-up to Phase B.6. `TypeTransformer.TransformAll` previously wrote a local `ResolveTsName` closure to do the TS-name lookup during its pre-context setup phase (the context does not exist yet while `_transpilableTypeMap` and `_guardNameToTypeMap` are being seeded). Now that the guard map retired in B.8, the closure is the last duplicate of the context's own `ResolveTsName`.

## Changes

- **`TypeScriptTransformContext`** adds a static `ResolveTsName(IReadOnlyDictionary<string, string>? typeNamesBySymbol, INamedTypeSymbol type)` overload that both the pre-context code path and the instance method delegate to. Single source of truth.
- **Instance `ResolveTsName`** becomes a one-line forwarder.
- **`TypeTransformer.TransformAll`** drops the local `ResolveTsName` closure; the dual-keyed `_transpilableTypeMap` setup now calls `TypeScriptTransformContext.ResolveTsName` directly.

## Follow-ups (out of scope)

- Retire `_transpilableTypeMap` + `DiscoverTranspilableTypes` via IR is the next big slice.

## Test plan

- [x] `dotnet build Metano.slnx`
- [x] `dotnet run --project tests/Metano.Tests/` → 602/602
- [x] `dotnet csharpier check .`
- [x] Samples byte-identical (sample-todo, sample-todo-service, sample-issue-tracker, flutter/sample_counter)

Part of #58