### PR TITLE
refactor(core): retire _transpilableTypeMap via IR (Phase B.10)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -191,10 +191,10 @@ public sealed class ImportCollector(
         >(StringComparer.Ordinal);
 
         // Per-specifier dedup inside a bucket. The outer `importedNames` set dedupes
-        // by the *referenced* identifier (the key used to look up the symbol), but
-        // `_context.TranspilableTypeMap` is dual-keyed by C# name AND TS name when [Name]
-        // diverges, so two distinct lookup keys can resolve to the same `targetTsName`
-        // and attempt to add it twice. Without this guard the output would be
+        // by the *referenced* identifier (the key used to look up the entry), but
+        // `_context.TranspilableTypes` is dual-keyed by C# name AND TS name when [Name]
+        // diverges, so two distinct lookup keys can resolve to the same `TsName` and
+        // attempt to add it twice. Without this guard the output would be
         // `import { Foo, Foo } from "..."`. Also: if a specifier is observed as both
         // value and type-only across iterations, the value form wins — type-only is
         // the narrower claim, and runtime-imported names must not be demoted to
@@ -285,20 +285,18 @@ public sealed class ImportCollector(
             // and `isCurrency` ends up with a single `import { Currency, isCurrency }`
             // line instead of two.
             if (
-                _context.TryResolveGuardImport(typeName, out var guardedSymbol)
+                _context.TryResolveGuardImport(typeName, out var guarded)
                 && importedNames.Add(typeName)
             )
             {
-                var guardNs = PathNaming.GetNamespace(guardedSymbol);
                 // Use the file name (not the type name) when computing the path so a
                 // guard for a [EmitInFile]-grouped type points at the merged file.
-                var guardFileName = GetFileName(guardedSymbol);
-                if (guardNs == currentNs && guardFileName == currentFileName)
+                if (guarded.Namespace == currentNs && guarded.FileName == currentFileName)
                     continue; // same file
                 var guardPath = _context.PathNaming.ComputeRelativeImportPath(
                     currentNs,
-                    guardNs,
-                    guardFileName
+                    guarded.Namespace,
+                    guarded.FileName
                 );
                 // Guards are functions → always imported as values, never type-only.
                 AddLocal(guardPath, typeName, typeOnly: false);
@@ -306,31 +304,27 @@ public sealed class ImportCollector(
             }
 
             // Transpilable type within the project
-            if (!_context.TranspilableTypeMap.TryGetValue(typeName, out var referencedSymbol))
+            if (!_context.TranspilableTypes.TryGetValue(typeName, out var referencedRef))
                 continue;
 
             // Skip types co-located in the same file via [EmitInFile] — they're
             // declared locally in the merged source, no import needed.
-            var targetNs = PathNaming.GetNamespace(referencedSymbol);
-            var targetFileName = GetFileName(referencedSymbol);
-            if (targetNs == currentNs && targetFileName == currentFileName)
+            if (referencedRef.Namespace == currentNs && referencedRef.FileName == currentFileName)
                 continue;
 
             if (!importedNames.Add(typeName))
                 continue;
 
-            var targetTsName = _context.ResolveTsName(referencedSymbol);
             // Path is computed against the FILE name (not the type name) so multiple
             // types co-located in the same file resolve to the same import path.
             var importPath = _context.PathNaming.ComputeRelativeImportPath(
                 currentNs,
-                targetNs,
-                targetFileName
+                referencedRef.Namespace,
+                referencedRef.FileName
             );
             // StringEnums generate const objects — always import as value
-            var isStringEnum = SymbolHelper.HasStringEnum(referencedSymbol);
-            var typeOnly = !valueTypes.Contains(typeName) && !isStringEnum;
-            AddLocal(importPath, targetTsName, typeOnly);
+            var typeOnly = !valueTypes.Contains(typeName) && !referencedRef.IsStringEnum;
+            AddLocal(importPath, referencedRef.TsName, typeOnly);
         }
 
         // Emit one merged TsImport per bucketed local path. Three-case form:

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -19,7 +19,7 @@ namespace Metano.Transformation;
 /// </list>
 ///
 /// Field checks recurse into other transpilable guards via the context's
-/// <see cref="TypeScriptTransformContext.TranspilableTypeMap"/>.
+/// <see cref="TypeScriptTransformContext.TranspilableTypes"/>.
 /// </summary>
 public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
 {
@@ -315,7 +315,7 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
             ),
 
             // Transpilable named type → call guard recursively
-            TsNamedType { Name: var n } when _context.TranspilableTypeMap.ContainsKey(n) =>
+            TsNamedType { Name: var n } when _context.TranspilableTypes.ContainsKey(n) =>
                 new TsCallExpression(new TsIdentifier($"is{n}"), [fieldAccess]),
 
             // Union with null (nullable) → field == null || innerCheck

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeScriptTransformContext.cs
@@ -31,7 +31,7 @@ public sealed class TypeScriptTransformContext(
     Compilation compilation,
     IAssemblySymbol? currentAssembly,
     bool assemblyWideTranspile,
-    IReadOnlyDictionary<string, INamedTypeSymbol> transpilableTypeMap,
+    IReadOnlyDictionary<string, IrTranspilableTypeRef> transpilableTypes,
     IReadOnlyDictionary<string, IrExternalImport> externalImportMap,
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, string> typeNamesBySymbol,
@@ -44,8 +44,21 @@ public sealed class TypeScriptTransformContext(
     public Compilation Compilation { get; } = compilation;
     public IAssemblySymbol? CurrentAssembly { get; } = currentAssembly;
     public bool AssemblyWideTranspile { get; } = assemblyWideTranspile;
-    public IReadOnlyDictionary<string, INamedTypeSymbol> TranspilableTypeMap { get; } =
-        transpilableTypeMap;
+
+    /// <summary>
+    /// Frontend-built projection of every current-assembly top-level
+    /// transpilable type, indexed under both its C# source name and its
+    /// TS alias. Resolves a bare identifier (walked out of the generated
+    /// target AST) to <see cref="IrTranspilableTypeRef"/> emit metadata
+    /// — origin key, namespace, on-disk file name, string-enum flag —
+    /// without going back to the Roslyn symbol table. Consulted by the
+    /// import collector (to decide whether to emit a local import) and
+    /// the guard builder (to decide whether a field type has its own
+    /// guard to recurse into).
+    /// </summary>
+    public IReadOnlyDictionary<string, IrTranspilableTypeRef> TranspilableTypes { get; } =
+        transpilableTypes;
+
     public IReadOnlyDictionary<string, IrExternalImport> ExternalImportMap { get; } =
         externalImportMap;
     public IReadOnlyDictionary<string, IrBclExport> BclExportMap { get; } = bclExportMap;
@@ -60,25 +73,25 @@ public sealed class TypeScriptTransformContext(
     /// function for a transpilable type — i.e. an <c>is{Name}</c>
     /// import where the underlying type is in
     /// <see cref="GuardableTypeKeys"/>. Returns the guarded type's
-    /// Roslyn symbol so callers can compute file paths / namespaces
+    /// IR projection so callers can compute file paths / namespaces
     /// without re-looking it up. The <c>is</c> prefix is the TypeScript
     /// naming convention and stays target-local; the IR ships only the
     /// guardable-type set.
     /// </summary>
     public bool TryResolveGuardImport(
         string candidate,
-        [NotNullWhen(true)] out INamedTypeSymbol? guardedSymbol
+        [NotNullWhen(true)] out IrTranspilableTypeRef? guarded
     )
     {
-        guardedSymbol = null;
+        guarded = null;
         if (!candidate.StartsWith("is", StringComparison.Ordinal) || candidate.Length <= 2)
             return false;
         var guessedTsName = candidate[2..];
-        if (!TranspilableTypeMap.TryGetValue(guessedTsName, out var resolved))
+        if (!TranspilableTypes.TryGetValue(guessedTsName, out var resolved))
             return false;
-        if (!GuardableTypeKeys.Contains(resolved.GetCrossAssemblyOriginKey()))
+        if (!GuardableTypeKeys.Contains(resolved.Key))
             return false;
-        guardedSymbol = resolved;
+        guarded = resolved;
         return true;
     }
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -118,15 +118,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal);
 
         var transpilableTypes = DiscoverTranspilableTypes();
-        // Map by both C# name and TS name (when [Name] override differs)
-        _transpilableTypeMap = new Dictionary<string, INamedTypeSymbol>();
-        foreach (var t in transpilableTypes)
-        {
-            _transpilableTypeMap[t.Name] = t;
-            var tsName = TypeScriptTransformContext.ResolveTsName(typeNamesBySymbol, t);
-            if (tsName != t.Name)
-                _transpilableTypeMap[tsName] = t;
-        }
 
         // Seed the external-import map from the frontend. The IR covers every
         // [Import] type from the current assembly, plus those from referenced
@@ -161,7 +152,8 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             compilation,
             _currentAssembly,
             _assemblyWideTranspile,
-            _transpilableTypeMap,
+            ir.TranspilableTypes
+                ?? new Dictionary<string, IrTranspilableTypeRef>(StringComparer.Ordinal),
             _externalImportMap,
             ir.BclExports,
             typeNamesBySymbol,
@@ -243,7 +235,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// <c>[ExportedAsModule]</c> + <c>[ModuleEntryPoint]</c>.
     /// </summary>
     private IMethodSymbol? _syntheticEntryPoint;
-    private Dictionary<string, INamedTypeSymbol> _transpilableTypeMap = [];
     private Dictionary<string, IrExternalImport> _externalImportMap = [];
     private PathNaming _pathNaming = new("");
 

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -123,6 +123,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? null
             : BuildGuardableTypeKeys(compilation, assemblyWideTranspile);
 
+        var transpilableTypes = compilation is null
+            ? null
+            : BuildTranspilableTypes(compilation, target, assemblyWideTranspile);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -148,7 +152,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             DeclarativePropertyMappings: declarativeMappings.Properties,
             ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper,
             TypeNamesBySymbol: typeNamesBySymbol,
-            GuardableTypeKeys: guardableTypeKeys
+            GuardableTypeKeys: guardableTypeKeys,
+            TranspilableTypes: transpilableTypes
         );
     }
 
@@ -358,6 +363,66 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         );
 
         return keys;
+    }
+
+    /// <summary>
+    /// Projects every current-assembly top-level transpilable type to an
+    /// <see cref="IrTranspilableTypeRef"/> and indexes it under both its
+    /// C# source name and its target-facing TS name (when
+    /// <c>[Name(target, …)]</c> diverges). Lets the backend resolve a
+    /// bare identifier walked out of the generated AST into emit
+    /// metadata — origin key, namespace, on-disk file name, string-enum
+    /// flag — without going back to the Roslyn symbol table. Current
+    /// assembly, top-level only, nested types excluded. The synthetic
+    /// C# 9+ top-level <c>Program</c> type is included under
+    /// <c>[assembly: TranspileAssembly]</c> so the target's import
+    /// collector resolves module-entry references consistently with
+    /// every other transpilable type.
+    /// </summary>
+    private static IReadOnlyDictionary<string, IrTranspilableTypeRef> BuildTranspilableTypes(
+        Compilation compilation,
+        TargetLanguage target,
+        bool assemblyWideTranspile
+    )
+    {
+        var map = new Dictionary<string, IrTranspilableTypeRef>(StringComparer.Ordinal);
+        var currentAssembly = compilation.Assembly;
+
+        void Register(INamedTypeSymbol type)
+        {
+            var tsName = SymbolHelper.GetNameOverride(type, target) ?? type.Name;
+            var ns = type.ContainingNamespace.IsGlobalNamespace
+                ? ""
+                : type.ContainingNamespace.ToDisplayString();
+            var emitInFile = SymbolHelper.GetEmitInFile(type);
+            var fileBase = emitInFile is { Length: > 0 } ? emitInFile : tsName;
+            var fileName = SymbolHelper.ToKebabCase(fileBase);
+            var entry = new IrTranspilableTypeRef(
+                Key: type.GetCrossAssemblyOriginKey(),
+                TsName: tsName,
+                Namespace: ns,
+                FileName: fileName,
+                IsStringEnum: SymbolHelper.HasStringEnum(type)
+            );
+            map.TryAdd(type.Name, entry);
+            if (tsName != type.Name)
+                map.TryAdd(tsName, entry);
+        }
+
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+            {
+                if (!SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+                    return;
+                Register(type);
+            }
+        );
+
+        if (assemblyWideTranspile && TryGetTopLevelProgramType(compilation, out var programType))
+            Register(programType);
+
+        return map;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -404,9 +404,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 FileName: fileName,
                 IsStringEnum: SymbolHelper.HasStringEnum(type)
             );
-            map.TryAdd(type.Name, entry);
+            // Last-wins on bare-identifier collision — matches the legacy
+            // `_transpilableTypeMap[...] = ...` assignments the target side
+            // ran inline. Two top-level types in different namespaces with
+            // the same simple name, or an alias that shadows another type's
+            // source name, stay resolvable (to whichever registered last)
+            // instead of silently dropping the second entry.
+            map[type.Name] = entry;
             if (tsName != type.Name)
-                map.TryAdd(tsName, entry);
+                map[tsName] = entry;
         }
 
         CollectTopLevelTypes(

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -104,6 +104,17 @@ namespace Metano.Compiler.IR;
 /// so each target owns the prefix but the set of guardable types stays
 /// source-truth. Current-assembly, top-level only — matches the scope
 /// <c>TypeTransformer</c> used inline.</param>
+/// <param name="TranspilableTypes">Dictionary of
+/// <see cref="IrTranspilableTypeRef"/> entries keyed by bare identifier —
+/// both the C# source name and, when it differs, the per-target
+/// <c>[Name(target, …)]</c> alias. Lets the backend resolve an identifier
+/// walked out of the generated target AST (import collector, guard
+/// builder) into emit metadata without going back to the Roslyn symbol
+/// table. Current-assembly top-level transpilable types only, with the
+/// synthetic C# 9+ top-level <c>Program</c> type included under
+/// <c>[assembly: TranspileAssembly]</c>. Appended with a nullable default
+/// so adding the projection cannot shift downstream positional
+/// arguments.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -126,5 +137,6 @@ public sealed record IrCompilation(
     >? DeclarativePropertyMappings = null,
     IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null,
     IReadOnlyDictionary<string, string>? TypeNamesBySymbol = null,
-    IReadOnlySet<string>? GuardableTypeKeys = null
+    IReadOnlySet<string>? GuardableTypeKeys = null,
+    IReadOnlyDictionary<string, IrTranspilableTypeRef>? TranspilableTypes = null
 );

--- a/src/Metano.Compiler/IR/IrTranspilableTypeRef.cs
+++ b/src/Metano.Compiler/IR/IrTranspilableTypeRef.cs
@@ -1,0 +1,37 @@
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// Projection of a transpilable type the backend may look up by identifier.
+/// Carries every emit-time fact the downstream import collector and guard
+/// builder need — origin key, target-facing name, namespace, on-disk file
+/// name (kebab-cased, honoring <c>[EmitInFile]</c>), and the string-enum
+/// flag that forces a value import. Lets the backend resolve a bare TS
+/// identifier (walked out of the generated AST) to emit metadata without
+/// going back to the Roslyn symbol table.
+/// </summary>
+/// <param name="Key">Cross-assembly origin key
+/// (<see cref="SymbolHelper.GetCrossAssemblyOriginKey"/>). Used to probe
+/// <see cref="IrCompilation.GuardableTypeKeys"/> when resolving
+/// <c>is{Name}</c> guard imports.</param>
+/// <param name="TsName">Target-facing name — already resolves
+/// <c>[Name(target, …)]</c> overrides. For top-level transpilable keys
+/// this matches the value <see cref="IrCompilation.TypeNamesBySymbol"/>
+/// would return for <see cref="Key"/>.</param>
+/// <param name="Namespace">Declaring namespace, or the empty string when
+/// the type lives in the global namespace. Equivalent to
+/// <c>PathNaming.GetNamespace</c> on the source symbol.</param>
+/// <param name="FileName">Kebab-cased file name (no extension) under which
+/// the type is emitted. Honors <c>[EmitInFile("name")]</c> when present;
+/// otherwise derived from <see cref="TsName"/>. The import collector pairs
+/// this with <see cref="Namespace"/> to elide self-imports for types
+/// co-located in the same file.</param>
+/// <param name="IsStringEnum">Whether the type carries <c>[StringEnum]</c>
+/// — string-enum targets emit as runtime const objects, so they must be
+/// imported as values even when referenced only in type position.</param>
+public sealed record IrTranspilableTypeRef(
+    string Key,
+    string TsName,
+    string Namespace,
+    string FileName,
+    bool IsStringEnum
+);

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1178,4 +1178,43 @@ public class CSharpSourceFrontendTests
         await Assert.That(ir.TypeNamesBySymbol!).ContainsKey(key);
         await Assert.That(ir.TypeNamesBySymbol![key]).IsEqualTo("RenamedInner");
     }
+
+    [Test]
+    public async Task TranspilableTypes_ProjectsDualKeys_ForRenamedType()
+    {
+        // The projection must index a [Name(TypeScript, "Ticker")] type
+        // under both its C# source name AND its TS alias — the target's
+        // import collector looks up identifiers walked out of the
+        // generated AST, which can come in as either form depending on
+        // whether the reference was emitted by the bridge (TS alias) or
+        // by a template / expression body that kept the C# name.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            [Name(TargetLanguage.TypeScript, "Ticker")]
+            public class Clock {}
+            """
+        );
+
+        var clock = compilation.GetTypeByMetadataName("Clock");
+        await Assert.That(clock).IsNotNull();
+        var key = clock!.GetCrossAssemblyOriginKey();
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.TranspilableTypes).IsNotNull();
+        await Assert.That(ir.TranspilableTypes!).ContainsKey("Clock");
+        await Assert.That(ir.TranspilableTypes!).ContainsKey("Ticker");
+
+        var fromSource = ir.TranspilableTypes!["Clock"];
+        var fromAlias = ir.TranspilableTypes!["Ticker"];
+
+        // Both keys resolve to the same projection — consumers can treat
+        // either identifier flavor as equivalent for emit metadata.
+        await Assert.That(fromSource).IsEqualTo(fromAlias);
+        await Assert.That(fromSource.Key).IsEqualTo(key);
+        await Assert.That(fromSource.TsName).IsEqualTo("Ticker");
+        await Assert.That(fromSource.FileName).IsEqualTo("ticker");
+        await Assert.That(fromSource.Namespace).IsEqualTo("");
+        await Assert.That(fromSource.IsStringEnum).IsFalse();
+    }
 }

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -261,7 +261,7 @@ public class TypeGuardTranspileTests
         // `isTicker`. A sibling record whose own guard references the
         // aliased type's guard must import `isTicker` via its alias —
         // this exercises the dual-keying invariant on
-        // _transpilableTypeMap + GuardableTypeKeys that
+        // IrCompilation.TranspilableTypes + GuardableTypeKeys that
         // TryResolveGuardImport relies on.
         var result = TranspileHelper.Transpile(
             """


### PR DESCRIPTION
## Summary

- Introduces `IrTranspilableTypeRef` — frontend-built projection keyed by bare identifier (C# source name + TS alias when `[Name(target, …)]` diverges) carrying origin key, TS name, namespace, on-disk kebab-cased file name (honoring `[EmitInFile]`), and the StringEnum flag.
- Retires `TypeTransformer._transpilableTypeMap` (the last Roslyn-keyed target-side registry). `TypeScriptTransformContext` now exposes `TranspilableTypes` instead of `TranspilableTypeMap`; `TryResolveGuardImport` returns the IR projection instead of an `INamedTypeSymbol`.
- Downstream consumers (`ImportCollector`, `TypeGuardBuilder`) switch to the projection — no more symbol lookups for import resolution or recursive-guard emission.

Scope mirrors the retired map: current assembly, top-level transpilable types only, plus the synthetic C# 9+ top-level `Program` type under `[assembly: TranspileAssembly]`. Retiring `DiscoverTranspilableTypes` (syntax-tree walk) entirely is deferred to Phase B.10a ("frontend owns entry point").

## Test plan

- [x] 603/603 TUnit tests green (602 baseline + new `TranspilableTypes_ProjectsDualKeys_ForRenamedType` locks the IR contract at the frontend boundary)
- [x] `dotnet csharpier check .` passes
- [x] `diff -rq targets/js` vs `main` → byte-identical (only build artifacts differ)
- [x] `diff -rq targets/flutter` vs `main` → byte-identical
- [x] `sample-todo` bun tests: 18/18 pass
- [x] `sample-issue-tracker` bun tests: 65/65 pass
- [x] `sample-todo-service` bun tests: 19/19 pass

## Net delta

| Measure | Value |
|---|---|
| Files changed | 9 (1 new: `IrTranspilableTypeRef.cs`) |
| Additions / deletions | +196 / -45 |

Out of scope (flagged for follow-up): `_externalImportMap` cleanup (already shadows `ir.ExternalImports`), `DiscoverTranspilableTypes` retirement (Phase B.10a).

Part of #58