### PR TITLE
refactor(core): retire DiscoverTranspilableTypes via IR (Phase B.10a)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -117,7 +117,15 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         var typeNamesBySymbol =
             ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal);
 
-        var transpilableTypes = DiscoverTranspilableTypes();
+        // Frontend owns discovery now — read the ordered entry list off the
+        // IR and project it back to raw symbols for the existing per-type
+        // emission helpers (GroupTypesByFile, BuildTypeStatements). The
+        // synthetic-Program flag + the separate EntryPoint record carry the
+        // routing metadata that used to live on the target-side
+        // `_syntheticEntryPoint` field.
+        var transpilableTypeEntries =
+            ir.TranspilableTypeEntries ?? Array.Empty<IrTranspilableTypeEntry>();
+        var transpilableTypes = transpilableTypeEntries.Select(e => e.Symbol).ToList();
 
         // Seed the external-import map from the frontend. The IR covers every
         // [Import] type from the current assembly, plus those from referenced
@@ -227,14 +235,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
     private bool _assemblyWideTranspile;
     private IAssemblySymbol? _currentAssembly;
-
-    /// <summary>
-    /// The compiler-synthesized entry point method from C# 9+ top-level statements.
-    /// When set, the containing type is routed through
-    /// <see cref="EmitTopLevelStatements"/> as an implicit
-    /// <c>[ExportedAsModule]</c> + <c>[ModuleEntryPoint]</c>.
-    /// </summary>
-    private IMethodSymbol? _syntheticEntryPoint;
     private Dictionary<string, IrExternalImport> _externalImportMap = [];
     private PathNaming _pathNaming = new("");
 
@@ -256,67 +256,6 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             "TypeScriptTransformContext is not yet initialized — TransformAll() must "
                 + "complete its setup phase before any per-type helper runs."
         );
-
-    private IReadOnlyList<INamedTypeSymbol> DiscoverTranspilableTypes()
-    {
-        var types = new List<INamedTypeSymbol>();
-        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-
-        foreach (var tree in compilation.SyntaxTrees)
-        {
-            var model = compilation.GetSemanticModel(tree);
-            var root = tree.GetRoot();
-
-            foreach (var typeDecl in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
-            {
-                var symbol = model.GetDeclaredSymbol(typeDecl);
-                if (symbol is not INamedTypeSymbol namedType)
-                    continue;
-                // Skip nested types — they're processed by their containing type as companion namespaces
-                if (namedType.ContainingType is not null)
-                    continue;
-                if (
-                    !SymbolHelper.IsTranspilable(
-                        namedType,
-                        _assemblyWideTranspile,
-                        _currentAssembly
-                    )
-                )
-                    continue;
-                if (!seen.Add(namedType))
-                    continue;
-                types.Add(namedType);
-            }
-        }
-
-        // Detect C# 9+ top-level statements. Only fires when the syntax tree
-        // actually contains GlobalStatementSyntax — an explicit `static void Main()`
-        // in a Program class (traditional entry point) must NOT be routed through
-        // TransformTopLevelStatements, because there are no global statements to walk.
-        if (_assemblyWideTranspile && compilation is CSharpCompilation csharpComp)
-        {
-            var hasGlobalStatements = compilation.SyntaxTrees.Any(t =>
-                t.GetRoot().DescendantNodes().OfType<GlobalStatementSyntax>().Any()
-            );
-
-            if (hasGlobalStatements)
-            {
-                var entryPoint = csharpComp.GetEntryPoint(System.Threading.CancellationToken.None);
-                if (
-                    entryPoint is not null
-                    && entryPoint.ContainingType is { } programType
-                    && !SymbolHelper.HasExportedAsModule(programType)
-                    && seen.Add(programType)
-                )
-                {
-                    types.Add(programType);
-                    _syntheticEntryPoint = entryPoint;
-                }
-            }
-        }
-
-        return types;
-    }
 
     /// <summary>
     /// Builds the top-level statements for a single type into <paramref name="sink"/>,
@@ -362,12 +301,12 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             new JsonSerializerContextTransformer(Context).Transform(type, sink);
         }
         else if (
-            _syntheticEntryPoint is not null
-            && SymbolEqualityComparer.Default.Equals(type, _syntheticEntryPoint.ContainingType)
+            ir.EntryPoint is not null
+            && SymbolEqualityComparer.Default.Equals(type, ir.EntryPoint.ContainingType)
         )
         {
             // C# 9+ top-level statements → unwrap as module-level code
-            EmitTopLevelStatements(_syntheticEntryPoint, sink);
+            EmitTopLevelStatements(ir.EntryPoint.Method, sink);
         }
         else if (
             (SymbolHelper.HasExportedAsModule(type) || HasExtensionMembers(type)) && type.IsStatic
@@ -472,16 +411,16 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             // as module-level code by EmitTopLevelStatements; the IR class
             // extraction would produce an irrelevant shape, so skip it.
             if (
-                _syntheticEntryPoint is not null
-                && SymbolEqualityComparer.Default.Equals(type, _syntheticEntryPoint.ContainingType)
+                ir.EntryPoint is not null
+                && SymbolEqualityComparer.Default.Equals(type, ir.EntryPoint.ContainingType)
             )
                 continue;
 
-            var ir = GetOrExtractIr(type, irCache);
-            if (ir is null)
+            var typeIr = GetOrExtractIr(type, irCache);
+            if (typeIr is null)
                 continue;
 
-            foreach (var req in IrRuntimeRequirementScanner.Scan(ir))
+            foreach (var req in IrRuntimeRequirementScanner.Scan(typeIr))
                 acc.Add(req);
         }
         return acc;

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -127,6 +127,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? null
             : BuildTranspilableTypes(compilation, target, assemblyWideTranspile);
 
+        var entryPoint = compilation is null
+            ? null
+            : BuildEntryPointInfo(compilation, assemblyWideTranspile);
+
+        var transpilableTypeEntries = compilation is null
+            ? null
+            : BuildTranspilableTypeEntries(compilation, assemblyWideTranspile, entryPoint);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -153,7 +161,9 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ChainMethodsByWrapper: declarativeMappings.ChainMethodsByWrapper,
             TypeNamesBySymbol: typeNamesBySymbol,
             GuardableTypeKeys: guardableTypeKeys,
-            TranspilableTypes: transpilableTypes
+            TranspilableTypes: transpilableTypes,
+            TranspilableTypeEntries: transpilableTypeEntries,
+            EntryPoint: entryPoint
         );
     }
 
@@ -429,6 +439,90 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             Register(programType);
 
         return map;
+    }
+
+    /// <summary>
+    /// Builds the ordered list of current-assembly top-level transpilable
+    /// types the backend should emit. Replaces the syntax-tree walk
+    /// <c>TypeTransformer.DiscoverTranspilableTypes</c> used inline on the
+    /// target side. The C# 9+ synthetic <c>Program</c> type is appended
+    /// when <paramref name="entryPoint"/> is non-null and
+    /// <c>[assembly: TranspileAssembly]</c> is set — matching the retired
+    /// target-side logic exactly, so the grouping / routing loop in
+    /// <c>TransformAll</c> sees the same types in the same order.
+    /// </summary>
+    private static IReadOnlyList<IrTranspilableTypeEntry> BuildTranspilableTypeEntries(
+        Compilation compilation,
+        bool assemblyWideTranspile,
+        IrEntryPointInfo? entryPoint
+    )
+    {
+        var entries = new List<IrTranspilableTypeEntry>();
+        var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var currentAssembly = compilation.Assembly;
+
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+            {
+                if (!SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+                    return;
+                if (!seen.Add(type))
+                    return;
+                entries.Add(
+                    new IrTranspilableTypeEntry(
+                        Symbol: type,
+                        Key: type.GetCrossAssemblyOriginKey(),
+                        IsSyntheticProgram: false
+                    )
+                );
+            }
+        );
+
+        // Synthetic Program appended last, matching the retired
+        // DiscoverTranspilableTypes ordering. De-dupe against `seen` so an
+        // explicit `[Transpile] class Program` doesn't collide with the
+        // synthetic routing flag.
+        if (entryPoint is not null && seen.Add(entryPoint.ContainingType))
+        {
+            entries.Add(
+                new IrTranspilableTypeEntry(
+                    Symbol: entryPoint.ContainingType,
+                    Key: entryPoint.ContainingType.GetCrossAssemblyOriginKey(),
+                    IsSyntheticProgram: true
+                )
+            );
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Detects the C# 9+ top-level-statement entry point and returns the
+    /// synthesized method + containing type. Returns <c>null</c> when
+    /// <c>[assembly: TranspileAssembly]</c> is absent, the compilation has
+    /// no <c>GlobalStatementSyntax</c>, Roslyn reports no entry point, or
+    /// the containing type opts out via <c>[ExportedAsModule]</c>. Reuses
+    /// <see cref="TryGetTopLevelProgramType"/> so the detection logic
+    /// stays in one place.
+    /// </summary>
+    private static IrEntryPointInfo? BuildEntryPointInfo(
+        Compilation compilation,
+        bool assemblyWideTranspile
+    )
+    {
+        if (!assemblyWideTranspile)
+            return null;
+        if (compilation is not CSharpCompilation csharpComp)
+            return null;
+        if (!TryGetTopLevelProgramType(compilation, out var programType))
+            return null;
+
+        var entryPoint = csharpComp.GetEntryPoint(CancellationToken.None);
+        if (entryPoint is null)
+            return null;
+
+        return new IrEntryPointInfo(Method: entryPoint, ContainingType: programType);
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -193,7 +193,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
         );
 
-        if (assemblyWideTranspile && TryGetTopLevelEntryPoint(compilation, out _, out var programType))
+        if (
+            assemblyWideTranspile
+            && TryGetTopLevelEntryPoint(compilation, out _, out var programType)
+        )
             transpilable.Add(programType);
 
         return ComputeRootNamespaceFromTypes(transpilable);
@@ -439,7 +442,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
         );
 
-        if (assemblyWideTranspile && TryGetTopLevelEntryPoint(compilation, out _, out var programType))
+        if (
+            assemblyWideTranspile
+            && TryGetTopLevelEntryPoint(compilation, out _, out var programType)
+        )
             Register(programType);
 
         return map;
@@ -518,13 +524,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     {
         if (!assemblyWideTranspile)
             return null;
-        if (
-            !TryGetTopLevelEntryPoint(
-                compilation,
-                out var entryPointMethod,
-                out var programType
-            )
-        )
+        if (!TryGetTopLevelEntryPoint(compilation, out var entryPointMethod, out var programType))
             return null;
 
         return new IrEntryPointInfo(Method: entryPointMethod!, ContainingType: programType);

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -193,7 +193,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
         );
 
-        if (assemblyWideTranspile && TryGetTopLevelProgramType(compilation, out var programType))
+        if (assemblyWideTranspile && TryGetTopLevelEntryPoint(compilation, out _, out var programType))
             transpilable.Add(programType);
 
         return ComputeRootNamespaceFromTypes(transpilable);
@@ -201,17 +201,20 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
     /// <summary>
     /// Detects C# 9+ top-level statements and returns the compiler-synthesized
-    /// containing type (usually <c>Program</c>) that <c>TypeTransformer</c>
-    /// treats as transpilable under assembly-wide mode. Returns <c>false</c>
-    /// when there are no global statements, when Roslyn reports no entry
-    /// point, or when the program type opts out via
-    /// <c>[ExportedAsModule]</c>.
+    /// entry-point method plus its containing type (usually <c>Program</c>)
+    /// that <c>TypeTransformer</c> treats as transpilable under assembly-wide
+    /// mode. Returns <c>false</c> when there are no global statements, when
+    /// Roslyn reports no entry point, or when the program type opts out via
+    /// <c>[ExportedAsModule]</c>. Callers that only need the containing type
+    /// can discard <paramref name="entryPointMethod"/> with <c>out _</c>.
     /// </summary>
-    private static bool TryGetTopLevelProgramType(
+    private static bool TryGetTopLevelEntryPoint(
         Compilation compilation,
+        out IMethodSymbol? entryPointMethod,
         out INamedTypeSymbol programType
     )
     {
+        entryPointMethod = null;
         if (compilation is not CSharpCompilation csharpComp)
         {
             programType = null!;
@@ -240,6 +243,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             return false;
         }
 
+        entryPointMethod = entryPoint;
         programType = containingType;
         return true;
     }
@@ -435,7 +439,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
         );
 
-        if (assemblyWideTranspile && TryGetTopLevelProgramType(compilation, out var programType))
+        if (assemblyWideTranspile && TryGetTopLevelEntryPoint(compilation, out _, out var programType))
             Register(programType);
 
         return map;
@@ -503,8 +507,9 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// <c>[assembly: TranspileAssembly]</c> is absent, the compilation has
     /// no <c>GlobalStatementSyntax</c>, Roslyn reports no entry point, or
     /// the containing type opts out via <c>[ExportedAsModule]</c>. Reuses
-    /// <see cref="TryGetTopLevelProgramType"/> so the detection logic
-    /// stays in one place.
+    /// <see cref="TryGetTopLevelEntryPoint"/> so the detection logic stays
+    /// in one place — a single <c>GetEntryPoint</c> call services every
+    /// caller.
     /// </summary>
     private static IrEntryPointInfo? BuildEntryPointInfo(
         Compilation compilation,
@@ -513,16 +518,16 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     {
         if (!assemblyWideTranspile)
             return null;
-        if (compilation is not CSharpCompilation csharpComp)
-            return null;
-        if (!TryGetTopLevelProgramType(compilation, out var programType))
+        if (
+            !TryGetTopLevelEntryPoint(
+                compilation,
+                out var entryPointMethod,
+                out var programType
+            )
+        )
             return null;
 
-        var entryPoint = csharpComp.GetEntryPoint(CancellationToken.None);
-        if (entryPoint is null)
-            return null;
-
-        return new IrEntryPointInfo(Method: entryPoint, ContainingType: programType);
+        return new IrEntryPointInfo(Method: entryPointMethod!, ContainingType: programType);
     }
 
     /// <summary>

--- a/src/Metano.Compiler/IR/IrCompilation.cs
+++ b/src/Metano.Compiler/IR/IrCompilation.cs
@@ -115,6 +115,22 @@ namespace Metano.Compiler.IR;
 /// <c>[assembly: TranspileAssembly]</c>. Appended with a nullable default
 /// so adding the projection cannot shift downstream positional
 /// arguments.</param>
+/// <param name="TranspilableTypeEntries">Ordered list of every
+/// current-assembly top-level transpilable type the backend should
+/// emit. Replaces the target-side syntax-tree walk
+/// (<c>TypeTransformer.DiscoverTranspilableTypes</c>) so discovery and
+/// order stay frontend-owned. Each entry carries the Roslyn
+/// <see cref="IrTranspilableTypeEntry.Symbol"/> (needed by per-type
+/// bridges and nested-type walking) plus the synthetic-Program flag so
+/// the target can route top-level-statement emission without a separate
+/// symbol comparison.</param>
+/// <param name="EntryPoint">Top-level-statement entry-point metadata
+/// when the current assembly declares <c>[assembly: TranspileAssembly]</c>
+/// and contains C# 9+ global statements; <c>null</c> otherwise.
+/// Backends pair this with the <c>IsSyntheticProgram</c> flag on
+/// <see cref="TranspilableTypeEntries"/> to route the containing type's
+/// emission through top-level-statement rendering instead of the
+/// regular class path.</param>
 public sealed record IrCompilation(
     string AssemblyName,
     string? PackageName,
@@ -138,5 +154,7 @@ public sealed record IrCompilation(
     IReadOnlyDictionary<string, IReadOnlySet<string>>? ChainMethodsByWrapper = null,
     IReadOnlyDictionary<string, string>? TypeNamesBySymbol = null,
     IReadOnlySet<string>? GuardableTypeKeys = null,
-    IReadOnlyDictionary<string, IrTranspilableTypeRef>? TranspilableTypes = null
+    IReadOnlyDictionary<string, IrTranspilableTypeRef>? TranspilableTypes = null,
+    IReadOnlyList<IrTranspilableTypeEntry>? TranspilableTypeEntries = null,
+    IrEntryPointInfo? EntryPoint = null
 );

--- a/src/Metano.Compiler/IR/IrEntryPointInfo.cs
+++ b/src/Metano.Compiler/IR/IrEntryPointInfo.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// Describes the compilation's top-level-statement entry point when
+/// present. Populated by the frontend only when
+/// <c>[assembly: TranspileAssembly]</c> is set, the compilation contains
+/// <c>GlobalStatementSyntax</c>, Roslyn reports an entry point, and the
+/// containing type is not opted out via <c>[ExportedAsModule]</c>.
+/// Target backends check for <c>null</c> to decide whether to route the
+/// entry-point body through top-level-statement emission instead of
+/// regular class emission.
+/// <para>
+/// Both members are Roslyn escape hatches — the synthetic <c>Program</c>
+/// routing still calls into semantic-model-backed bridges that need the
+/// original <see cref="IMethodSymbol"/> to walk the entry-point body.
+/// </para>
+/// </summary>
+/// <param name="Method">Compiler-synthesized entry-point method
+/// (<see cref="Microsoft.CodeAnalysis.CSharp.CSharpCompilation.GetEntryPoint"/>).</param>
+/// <param name="ContainingType">The synthesized containing type
+/// (usually <c>Program</c>) that targets route through top-level-
+/// statement emission.</param>
+public sealed record IrEntryPointInfo(IMethodSymbol Method, INamedTypeSymbol ContainingType);

--- a/src/Metano.Compiler/IR/IrTranspilableTypeEntry.cs
+++ b/src/Metano.Compiler/IR/IrTranspilableTypeEntry.cs
@@ -1,0 +1,35 @@
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// Ordered element of <see cref="IrCompilation.TranspilableTypeEntries"/>.
+/// Carries the Roslyn <see cref="INamedTypeSymbol"/> of a transpilable
+/// top-level type in the current assembly plus the metadata the target
+/// needs to route emission without re-walking syntax trees. The
+/// <see cref="Symbol"/> reference is a documented escape hatch during
+/// the frontend / core split — body extraction, nested-type walking,
+/// and semantic-model-backed bridges on the target side still need a
+/// symbol in hand. Retiring it requires pre-extracting the full
+/// per-type IR up-front, well beyond the scope of this refactor.
+/// </summary>
+/// <param name="Symbol">The current-assembly top-level type. Nested
+/// types are handled as companion namespaces by the target's per-type
+/// emission loop — they never appear here on their own.</param>
+/// <param name="Key">Assembly-qualified stable full name
+/// (<see cref="SymbolHelper.GetCrossAssemblyOriginKey"/>). Matches the
+/// <see cref="IrTranspilableTypeRef.Key"/> associated with the same
+/// type in <see cref="IrCompilation.TranspilableTypes"/>.</param>
+/// <param name="IsSyntheticProgram">True when this entry is the
+/// compiler-synthesized containing type for C# 9+ top-level statements.
+/// Forward-compat metadata: current targets decide top-level-statement
+/// routing by comparing <paramref name="Symbol"/> against
+/// <see cref="IrCompilation.EntryPoint"/>'s <c>ContainingType</c>, but
+/// the flag lets future consumers route on the entry itself without a
+/// symbol-equality probe. Under traditional <c>static void Main</c> the
+/// flag is false and the type emits as a regular class.</param>
+public sealed record IrTranspilableTypeEntry(
+    INamedTypeSymbol Symbol,
+    string Key,
+    bool IsSyntheticProgram
+);

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -3,6 +3,7 @@ using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.IR;
 using Metano.Tests.IR;
+using Microsoft.CodeAnalysis;
 
 namespace Metano.Tests.Frontend;
 
@@ -1216,5 +1217,111 @@ public class CSharpSourceFrontendTests
         await Assert.That(fromSource.FileName).IsEqualTo("ticker");
         await Assert.That(fromSource.Namespace).IsEqualTo("");
         await Assert.That(fromSource.IsStringEnum).IsFalse();
+    }
+
+    [Test]
+    public async Task EntryPointInfoIsPopulatedForTopLevelStatements()
+    {
+        // C# 9+ top-level statements under [assembly: TranspileAssembly]
+        // produce an entry point the target routes through
+        // EmitTopLevelStatements. The IR must surface both the
+        // synthesized method and its containing type so the target
+        // doesn't need to re-detect them.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            System.Console.WriteLine("Hello");
+            """,
+            OutputKind.ConsoleApplication
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.EntryPoint).IsNotNull();
+        await Assert.That(ir.EntryPoint!.Method).IsNotNull();
+        await Assert.That(ir.EntryPoint.ContainingType).IsNotNull();
+        // The synthesized method's containing type is what routes through
+        // top-level-statement emission — Roslyn names it "Program".
+        await Assert.That(ir.EntryPoint.ContainingType.Name).IsEqualTo("Program");
+    }
+
+    [Test]
+    public async Task EntryPointInfoIsNullForTraditionalMain()
+    {
+        // A traditional static Main + no [assembly: TranspileAssembly]
+        // must not produce an entry-point record — the target's
+        // top-level-statement routing should stay inert.
+        var compilation = IrTestHelper.Compile(
+            """
+            [Transpile]
+            public static class App
+            {
+                public static void Main() {}
+            }
+            """,
+            OutputKind.ConsoleApplication
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.EntryPoint).IsNull();
+    }
+
+    [Test]
+    public async Task TranspilableTypeEntriesIncludesSyntheticProgram()
+    {
+        // Under [assembly: TranspileAssembly] with top-level statements,
+        // the synthetic Program type is appended to the entry list with
+        // IsSyntheticProgram=true so the target routes it through
+        // top-level-statement emission. Regular transpilable types carry
+        // IsSyntheticProgram=false.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            System.Console.WriteLine("boot");
+
+            namespace App
+            {
+                public record Greeting(string Message);
+            }
+            """,
+            OutputKind.ConsoleApplication
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.TranspilableTypeEntries).IsNotNull();
+
+        var synthetic = ir.TranspilableTypeEntries!.SingleOrDefault(e => e.IsSyntheticProgram);
+        await Assert.That(synthetic).IsNotNull();
+        await Assert.That(synthetic!.Symbol.Name).IsEqualTo("Program");
+
+        var greeting = ir.TranspilableTypeEntries!.SingleOrDefault(e =>
+            e.Symbol.Name == "Greeting"
+        );
+        await Assert.That(greeting).IsNotNull();
+        await Assert.That(greeting!.IsSyntheticProgram).IsFalse();
+    }
+
+    [Test]
+    public async Task ExportedAsModuleOnProgramOptsOutOfSyntheticRouting()
+    {
+        // `[ExportedAsModule]` on a `Program` partial opts the synthetic
+        // entry-point routing out. The IR entry-point record must be null
+        // so top-level-statement bodies fall through to the regular
+        // module-emission path.
+        var compilation = IrTestHelper.Compile(
+            """
+            [assembly: TranspileAssembly]
+
+            System.Console.WriteLine("boot");
+
+            [ExportedAsModule]
+            public static partial class Program {}
+            """,
+            OutputKind.ConsoleApplication
+        );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.EntryPoint).IsNull();
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `IrTranspilableTypeEntry` (ordered list element: Roslyn symbol + origin key + `IsSyntheticProgram` flag) and `IrEntryPointInfo` (entry-point method + containing type) so the frontend owns transpilable-type discovery and C# 9+ top-level-statement entry-point detection.
- Deletes `TypeTransformer.DiscoverTranspilableTypes()` (syntax-tree walker) and the `_syntheticEntryPoint` field. Routing at both emission sites (`BuildTypeStatements`, `ScanIrRuntimeRequirements`) now compares against `ir.EntryPoint?.ContainingType`.
- Last Roslyn syntax walker on the TS target side for discovery gone — unblocks future targets from replicating the walk.

Scope mirrors the retired walker exactly: current assembly, top-level only, synthesized `Program` appended under `[assembly: TranspileAssembly]` + `GlobalStatementSyntax` + non-`[ExportedAsModule]` gates (reuses `TryGetTopLevelProgramType`).

Dart target unchanged — the new IR fields are additive/nullable.

## Test plan

- [x] 607/607 TUnit tests green (603 baseline + 4 new frontend tests)
  - `EntryPointInfoIsPopulatedForTopLevelStatements`
  - `EntryPointInfoIsNullForTraditionalMain`
  - `TranspilableTypeEntriesIncludesSyntheticProgram`
  - `ExportedAsModuleOnProgramOptsOutOfSyntheticRouting`
- [x] `dotnet csharpier check .` passes
- [x] `git diff main -- targets/` empty → TS + Dart sample outputs byte-identical vs main
- [x] `sample-todo` bun tests: 18/18 pass
- [x] `sample-issue-tracker` bun tests: 65/65 pass
- [x] `sample-todo-service` bun tests: 19/19 pass

## Net delta

| Measure | Value |
|---|---|
| Files changed | 6 (2 new: `IrTranspilableTypeEntry.cs`, `IrEntryPointInfo.cs`) |
| Additions / deletions | +298 / -80 |

Part of #56