### PR TITLE
refactor(dart): consume ir.TranspilableTypeEntries in Dart target (Phase B.10a mirror)

### DIFF
--- a/src/Metano.Compiler.Dart/DartTarget.cs
+++ b/src/Metano.Compiler.Dart/DartTarget.cs
@@ -23,16 +23,11 @@ public sealed class DartTarget : ITranspilerTarget
         if (compilation is null)
             throw new NotSupportedException(
                 "DartTarget currently requires a Roslyn-backed source frontend; "
-                    + "compilation was null. The Roslyn dependency will go away once the "
-                    + "Dart transformer reads everything it needs from IrCompilation."
+                    + "compilation was null. The Roslyn dependency will go away once every "
+                    + "Dart per-type extractor also reads its inputs from IrCompilation."
             );
 
-        // The Dart prototype still drives discovery off the Roslyn compilation;
-        // the IR is accepted to honor the contract and used opportunistically
-        // by helpers as they migrate.
-        _ = ir;
-
-        var transformer = new DartTransformer(compilation);
+        var transformer = new DartTransformer(ir, compilation);
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
 

--- a/src/Metano.Compiler.Dart/Transformation/DartTransformer.cs
+++ b/src/Metano.Compiler.Dart/Transformation/DartTransformer.cs
@@ -10,17 +10,19 @@ using Microsoft.CodeAnalysis;
 namespace Metano.Dart.Transformation;
 
 /// <summary>
-/// Orchestrates Dart emission: discovers <c>[Transpile]</c>-annotated types in the
-/// compilation, extracts each into IR, routes to the appropriate Dart bridge, and
-/// assembles the resulting <see cref="DartSourceFile"/>s with their imports.
+/// Orchestrates Dart emission: reads the ordered transpilable-type list
+/// off the shared <see cref="IrCompilation"/>, extracts each into IR,
+/// routes to the appropriate Dart bridge, and assembles the resulting
+/// <see cref="DartSourceFile"/>s with their imports.
 /// <para>
 /// This is a prototype — currently handles enums, interfaces, and plain class shapes
 /// (no method bodies). Records/operators/exceptions need expression extraction, which
 /// lands in Phase 5.
 /// </para>
 /// </summary>
-public sealed class DartTransformer(Compilation compilation)
+public sealed class DartTransformer(IrCompilation ir, Compilation compilation)
 {
+    private readonly IrCompilation _ir = ir;
     private readonly Compilation _compilation = compilation;
     private readonly List<MetanoDiagnostic> _diagnostics = new();
 
@@ -147,35 +149,26 @@ public sealed class DartTransformer(Compilation compilation)
 
     // ── Discovery ─────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Flattens the frontend-owned ordered top-level transpilable-type
+    /// list (<see cref="IrCompilation.TranspilableTypeEntries"/>) plus
+    /// every nested transpilable type under each entry into a single
+    /// emission list. The Dart prototype emits one file per type (no
+    /// companion-namespace wrapping like the TS target), so nested types
+    /// join the flat list here — <see cref="CollectNested"/> recurses
+    /// into them using the frontend-reported
+    /// <see cref="IrCompilation.AssemblyWideTranspile"/> flag.
+    /// </summary>
     private List<INamedTypeSymbol> DiscoverTranspilableTypes()
     {
-        var assemblyWide = _compilation
-            .Assembly.GetAttributes()
-            .Any(a =>
-                a.AttributeClass?.Name is "TranspileAssemblyAttribute" or "TranspileAssembly"
-            );
-
+        var entries = _ir.TranspilableTypeEntries ?? Array.Empty<IrTranspilableTypeEntry>();
         var result = new List<INamedTypeSymbol>();
-        Walk(_compilation.Assembly.GlobalNamespace);
-        return result;
-
-        void Walk(INamespaceSymbol ns)
+        foreach (var entry in entries)
         {
-            foreach (var member in ns.GetMembers())
-            {
-                switch (member)
-                {
-                    case INamespaceSymbol inner:
-                        Walk(inner);
-                        break;
-                    case INamedTypeSymbol type:
-                        if (IsTranspilable(type, assemblyWide))
-                            result.Add(type);
-                        CollectNested(type, assemblyWide, result);
-                        break;
-                }
-            }
+            result.Add(entry.Symbol);
+            CollectNested(entry.Symbol, _ir.AssemblyWideTranspile, result);
         }
+        return result;
     }
 
     /// <summary>

--- a/tests/Metano.Tests/DartBackendTests.cs
+++ b/tests/Metano.Tests/DartBackendTests.cs
@@ -1,3 +1,5 @@
+using Metano.Annotations;
+using Metano.Compiler;
 using Metano.Compiler.Diagnostics;
 using Metano.Dart.Transformation;
 using Microsoft.CodeAnalysis;
@@ -506,7 +508,11 @@ public class DartBackendTests
                 "C# compilation failed:\n" + string.Join("\n", errors.Select(e => e.ToString()))
             );
 
-        var transformer = new DartTransformer(compilation);
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(
+            compilation,
+            TargetLanguage.Dart
+        );
+        var transformer = new DartTransformer(ir, compilation);
         var files = transformer.TransformAll();
         var printer = new Metano.Dart.Printer();
         var result = new Dictionary<string, string>();


### PR DESCRIPTION
## Summary

- `DartTransformer` drops its inline `GlobalNamespace` walk + `TranspileAssembly` attribute probe; consumes frontend-owned `IrCompilation.TranspilableTypeEntries` as top-level seeds.
- Nested-type flattening stays Dart-local via `CollectNested` + `ir.AssemblyWideTranspile` — Dart prototype still emits one file per type (no companion-namespace wrapping like TS target).
- `DartTarget` threads `IR` into the transformer. Test helper builds IR via `CSharpSourceFrontend.ExtractFromCompilation(compilation, TargetLanguage.Dart)` so per-target `[Name(Dart, ...)]` overrides exercise the IR's `TypeNamesBySymbol` path end-to-end.

**Side effect**: general `[NoEmit]` types drop at IR layer (frontend's `IsTranspilable` filters untargeted NoEmit) instead of at the emission site. Target-specific `[NoEmit(Dart)]` stays filtered by the existing `HasNoEmit(type, TargetLanguage.Dart)` check. Observable behavior identical — drop point moves earlier.

## Test plan

- [x] 607/607 TUnit tests green
- [x] `dotnet csharpier check .` passes
- [x] `git diff main -- targets/` empty → Dart sample (`targets/flutter/sample_counter`) byte-identical
- [x] All 20 Dart backend tests in `DartBackendTests` pass through the new IR-driven path (including `NoEmit*`, per-target `[Name]` overrides, duplicate-simple-name diagnostic)

## Net delta

| Measure | Value |
|---|---|
| Files changed | 3 |
| Additions / deletions | +31 / −37 |

Part of #56