### PR TITLE
refactor(ts): emit loose equality for null compares in generated TS

### DIFF
--- a/docs/adr/0014-loose-null-equality-in-generated-typescript.md
+++ b/docs/adr/0014-loose-null-equality-in-generated-typescript.md
@@ -1,0 +1,105 @@
+# ADR-0014 — Loose null equality in generated TypeScript
+
+**Status:** Accepted
+**Date:** 2026-04-22
+
+## Context
+
+C# has a single "missing value" concept — `null`. JavaScript / TypeScript
+has two: `null` (explicit absence) and `undefined` (not assigned). A
+transpiled pipeline that emits strict `=== null` / `!== null` checks in
+generated TS breaks whenever a JS-side value crosses the boundary as
+`undefined` — optional object properties omitted at construction, array
+elements past the declared length, sparse deserialization — because the
+strict comparison fails to recognize those states as "equivalent to
+null".
+
+Concretely, `SampleTodo.Service` emits handlers that read the request
+body and compare fields against `null`. Hono delivers request bodies
+parsed from JSON; a client that sends `{}` (omitting a key) produces a
+JS object where the key reads back as `undefined`, not `null`. With the
+pre-existing `=== null` check, the guard failed and downstream code ran
+with an undefined value the C# source assumed was absent.
+
+Kotlin/JS — the closest-kin compile-to-JS ecosystem — faces the exact
+same asymmetry and resolves it by emitting loose `== null` for nullable
+comparisons, treating `null` and `undefined` as interchangeable at the
+compare site. The referential `=== undefined` form stays available for
+the rare case that genuinely needs to distinguish them.
+
+## Decision
+
+Generated TypeScript uses loose `==` / `!=` when comparing against a
+`null` literal, and strict `===` / `!==` for every other comparison.
+The emission site is `IrToTsExpressionBridge.BinaryOperatorToken`, which
+now inspects the operator's operands and relaxes `IrBinaryOp.Equal` /
+`NotEqual` to loose form exactly when either operand is an
+`IrLiteral { Kind: Null }`. `is null` / `is not null` pattern forms
+route through the same helper so the contract stays single-sourced.
+
+Examples:
+
+```ts
+// C#: value is null          →  value == null
+// C#: value is not null      →  !(value == null)
+// C#: value == null          →  value == null
+// C#: arr.Length == 3        →  arr.length === 3  (unchanged: not a null compare)
+```
+
+C# itself has no `undefined` concept; the relaxation only broadens the
+JS-visible check and does not affect round-trip semantics. Targets
+other than TypeScript are unaffected — the bridge is TS-specific.
+
+## Consequences
+
+- (+) TS consumers that produce `undefined` (omitted optional property,
+      sparse JSON, React component props defaulting to the type's
+      default) no longer silently bypass C#-authored null guards.
+- (+) Opens the door to a future `[Optional]` attribute (issue #23)
+      that emits `name?: T | null` at interface boundaries — consumers
+      can genuinely omit the key, and the generated C#-authored reads
+      still behave correctly.
+- (+) Mirrors Kotlin/JS's established convention, reducing the surprise
+      for developers who bring that mental model.
+- (−) Generated code uses `==` / `!=` which some TypeScript style
+      guides discourage. Biome and TypeScript ESLint both exempt
+      `== null` / `!= null` specifically because the "sloppy" behavior
+      is the desired behavior at this one comparison.
+- (−) Developers reading the generated output who are not aware of the
+      distinction might assume the emitter is "careless". The lowering
+      is deliberate; the ADR documents the reasoning.
+- (−) One-time sample churn: every `=== null` / `!== null` in
+      previously-generated TS turns into `==` / `!=`. Follow-up
+      regeneration is a mechanical rewrite the test suite covers.
+
+## Alternatives considered
+
+- **Strict `===` everywhere** — the prior state. Breaks any C# read
+  of a JS-produced `undefined` value. Rejected.
+- **Attribute-scoped relaxation** (`[Optional]`-tagged fields only) —
+  would require threading the attribute through every binary
+  comparison in the expression bridge and still leave non-attributed
+  nullable compares exposed to the same hazard. Rejected as both
+  invasive and partial.
+- **Runtime boundary normalization** (coerce `undefined` → `null` in a
+  deserialization helper) — fixes the specific JSON parse path but
+  misses every other boundary (direct TS calls, React props,
+  destructured arguments). Kept as a possible future layer on top of
+  the loose-equality emission for strictly-typed round trips.
+
+## References
+
+- Code pointer: `src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs`
+  (`BinaryOperatorToken`, `IsNullCompare`, `MapIsPattern`,
+  `BuildPatternTest`).
+- Tests: `tests/Metano.Tests/SwitchPatternTranspileTests.cs`
+  (`IsNull_GeneratesLooseEquality`, `IsNotNull_GeneratesNegatedLooseEquality`),
+  `tests/Metano.Tests/IR/IrToTsBodyBridgeTests.cs`
+  (`IsNullPattern_LowersToLooseEquality`, `NotPattern_LowersToNegation`).
+- Related issue: [#23 `[Optional]` attribute for nullable-as-optional
+  opt-in](https://github.com/danfma/metano/issues/23) — this ADR is a
+  prerequisite.
+- External: Kotlin/JS treats nullable types as `T | null | undefined`
+  and uses loose equality at the JVM/JS interop boundary for the same
+  reason (Kotlin/JS documentation on JS interop and the `kotlin.js`
+  package).

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -116,7 +116,11 @@ public static class IrToTsExpressionBridge
             bin.Operator,
             isLeft: false
         );
-        return new TsBinaryExpression(left, BinaryOperatorToken(bin.Operator), right);
+        return new TsBinaryExpression(
+            left,
+            BinaryOperatorToken(bin.Operator, bin.Left, bin.Right),
+            right
+        );
     }
 
     /// <summary>
@@ -370,7 +374,11 @@ public static class IrToTsExpressionBridge
         switch (node.Pattern)
         {
             case IrConstantPattern constant:
-                return new TsBinaryExpression(lowered, "===", Map(constant.Value, bclRegistry));
+                return new TsBinaryExpression(
+                    lowered,
+                    BinaryOperatorToken(IrBinaryOp.Equal, node.Expression, constant.Value),
+                    Map(constant.Value, bclRegistry)
+                );
             case IrTypePattern typePat when typePat.DesignatorName is null:
                 return BuildTypeTest(lowered, typePat.Type);
             case IrDiscardPattern:
@@ -549,7 +557,7 @@ public static class IrToTsExpressionBridge
         {
             IrConstantPattern constant => new TsBinaryExpression(
                 value,
-                "===",
+                BinaryOperatorToken(IrBinaryOp.Equal, right: constant.Value),
                 Map(constant.Value, bclRegistry)
             ),
             IrTypePattern typePat => BuildTypeTest(value, typePat.Type),
@@ -825,7 +833,33 @@ public static class IrToTsExpressionBridge
             ? f.ToString(null, CultureInfo.InvariantCulture)
             : value?.ToString() ?? "0";
 
-    private static string BinaryOperatorToken(IrBinaryOp op) =>
+    /// <summary>
+    /// True when either side of a binary comparison is the IR null
+    /// literal. Pairs with the loose <c>==</c> / <c>!=</c> emission path
+    /// so <c>x == null</c> matches both <c>null</c> and <c>undefined</c>
+    /// on the JS side — necessary for TS consumers that may produce
+    /// <c>undefined</c> (absent optional property, uninitialized field)
+    /// where the C# contract only knows about <c>null</c>.
+    /// </summary>
+    private static bool IsNullCompare(IrExpression? left, IrExpression? right) =>
+        left is IrLiteral { Kind: IrLiteralKind.Null }
+        || right is IrLiteral { Kind: IrLiteralKind.Null };
+
+    /// <summary>
+    /// Picks the JS operator token for an IR binary operator. Equal /
+    /// NotEqual normally lower to strict <c>===</c> / <c>!==</c>, but
+    /// when either operand is a null literal the bridge emits the loose
+    /// <c>==</c> / <c>!=</c> form so that a TS consumer reading the
+    /// compared expression cannot be tripped by an <c>undefined</c> that
+    /// came across the boundary (Kotlin/JS uses the same strategy). C#
+    /// does not expose <c>undefined</c>, so this relaxation is safe for
+    /// round-trip semantics — only the JS-visible check broadens.
+    /// </summary>
+    private static string BinaryOperatorToken(
+        IrBinaryOp op,
+        IrExpression? left = null,
+        IrExpression? right = null
+    ) =>
         op switch
         {
             IrBinaryOp.Add => "+",
@@ -833,8 +867,8 @@ public static class IrToTsExpressionBridge
             IrBinaryOp.Multiply => "*",
             IrBinaryOp.Divide => "/",
             IrBinaryOp.Modulo => "%",
-            IrBinaryOp.Equal => "===",
-            IrBinaryOp.NotEqual => "!==",
+            IrBinaryOp.Equal => IsNullCompare(left, right) ? "==" : "===",
+            IrBinaryOp.NotEqual => IsNullCompare(left, right) ? "!=" : "!==",
             IrBinaryOp.LessThan => "<",
             IrBinaryOp.LessThanOrEqual => "<=",
             IrBinaryOp.GreaterThan => ">",

--- a/targets/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
+++ b/targets/js/sample-issue-tracker/src/issues/application/in-memory-issue-repository.ts
@@ -29,7 +29,7 @@ export class InMemoryIssueRepository implements IIssueRepository {
   }
 
   async existsAsync(id: IssueId): Promise<boolean> {
-    return !(await this.getByIdAsync(id) === null);
+    return !(await this.getByIdAsync(id) == null);
   }
 
   listBySprintAsync(sprintKey: string): Promise<Issue[]> {
@@ -37,7 +37,7 @@ export class InMemoryIssueRepository implements IIssueRepository {
   }
 
   searchAsync(status: IssueStatus | null, priority: IssuePriority | null, assigneeId: UserId | null, sprintKey: string | null, page: PageRequest): Promise<PageResult<Issue>> {
-    const filtered = Enumerable.from(this._issues).where((issue: Issue) => status === null || issue.status === status).where((issue: Issue) => priority === null || issue.priority === priority).where((issue: Issue) => assigneeId === null || issue.assigneeId === assigneeId).where((issue: Issue) => sprintKey === null || issue.sprintKey === sprintKey).orderByDescending((issue: Issue) => issue.priority).thenBy((issue: Issue) => issue.title).toArray();
+    const filtered = Enumerable.from(this._issues).where((issue: Issue) => status == null || issue.status === status).where((issue: Issue) => priority == null || issue.priority === priority).where((issue: Issue) => assigneeId == null || issue.assigneeId === assigneeId).where((issue: Issue) => sprintKey == null || issue.sprintKey === sprintKey).orderByDescending((issue: Issue) => issue.priority).thenBy((issue: Issue) => issue.title).toArray();
     const items = Enumerable.from(filtered).skip(page.skip).take(page.safeSize).toArray();
 
     return Promise.resolve(new PageResult(items, filtered.length, page));

--- a/targets/js/sample-issue-tracker/src/issues/application/issue-service.ts
+++ b/targets/js/sample-issue-tracker/src/issues/application/issue-service.ts
@@ -38,13 +38,13 @@ export class IssueService {
   async loadAsync(issueId: IssueId): Promise<OperationResult<Issue>> {
     const issue = await this._repository.getByIdAsync(issueId);
 
-    return issue === null ? OperationResult.fail("issue_not_found", `Issue ${issueId} was not found.`) : OperationResult.ok(issue);
+    return issue == null ? OperationResult.fail("issue_not_found", `Issue ${issueId} was not found.`) : OperationResult.ok(issue);
   }
 
   async assignAsync(issueId: IssueId, assigneeId: UserId): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
 
-    if (!loadResult.hasValue || loadResult.value === null) {
+    if (!loadResult.hasValue || loadResult.value == null) {
       return loadResult;
     }
 
@@ -57,7 +57,7 @@ export class IssueService {
   async planSprintAsync(issueId: IssueId, sprintKey: string): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
 
-    if (!loadResult.hasValue || loadResult.value === null) {
+    if (!loadResult.hasValue || loadResult.value == null) {
       return loadResult;
     }
 
@@ -70,7 +70,7 @@ export class IssueService {
   private async addCommentAsyncIssueIdAuthorIdMessage(issueId: IssueId, authorId: UserId, message: string): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
 
-    if (!loadResult.hasValue || loadResult.value === null) {
+    if (!loadResult.hasValue || loadResult.value == null) {
       return loadResult;
     }
 
@@ -101,7 +101,7 @@ export class IssueService {
   async transitionAsync(issueId: IssueId, nextStatus: IssueStatus, actorId: UserId): Promise<OperationResult<Issue>> {
     const loadResult = await this.loadAsync(issueId);
 
-    if (!loadResult.hasValue || loadResult.value === null) {
+    if (!loadResult.hasValue || loadResult.value == null) {
       return loadResult;
     }
 

--- a/targets/js/sample-issue-tracker/src/shared-kernel/operation-result.ts
+++ b/targets/js/sample-issue-tracker/src/shared-kernel/operation-result.ts
@@ -4,7 +4,7 @@ export class OperationResult<T> {
   constructor(readonly success: boolean, readonly value: T | null, readonly errorCode: string | null = null, readonly errorMessage: string | null = null) { }
 
   get hasValue(): boolean {
-    return this.success && !(this.value === null);
+    return this.success && !(this.value == null);
   }
 
   static ok<T>(value: T): OperationResult<T> {

--- a/targets/js/sample-todo-service/src/program.ts
+++ b/targets/js/sample-todo-service/src/program.ts
@@ -11,13 +11,13 @@ app.get("/todos", (c) => c.json(store.all()));
 app.get("/todos/:id", (c) => {
   const id = c.req.param("id");
 
-  if (id === null) {
+  if (id == null) {
     return c.notFound();
   }
 
   const stored = store.get(id);
 
-  return stored === null ? c.notFound() : c.json(stored);
+  return stored == null ? c.notFound() : c.json(stored);
 });
 
 app.post("/todos", async (c) => {
@@ -30,20 +30,20 @@ app.post("/todos", async (c) => {
 app.patch("/todos/:id", async (c) => {
   const id = c.req.param("id");
 
-  if (id === null) {
+  if (id == null) {
     return c.notFound();
   }
 
   const patch = await c.req.json();
   const updated = store.update(id, patch);
 
-  return updated === null ? c.notFound() : c.json(updated);
+  return updated == null ? c.notFound() : c.json(updated);
 });
 
 app.delete("/todos/:id", (c) => {
   const id = c.req.param("id");
 
-  if (id === null) {
+  if (id == null) {
     return c.notFound();
   }
 

--- a/targets/js/sample-todo-service/src/todos.ts
+++ b/targets/js/sample-todo-service/src/todos.ts
@@ -41,21 +41,21 @@ export class TodoStore {
   update(id: string, patch: UpdateTodoDto): StoredTodo | null {
     const existing = (this._items.find((t: StoredTodo) => t.id === id) ?? null);
 
-    if (existing === null) {
+    if (existing == null) {
       return null;
     }
 
     let item = existing.item;
 
-    if (!(patch.title === null)) {
+    if (!(patch.title == null)) {
       item = item.with({ title: patch.title });
     }
 
-    if (!(patch.priority === null)) {
+    if (!(patch.priority == null)) {
       item = item.with({ priority: patch.priority });
     }
 
-    if (!(patch.completed === null)) {
+    if (!(patch.completed == null)) {
       item = item.with({ completed: patch.completed });
     }
 
@@ -72,7 +72,7 @@ export class TodoStore {
   remove(id: string): boolean {
     const existing = (this._items.find((t: StoredTodo) => t.id === id) ?? null);
 
-    if (existing === null) {
+    if (existing == null) {
       return false;
     }
 

--- a/tests/Metano.Tests/IR/IrToTsBodyBridgeTests.cs
+++ b/tests/Metano.Tests/IR/IrToTsBodyBridgeTests.cs
@@ -84,10 +84,12 @@ public class IrToTsBodyBridgeTests
     }
 
     [Test]
-    public async Task IsNullPattern_LowersToStrictEquality()
+    public async Task IsNullPattern_LowersToLooseEquality()
     {
+        // `is null` uses `== null` (loose) so the check also matches JS
+        // `undefined`, protecting C# consumers against TS-side undefined.
         var ts = PrintMethodFromIr("bool IsNull(object? x) => x is null;");
-        await Assert.That(ts).Contains("x === null");
+        await Assert.That(ts).Contains("x == null");
     }
 
     [Test]
@@ -223,8 +225,10 @@ public class IrToTsBodyBridgeTests
     [Test]
     public async Task NotPattern_LowersToNegation()
     {
+        // `is not null` wraps the loose-equality constant test so the
+        // negation also excludes `undefined` on the JS side.
         var ts = PrintMethodFromIr("bool NotNull(object? x) => x is not null;");
-        await Assert.That(ts).Contains("!(x === null)");
+        await Assert.That(ts).Contains("!(x == null)");
     }
 
     [Test]

--- a/tests/Metano.Tests/SwitchPatternTranspileTests.cs
+++ b/tests/Metano.Tests/SwitchPatternTranspileTests.cs
@@ -61,8 +61,13 @@ public class SwitchPatternTranspileTests
     // ─── Is pattern ─────────────────────────────────────────
 
     [Test]
-    public async Task IsNull_GeneratesStrictEquality()
+    public async Task IsNull_GeneratesLooseEquality()
     {
+        // `is null` lowers to `== null` (loose) so the check also matches
+        // a JS-side `undefined` — necessary when a TS consumer produces an
+        // absent optional property or an uninitialized field. C# does not
+        // expose `undefined`, so relaxing the comparison is safe for
+        // round-trip semantics and matches Kotlin/JS behavior.
         var result = TranspileHelper.Transpile(
             """
             #nullable enable
@@ -78,12 +83,16 @@ public class SwitchPatternTranspileTests
         );
 
         var output = result["checker.ts"];
-        await Assert.That(output).Contains("value === null");
+        await Assert.That(output).Contains("value == null");
     }
 
     [Test]
-    public async Task IsNotNull_GeneratesNegatedEquality()
+    public async Task IsNotNull_GeneratesNegatedLooseEquality()
     {
+        // `is not null` lowers to `!(value == null)` so the negation also
+        // excludes `undefined`. Pairs with `IsNull_GeneratesLooseEquality`
+        // — both sides of the C# pattern collapse to the same loose
+        // comparison on the TS side.
         var result = TranspileHelper.Transpile(
             """
             #nullable enable
@@ -99,7 +108,7 @@ public class SwitchPatternTranspileTests
         );
 
         var output = result["checker.ts"];
-        await Assert.That(output).Contains("!(value === null)");
+        await Assert.That(output).Contains("!(value == null)");
     }
 
     [Test]


### PR DESCRIPTION
Generated TypeScript now uses `== null` / `!= null` when comparing
against a null literal. Strict `===` / `!==` stays for every other
comparison. The lowering is single-sourced at
IrToTsExpressionBridge.BinaryOperatorToken — Equal / NotEqual detect a
null literal on either operand and relax to loose form. `is null` /
`is not null` pattern forms route through the same helper.

Motivation: a TS consumer that produces `undefined` (omitted optional
property, uninitialized field, sparse JSON) would silently bypass a
strict null check authored in C#, since C# does not expose undefined.
Loose equality treats null and undefined as interchangeable at the
compare site — Kotlin/JS's established convention for the same
boundary hazard.

Samples regenerate: every previously-emitted `=== null` / `!== null`
turns into `== null` / `!= null` across sample-issue-tracker,
sample-todo-service. Length checks and other non-null compares stay
strict. 607/607 TUnit green; bun suites green
(sample-todo 18/18, sample-issue-tracker 65/65, sample-todo-service
19/19).

Prerequisite for issue #23 (`[Optional]` attribute).

ADR-0014 documents the decision and its constraints.

Part of #23

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>