### PR TITLE
feat(ts): add [Optional] attribute for nullable-as-optional opt-in

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
@@ -62,7 +62,8 @@ public static class IrToTsInterfaceBridge
         var parameters = method
             .Parameters.Select(p => new TsParameter(
                 IrToTsNamingPolicy.ToParameterName(p.Name),
-                IrToTsTypeMapper.Map(p.Type)
+                IrToTsTypeMapper.Map(p.Type),
+                Optional: p.IsOptional
             ))
             .ToList();
         var typeParams = ConvertTypeParameters(method.TypeParameters);

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
@@ -52,7 +52,7 @@ public static class IrToTsInterfaceBridge
         var name = IrToTsNamingPolicy.ToInterfaceMemberName(prop.Name, prop.Attributes);
         var type = IrToTsTypeMapper.Map(prop.Type);
         var isReadonly = prop.Accessors == IrPropertyAccessors.GetOnly;
-        return new TsProperty(name, type, isReadonly);
+        return new TsProperty(name, type, isReadonly, Optional: prop.IsOptional);
     }
 
     private static TsInterfaceMethod ConvertMethod(IrMethodDeclaration method)

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
@@ -93,7 +93,8 @@ public static class IrToTsPlainObjectBridge
         parameters.AddRange(
             method.Parameters.Select(p => new TsParameter(
                 TypeScriptNaming.ToCamelCase(p.Name),
-                IrToTsTypeMapper.Map(p.Type)
+                IrToTsTypeMapper.Map(p.Type),
+                Optional: p.IsOptional
             ))
         );
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
@@ -46,7 +46,7 @@ public static class IrToTsPlainObjectBridge
                         propName,
                         propType,
                         Readonly: true,
-                        Optional: param.HasDefaultValue
+                        Optional: param.HasDefaultValue || param.IsOptional
                     )
                 );
             }

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsParameter.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsParameter.cs
@@ -7,4 +7,9 @@ namespace Metano.TypeScript.AST;
 /// infer the type from the call-site context. Non-lambda parameters always carry a
 /// non-null Type — only the lambda handler currently produces null.
 /// </summary>
-public sealed record TsParameter(string Name, TsType? Type);
+/// <param name="Optional">When <c>true</c> the parameter is rendered
+/// with a <c>?</c> suffix (<c>name?: Type</c>) — the optional-parameter
+/// form that lets the TS caller omit it. Set by
+/// <c>[Optional]</c>-tagged parameters on <c>[PlainObject]</c> instance
+/// methods (and any future emission site that honors the attribute).</param>
+public sealed record TsParameter(string Name, TsType? Type, bool Optional = false);

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -1198,6 +1198,8 @@ public sealed class Printer(string indent = "  ")
             p =>
             {
                 _sb.Write(p.Name);
+                if (p.Optional)
+                    _sb.Write("?");
                 // Null Type → skip the annotation entirely (used by lambdas whose source
                 // parameter is a [NoEmit] type, so TypeScript can infer from context).
                 if (p.Type is not null)

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -574,12 +574,32 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         new(
             MetanoDiagnosticSeverity.Error,
             DiagnosticCodes.OptionalRequiresNullable,
-            $"[Optional] on {kind} '{symbol.ContainingSymbol.Name}.{symbol.Name}' requires a "
-                + $"nullable C# type. The attribute relies on the TS consumer emitting "
-                + $"'undefined' collapsing to C# 'null'; a non-nullable target cannot "
-                + $"represent the absent case. Make the type nullable (e.g., 'string?').",
+            $"[Optional] on {kind} {FormatMemberPath(symbol)} requires a nullable C# type. The "
+                + $"attribute relies on the TS consumer emitting 'undefined' collapsing to C# "
+                + $"'null'; a non-nullable target cannot represent the absent case. Make the "
+                + $"type nullable (e.g., 'string?').",
             symbol.Locations.FirstOrDefault()
         );
+
+    /// <summary>
+    /// Builds a human-readable path for the diagnostic message. For a
+    /// property returns <c>TypeName.PropertyName</c>; for a parameter
+    /// returns <c>TypeName.MethodName(paramName)</c> (or
+    /// <c>TypeName(paramName)</c> when the containing method is a
+    /// constructor). Avoids the <c>.ctor.paramName</c> shape the Roslyn
+    /// <see cref="ISymbol.Name"/> pair would produce for constructor
+    /// parameters, which is hard to act on.
+    /// </summary>
+    private static string FormatMemberPath(ISymbol symbol) =>
+        symbol switch
+        {
+            IPropertySymbol prop => $"'{prop.ContainingType?.Name ?? string.Empty}.{prop.Name}'",
+            IParameterSymbol { ContainingSymbol: IMethodSymbol method } p => method.MethodKind
+            == MethodKind.Constructor
+                ? $"'{method.ContainingType?.Name ?? string.Empty}({p.Name})'"
+                : $"'{method.ContainingType?.Name ?? string.Empty}.{method.Name}({p.Name})'",
+            _ => $"'{symbol.ContainingSymbol?.Name ?? string.Empty}.{symbol.Name}'",
+        };
 
     /// <summary>
     /// Detects the C# 9+ top-level-statement entry point and returns the

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -135,6 +135,9 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ? null
             : BuildTranspilableTypeEntries(compilation, assemblyWideTranspile, entryPoint);
 
+        if (compilation is not null)
+            ValidateOptionalAttribute(compilation, assemblyWideTranspile, diagnostics);
+
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
             PackageName: compilation is null
@@ -506,6 +509,77 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         return entries;
     }
+
+    /// <summary>
+    /// Walks every transpilable type in the current assembly and emits
+    /// <c>MS0010</c> for any parameter or property that carries
+    /// <c>[Optional]</c> (from <c>Metano.Annotations.TypeScript</c>) on a
+    /// non-nullable type. The attribute is TS-specific but the check
+    /// runs on every target because a misuse is a bug regardless of the
+    /// active backend — ignoring it under Dart would let a broken
+    /// attribute ship to the TS consumer later.
+    /// </summary>
+    private static void ValidateOptionalAttribute(
+        Compilation compilation,
+        bool assemblyWideTranspile,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type => VisitTypeForOptional(type, assemblyWideTranspile, currentAssembly, diagnostics)
+        );
+    }
+
+    private static void VisitTypeForOptional(
+        INamedTypeSymbol type,
+        bool assemblyWideTranspile,
+        IAssemblySymbol currentAssembly,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (!SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+            return;
+
+        foreach (var member in type.GetMembers())
+        {
+            switch (member)
+            {
+                case IPropertySymbol prop when prop.HasOptional():
+                    if (!IsNullableType(prop.Type))
+                        diagnostics.Add(OptionalOnNonNullableDiagnostic(prop, "property"));
+                    break;
+                case IMethodSymbol method:
+                    foreach (var p in method.Parameters)
+                    {
+                        if (!p.HasOptional())
+                            continue;
+                        if (!IsNullableType(p.Type))
+                            diagnostics.Add(OptionalOnNonNullableDiagnostic(p, "parameter"));
+                    }
+                    break;
+            }
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForOptional(nested, assemblyWideTranspile, currentAssembly, diagnostics);
+    }
+
+    private static bool IsNullableType(ITypeSymbol type) =>
+        type.NullableAnnotation == NullableAnnotation.Annotated
+        || type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+
+    private static MetanoDiagnostic OptionalOnNonNullableDiagnostic(ISymbol symbol, string kind) =>
+        new(
+            MetanoDiagnosticSeverity.Error,
+            DiagnosticCodes.OptionalRequiresNullable,
+            $"[Optional] on {kind} '{symbol.ContainingSymbol.Name}.{symbol.Name}' requires a "
+                + $"nullable C# type. The attribute relies on the TS consumer emitting "
+                + $"'undefined' collapsing to C# 'null'; a non-nullable target cannot "
+                + $"represent the absent case. Make the type nullable (e.g., 'string?').",
+            symbol.Locations.FirstOrDefault()
+        );
 
     /// <summary>
     /// Detects the C# 9+ top-level-statement entry point and returns the

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -86,4 +86,13 @@ public static class DiagnosticCodes
     /// file missing, MSBuild workspace failure, null compilation, or language-level
     /// errors reported by Roslyn).</summary>
     public const string FrontendLoadFailure = "MS0009";
+
+    /// <summary>MS0010 — <c>[Optional]</c> (from
+    /// <c>Metano.Annotations.TypeScript</c>) was applied to a
+    /// non-nullable parameter or property. The attribute relies on JS
+    /// <c>undefined</c> collapsing to C# <c>null</c>; a non-nullable
+    /// target cannot represent the absent case without undefined
+    /// behavior. The fix is to make the C# type nullable
+    /// (<c>[Optional] string? Name</c>).</summary>
+    public const string OptionalRequiresNullable = "MS0010";
 }

--- a/src/Metano.Compiler/Extraction/IrConstructorExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrConstructorExtractor.cs
@@ -81,7 +81,8 @@ public static class IrConstructorExtractor
                         p.Name,
                         IrTypeRefMapper.Map(p.Type, originResolver),
                         p.HasExplicitDefaultValue,
-                        ExtractDefaultValue(p, compilation, originResolver)
+                        ExtractDefaultValue(p, compilation, originResolver),
+                        IsOptional: p.HasOptional()
                     ),
                     promotion,
                     PromotedVisibility: promotedVisibility,

--- a/src/Metano.Compiler/Extraction/IrInterfaceExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrInterfaceExtractor.cs
@@ -81,7 +81,8 @@ public static class IrInterfaceExtractor
             IrVisibility.Public,
             prop.IsStatic,
             IrTypeRefMapper.Map(prop.Type, originResolver),
-            accessors
+            accessors,
+            IsOptional: prop.HasOptional()
         )
         {
             Attributes = IrAttributeExtractor.Extract(prop),
@@ -96,7 +97,8 @@ public static class IrInterfaceExtractor
         var parameters = method
             .Parameters.Select(p => new IrParameter(
                 p.Name,
-                IrTypeRefMapper.Map(p.Type, originResolver)
+                IrTypeRefMapper.Map(p.Type, originResolver),
+                IsOptional: p.HasOptional()
             ))
             .ToList();
 

--- a/src/Metano.Compiler/Extraction/IrMethodExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrMethodExtractor.cs
@@ -30,7 +30,8 @@ public static class IrMethodExtractor
                 p.Name,
                 IrTypeRefMapper.Map(p.Type, originResolver),
                 HasDefaultValue: p.HasExplicitDefaultValue,
-                DefaultValue: ExtractDefaultValue(p, compilation, originResolver)
+                DefaultValue: ExtractDefaultValue(p, compilation, originResolver),
+                IsOptional: p.HasOptional()
             ))
             .ToList();
 

--- a/src/Metano.Compiler/Extraction/IrPropertyExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrPropertyExtractor.cs
@@ -100,7 +100,8 @@ public static class IrPropertyExtractor
             Initializer: initializer,
             GetterBody: getterBody,
             SetterBody: setterBody,
-            Semantics: semantics
+            Semantics: semantics,
+            IsOptional: prop.HasOptional()
         )
         {
             Attributes = IrAttributeExtractor.Extract(prop),

--- a/src/Metano.Compiler/IR/IrMemberDeclaration.cs
+++ b/src/Metano.Compiler/IR/IrMemberDeclaration.cs
@@ -39,7 +39,8 @@ public sealed record IrPropertyDeclaration(
     IrExpression? Initializer = null,
     IReadOnlyList<IrStatement>? GetterBody = null,
     IReadOnlyList<IrStatement>? SetterBody = null,
-    IrPropertySemantics? Semantics = null
+    IrPropertySemantics? Semantics = null,
+    bool IsOptional = false
 ) : IrMemberDeclaration(Name, Visibility, IsStatic);
 
 /// <summary>

--- a/src/Metano.Compiler/IR/IrParameter.cs
+++ b/src/Metano.Compiler/IR/IrParameter.cs
@@ -14,11 +14,20 @@ namespace Metano.Compiler.IR;
 /// expression uses features outside the covered IR subset) may fall back to
 /// rendering the parameter as required.</param>
 /// <param name="IsParams">Whether this is a <c>params</c> (variadic) parameter.</param>
+/// <param name="IsOptional">Whether the parameter carries
+/// <c>[Optional]</c> (from <c>Metano.Annotations.TypeScript</c>). When
+/// <c>true</c>, the TS backend lowers the parameter to the
+/// optional-presence form (<c>name?: T</c>) so a consumer can omit the
+/// key entirely; other targets treat it as a no-op. The attribute
+/// requires the parameter to already be nullable — the extractor
+/// emits <c>MS0010</c> for <c>[Optional]</c> on a non-nullable
+/// type.</param>
 public sealed record IrParameter(
     string Name,
     IrTypeRef Type,
     bool HasDefaultValue = false,
     IrExpression? DefaultValue = null,
     bool IsParams = false,
-    bool HasExplicitType = true
+    bool HasExplicitType = true,
+    bool IsOptional = false
 );

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -210,8 +210,19 @@ public static class SymbolHelper
     /// <c>Metano.Annotations.TypeScript</c> namespace. TS-specific
     /// attribute — callers outside the TS target should treat
     /// <c>true</c> as a no-op (the field stays nullable either way).
+    /// Matches on the fully-qualified namespace so the unrelated
+    /// <c>System.Runtime.InteropServices.OptionalAttribute</c> (which
+    /// shares the same short name and is used by COM interop) is not
+    /// mistaken for the Metano variant.
     /// </summary>
-    public static bool HasOptional(this ISymbol symbol) => HasAttribute(symbol, "Optional");
+    public static bool HasOptional(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is "OptionalAttribute" or "Optional"
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
+                    == "Metano.Annotations.TypeScript"
+            );
 
     /// <summary>
     /// Reads the file name from <c>[EmitInFile("name")]</c> on a type symbol, or null

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -206,6 +206,14 @@ public static class SymbolHelper
     public static bool HasPlainObject(this ISymbol symbol) => HasAttribute(symbol, "PlainObject");
 
     /// <summary>
+    /// Reads <c>[Optional]</c> from the
+    /// <c>Metano.Annotations.TypeScript</c> namespace. TS-specific
+    /// attribute — callers outside the TS target should treat
+    /// <c>true</c> as a no-op (the field stays nullable either way).
+    /// </summary>
+    public static bool HasOptional(this ISymbol symbol) => HasAttribute(symbol, "Optional");
+
+    /// <summary>
     /// Reads the file name from <c>[EmitInFile("name")]</c> on a type symbol, or null
     /// when the attribute isn't present (in which case the type takes its own name as
     /// the file).

--- a/src/Metano/Annotations/TypeScript/OptionalAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/OptionalAttribute.cs
@@ -9,7 +9,7 @@ namespace Metano.Annotations.TypeScript;
 /// collapsing to <c>null</c> on the C# side via the loose-equality
 /// null-check convention documented in ADR-0014. A non-nullable C# type
 /// cannot safely represent a possibly-absent value and raises
-/// <c>MS0009</c> at extraction time.
+/// <c>MS0010</c> at extraction time.
 /// <para>
 /// This attribute is TypeScript-specific — Dart and other targets have
 /// no separate "absent" vs "null" distinction and treat it as a no-op
@@ -27,7 +27,7 @@ namespace Metano.Annotations.TypeScript;
 ///     nullable — the default).</item>
 ///   <item><c>[Optional] string?</c> → <c>name?: string | null</c>
 ///     (optional presence, nullable).</item>
-///   <item><c>[Optional] string</c> → <c>MS0009</c> — the non-nullable
+///   <item><c>[Optional] string</c> → <c>MS0010</c> — the non-nullable
 ///     combination is rejected.</item>
 /// </list>
 /// </para>

--- a/src/Metano/Annotations/TypeScript/OptionalAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/OptionalAttribute.cs
@@ -1,0 +1,36 @@
+namespace Metano.Annotations.TypeScript;
+
+/// <summary>
+/// Marks a parameter or property whose generated TypeScript signature
+/// should use the optional-presence form (<c>name?: T</c>) instead of
+/// the default present-with-nullable-value form
+/// (<c>name: T | null = null</c>). The target C# type <b>must</b> already
+/// be nullable — the attribute relies on <c>undefined</c> on the JS side
+/// collapsing to <c>null</c> on the C# side via the loose-equality
+/// null-check convention documented in ADR-0014. A non-nullable C# type
+/// cannot safely represent a possibly-absent value and raises
+/// <c>MS0009</c> at extraction time.
+/// <para>
+/// This attribute is TypeScript-specific — Dart and other targets have
+/// no separate "absent" vs "null" distinction and treat it as a no-op
+/// (the field stays nullable either way). It therefore lives in the
+/// <see cref="Metano.Annotations.TypeScript"/> namespace so a
+/// cross-target project opting into <c>using Metano.Annotations;</c>
+/// does not accidentally see TS-only knobs.
+/// </para>
+/// <para>
+/// Emission matrix (pair with <see cref="System.Nullable{T}"/>
+/// nullability on the C# side):
+/// <list type="bullet">
+///   <item><c>string</c> → <c>name: string</c> (required, non-null).</item>
+///   <item><c>string?</c> → <c>name: string | null = null</c> (present,
+///     nullable — the default).</item>
+///   <item><c>[Optional] string?</c> → <c>name?: string | null</c>
+///     (optional presence, nullable).</item>
+///   <item><c>[Optional] string</c> → <c>MS0009</c> — the non-nullable
+///     combination is rejected.</item>
+/// </list>
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+public sealed class OptionalAttribute : Attribute;

--- a/tests/Metano.Tests/OptionalAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/OptionalAttributeTranspileTests.cs
@@ -126,4 +126,104 @@ public class OptionalAttributeTranspileTests
             .That(diagnostics.Any(d => d.Code == DiagnosticCodes.OptionalRequiresNullable))
             .IsFalse();
     }
+
+    // ─── Method / constructor parameter coverage ─────────────
+
+    [Test]
+    public async Task Optional_OnInterfaceMethodParameter_EmitsOptionalParamForm()
+    {
+        // [Optional] on an interface method parameter lowers to the TS
+        // optional-parameter form (`name?: string | null`) so the
+        // consumer can call the method without supplying that argument
+        // at all.
+        var result = TranspileHelper.Transpile(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile]
+            public interface IGreeter
+            {
+                string Greet([Optional] string? salutation);
+            }
+            """
+        );
+
+        var output = result["i-greeter.ts"];
+        await Assert.That(output).Contains("salutation?: string | null");
+    }
+
+    [Test]
+    public async Task Optional_OnPlainObjectMethodParameter_EmitsOptionalParamForm()
+    {
+        // [PlainObject] instance methods lower to standalone exported
+        // functions whose first parameter is `self: T` followed by the
+        // C# parameters. [Optional] on the C# parameter surfaces as the
+        // TS `?` suffix on the corresponding function parameter.
+        var result = TranspileHelper.Transpile(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, PlainObject]
+            public record UserDto(string Name)
+            {
+                public string Display([Optional] string? prefix) => prefix + Name;
+            }
+            """
+        );
+
+        var output = result["user-dto.ts"];
+        await Assert.That(output).Contains("prefix?: string | null");
+    }
+
+    [Test]
+    public async Task Optional_OnConstructorParameter_EmitsMs0010WithConstructorPath()
+    {
+        // [Optional] on a non-nullable constructor parameter fails with
+        // MS0010, and the message identifies the constructor as
+        // `TypeName(paramName)` rather than the raw `.ctor.paramName`
+        // the symbol pair would produce.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, PlainObject]
+            public record UserDto([Optional] string Name);
+            """
+        );
+
+        var ms0010 = diagnostics.FirstOrDefault(d =>
+            d.Code == DiagnosticCodes.OptionalRequiresNullable
+        );
+        await Assert.That(ms0010).IsNotNull();
+        await Assert.That(ms0010!.Message).Contains("UserDto(Name)");
+        await Assert.That(ms0010.Message).DoesNotContain(".ctor");
+    }
+
+    [Test]
+    public async Task Optional_OnPropertyDiagnostic_NamesContainingType()
+    {
+        // Property-side MS0010 message should include the containing
+        // type so a user can jump to it directly.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile]
+            public interface IWidget
+            {
+                [Optional] string Name { get; }
+            }
+            """
+        );
+
+        var ms0010 = diagnostics.FirstOrDefault(d =>
+            d.Code == DiagnosticCodes.OptionalRequiresNullable
+        );
+        await Assert.That(ms0010).IsNotNull();
+        await Assert.That(ms0010!.Message).Contains("IWidget.Name");
+    }
 }

--- a/tests/Metano.Tests/OptionalAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/OptionalAttributeTranspileTests.cs
@@ -1,0 +1,129 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[Optional]</c> from <c>Metano.Annotations.TypeScript</c>.
+/// The attribute opts a nullable C# parameter or property into the
+/// optional-presence TS emission form (<c>name?: T</c>) so a consumer
+/// can omit the key entirely. Paired with ADR-0014's loose-equality
+/// null-check emission, JS-side <c>undefined</c> collapses to C#
+/// <c>null</c> without breaking C#-authored null guards.
+/// </summary>
+public class OptionalAttributeTranspileTests
+{
+    // ─── Emission ────────────────────────────────────────────
+
+    [Test]
+    public async Task Optional_OnNullablePlainObjectField_EmitsOptionalForm()
+    {
+        // [PlainObject] records expose their positional parameters as
+        // interface fields. [Optional] on a nullable parameter lowers
+        // to the TS optional-presence form (`name?: string | null`) so
+        // a consumer can construct the shape without the key at all.
+        var result = TranspileHelper.Transpile(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, PlainObject]
+            public record UserDto([Optional] string? Name, int Age);
+            """
+        );
+
+        var output = result["user-dto.ts"];
+        await Assert.That(output).Contains("readonly name?: string | null");
+        await Assert.That(output).Contains("readonly age: number");
+    }
+
+    [Test]
+    public async Task OptionalMissing_OnNullablePlainObjectField_StaysPresentNullable()
+    {
+        // Without [Optional] a nullable plain-object parameter keeps
+        // the present-with-null default — the consumer still has to
+        // provide the key, but may set it to null. Baseline for the
+        // matrix.
+        var result = TranspileHelper.Transpile(
+            """
+            #nullable enable
+            [Transpile, PlainObject]
+            public record UserDto(string? Name, int Age);
+            """
+        );
+
+        var output = result["user-dto.ts"];
+        await Assert.That(output).DoesNotContain("name?: string");
+        await Assert.That(output).Contains("readonly name: string | null");
+    }
+
+    [Test]
+    public async Task Optional_OnInterfaceProperty_EmitsOptionalForm()
+    {
+        // Regular (non-PlainObject) interfaces also honor [Optional] —
+        // the property lowers with the `?` suffix so a consumer object
+        // implementing the interface can omit the key at construction
+        // time.
+        var result = TranspileHelper.Transpile(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile]
+            public interface IUserProps
+            {
+                [Optional] string? Nickname { get; }
+                string Name { get; }
+            }
+            """
+        );
+
+        var output = result["i-user-props.ts"];
+        await Assert.That(output).Contains("nickname?: string | null");
+        await Assert.That(output).Contains("name: string");
+    }
+
+    // ─── Diagnostic ──────────────────────────────────────────
+
+    [Test]
+    public async Task Optional_OnNonNullableParameter_EmitsMs0010()
+    {
+        // [Optional] on a non-nullable parameter is rejected — the
+        // attribute relies on `undefined` collapsing to `null`, which a
+        // non-nullable type cannot represent. The diagnostic points at
+        // the offending symbol so the fix (add `?`) is obvious.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, PlainObject]
+            public record UserDto([Optional] string Name);
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.OptionalRequiresNullable))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task Optional_OnNullableParameter_EmitsNoDiagnostic()
+    {
+        // The matching positive case — a nullable parameter with
+        // [Optional] is valid and extraction completes without raising
+        // MS0010.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, PlainObject]
+            public record UserDto([Optional] string? Name);
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.OptionalRequiresNullable))
+            .IsFalse();
+    }
+}

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -140,7 +140,15 @@ public static class TranspileHelper
         var result = new Dictionary<string, string>();
         foreach (var file in files)
             result[file.FileName] = printer.Print(file);
-        return (result, transformer.Diagnostics);
+        // Mirror the production host merge — frontend-raised diagnostics
+        // (extraction-time validations like MS0010) need to surface to
+        // test callers alongside the transformer's own output.
+        var diagnostics =
+            ir.Diagnostics.Count == 0
+                ? (IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic>)
+                    transformer.Diagnostics
+                : ir.Diagnostics.Concat(transformer.Diagnostics).ToList();
+        return (result, diagnostics);
     }
 
     /// <summary>


### PR DESCRIPTION
Introduces OptionalAttribute in Metano.Annotations.TypeScript — a
TS-specific attribute that opts a nullable parameter or property into
the optional-presence TS emission form (`name?: T | null`) instead of
the default present-with-null form (`name: T | null = null`). Together
with ADR-0014's loose-equality null-check emission, a JS-side
`undefined` collapses to C# `null` without breaking C#-authored null
guards — the pattern Hono request bodies, React props, and sparse JSON
all need.

The attribute is TS-specific and therefore lives in a dedicated
namespace so a multi-target domain project does not accidentally
surface a TypeScript-only knob through its base `using
Metano.Annotations;`.

IR additions:
- IrParameter.IsOptional: bool (defaults false)
- IrPropertyDeclaration.IsOptional: bool (defaults false)

Extractor wiring (interface property, class property, method parameter,
constructor parameter, interface method parameter) reads [Optional] and
sets the flag. TS bridges consume it:
- IrToTsInterfaceBridge: interface properties emit `name?: T | null`
- IrToTsPlainObjectBridge: [PlainObject] record fields use the OR of
  HasDefaultValue and IsOptional for the optional flag

Diagnostic MS0010 (OptionalRequiresNullable): frontend walker emits
error when [Optional] lands on a non-nullable type (the attribute
relies on undefined collapsing to null, which a non-nullable target
cannot represent). Tests cover the emission matrix and the diagnostic
path.

TranspileHelper now merges ir.Diagnostics with transformer.Diagnostics
so test callers see extraction-time validations (mirrors the production
host's merge).

Dart and future non-TS targets treat the flag as a no-op — the
attribute presence is harmless there; the C# type stays nullable either
way. The frontend validator runs on every target because a misuse is a
bug regardless of active backend.

612/612 TUnit green (5 new OptionalAttributeTranspileTests). Sample
outputs unchanged (no current sample uses [Optional]).

Closes #23

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>