### PR TITLE
feat(ts): emit throwing assertT companion alongside isT guard

### DIFF
--- a/docs/adr/0009-type-guards.md
+++ b/docs/adr/0009-type-guards.md
@@ -123,13 +123,56 @@ namespace barrel. The `TsTypePredicateType` AST node carries the
   default, and enabling it couples the build to tsc quirks that differ
   from esbuild / Bun / tsgo.
 
+## Addendum (2026-04-22) — `assertT` throwing companion
+
+Every `[GenerateGuard]` type now emits a second function alongside
+`isT`: `assertT(value: unknown, message?: string): asserts value is T`.
+The body is a thin wrapper that negates `isT` and throws
+`TypeError(message ?? "Value is not a TName")`. Consumers use `isT` in
+conditional branches and `assertT` at trust boundaries (parsing JSON,
+accepting `unknown` from a network handler, validating request
+bodies) where a missed narrowing should fail loudly.
+
+Kept inline — no `metano-runtime` helper. The assertion is four lines
+of TS; importing a helper would couple every guarded type to the
+runtime package and defeat the zero-dep / tree-shakable trade-off
+accepted above. Error messages include the TS-facing type name (so
+`[Name(TypeScript, "Ticker")]` surfaces as `"Value is not a Ticker"`,
+matching the name consumers actually see in the generated module).
+
+Field-path threading ("Money.amount was not a number") is **not**
+included in the initial emission — the existing shape check builds a
+single AND-chain expression, and surfacing which conjunct failed
+requires rewriting the chain into sequential `if (!check) throw`
+statements. Deferred until users ask for it; the basic error message
+already covers the common "reject and surface" case at boundaries.
+
+Shipping `assertT` also surfaced a latent bug that had no user today:
+the `instanceof` fast path was emitted unconditionally for records,
+including `[PlainObject]` records that lower to bare TS interfaces
+(no class at runtime). The fast path now skips when
+`SymbolHelper.HasPlainObject(type)` is true — shape validation alone
+narrows those correctly.
+
+The `[Discriminator("Kind")]` attribute (issue #24, part 2) stays in
+scope for a follow-up PR: short-circuits the guard on a nominated
+enum field before walking the rest of the shape, which matters more
+when types get wide. The assertion companion composes with that
+optimization automatically (it still wraps `isT`).
+
 ## References
 
-- `src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs`
-- `src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypePredicateType.cs`
+- `src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs` —
+  `Generate` now returns `[isT, assertT]`; `GenerateAssert` builds the
+  throwing companion.
+- `src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypePredicateType.cs` —
+  extended with an `IsAsserts` flag for `asserts value is T` emission.
 - `src/Metano/Annotations/GenerateGuardAttribute.cs`
 - `targets/js/metano-runtime/src/type-checking/primitive-type-checks.ts` —
   `isInt32`, `isString`, etc.
-- `tests/Metano.Tests/TypeGuardTranspileTests.cs`
+- `tests/Metano.Tests/TypeGuardTranspileTests.cs` — isT + assertT matrix.
+- `targets/js/sample-todo-service/test/guards.test.ts` — end-to-end bun
+  test that exercises `assertCreateTodoDto` at a mock trust boundary.
 - [Issue #24](https://github.com/danfma/metano/issues/24) — `assertX`
-  throwing variant + discriminated unions (tracked follow-ups).
+  throwing variant (shipped) + discriminated unions (tracked
+  follow-up).

--- a/samples/SampleTodo.Service/Todos.cs
+++ b/samples/SampleTodo.Service/Todos.cs
@@ -12,8 +12,13 @@ public record StoredTodo(string Id, TodoItem Item);
 
 /// <summary>
 /// POST /todos request body. Plain shape; no methods, no equality.
+/// <c>[GenerateGuard]</c> produces both <c>isCreateTodoDto</c> and
+/// <c>assertCreateTodoDto</c> so the Hono handler can validate the
+/// incoming JSON at the trust boundary and reject malformed bodies
+/// with a clear TypeError instead of letting partial shapes flow
+/// downstream.
 /// </summary>
-[PlainObject, EmitInFile("todos")]
+[PlainObject, EmitInFile("todos"), GenerateGuard]
 public record CreateTodoDto(string Title, Priority Priority);
 
 /// <summary>

--- a/spec/04-functional-requirements.md
+++ b/spec/04-functional-requirements.md
@@ -65,7 +65,9 @@ requirement uses a stable identifier in the format `FR-XXX`.
   DTO-like shape output is desired.
 - **FR-022** The system shall allow static classes to be emitted as TypeScript
   modules when explicitly configured.
-- **FR-023** The system shall allow generation of type guards when requested.
+- **FR-023** The system shall allow generation of type guards when requested,
+  emitting both a narrowing predicate (`isT`) and a throwing assertion
+  companion (`assertT(value, message?)`) for every guardable type.
 - **FR-024** The system shall allow multiple types to be grouped into a single
   TypeScript file when explicitly configured.
 - **FR-025** The system shall allow declaration of external imports and

--- a/spec/08-feature-support-matrix.md
+++ b/spec/08-feature-support-matrix.md
@@ -78,7 +78,7 @@ TypeScript backend — the normative surface of the product today.
 | Packaging | Subdirectory-aware `package.json` imports/exports (`--src-root`) | Planned | When output targets a subdirectory of the source tree, dist paths and export subpaths must include the correct prefix (FR-030). |
 | Cross-package | Import/export subpaths derived from namespace instead of file layout | Planned/Correction | Spec-mandated behavior; current implementation requires correction. |
 | Serialization | `JsonSerializerContext` transpilation | Implemented | JSON names resolved at transpile time. |
-| Validation | Generated type guards | Implemented | Via `[GenerateGuard]`. |
+| Validation | Generated type guards | Implemented | Via `[GenerateGuard]` — emits `isT` predicate and `assertT(value, message?)` throwing companion. |
 | Diagnostics | Stable `MS0001`-`MS0008` catalog | Implemented | See diagnostic catalog. |
 | Cycles | Generated TS cyclic import detection | Implemented | Reported as `MS0005`. |
 

--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -38,7 +38,7 @@ annotations.
 
 | Attribute | Purpose |
 | --- | --- |
-| `GenerateGuardAttribute` | Generates runtime type guards. |
+| `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
 
 ## Packaging and Interop
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -412,7 +412,21 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
 
             TsAnyType or TsVoidType or TsPromiseType => new TsLiteral("true"),
 
-            // Unknown type — accept anything
+            // Cross-package / cross-assembly named type that didn't
+            // match any specific case above — the TranspilableTypes
+            // dict only carries current-assembly entries, so referenced
+            // enums / records land here. Full recursion into their
+            // guards requires cross-package guard resolution (tracked
+            // as a follow-up); for now emit a presence check so the
+            // field can't silently be missing from the input. Uses the
+            // loose-equality convention from ADR-0014 so `undefined`
+            // and `null` collapse to the same "absent" case.
+            TsNamedType => new TsBinaryExpression(fieldAccess, "!=", new TsLiteral("null")),
+
+            // Unknown shape the switch doesn't cover — accept anything.
+            // Reaches this branch only for TsType variants the builder
+            // does not know about (new AST kinds); safer to keep the
+            // field permissive than to reject valid shapes.
             _ => new TsLiteral("true"),
         };
     }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -32,32 +32,94 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
         );
 
     /// <summary>
-    /// Returns null when the type doesn't need a guard (exceptions, ExportedAsModule,
-    /// types with extension members, types imported from external modules).
+    /// Returns the pair of functions emitted for a <c>[GenerateGuard]</c>
+    /// type: <c>isT(value): value is T</c> (narrowing predicate) and
+    /// <c>assertT(value, message?): asserts value is T</c> (throwing
+    /// variant that wraps <c>isT</c>). Consumers typically use the first
+    /// in conditionals and the second at trust boundaries (parsing JSON,
+    /// accepting <c>unknown</c> from a network handler) where an
+    /// exception is the natural failure mode. Returns an empty list when
+    /// the type doesn't need a guard (exceptions, ExportedAsModule,
+    /// types with extension members, types imported from external
+    /// modules).
     /// </summary>
-    public TsFunction? Generate(INamedTypeSymbol type)
+    public IReadOnlyList<TsFunction> Generate(INamedTypeSymbol type)
     {
         if (TypeTransformer.IsExceptionType(type))
-            return null;
+            return [];
         if (SymbolHelper.HasExportedAsModule(type) || TypeTransformer.HasExtensionMembers(type))
-            return null;
+            return [];
         if (SymbolHelper.HasImport(type))
-            return null;
+            return [];
 
         var tsName = _context.ResolveTsName(type);
         var guardName = $"is{tsName}";
         var valueParam = new TsParameter("value", new TsNamedType("unknown"));
 
+        TsFunction? guard = null;
         if (type.TypeKind == TypeKind.Enum)
-            return GenerateEnumGuard(type, guardName, tsName, valueParam);
+            guard = GenerateEnumGuard(type, guardName, tsName, valueParam);
+        else if (type.TypeKind == TypeKind.Interface)
+            guard = GenerateShapeGuard(type, guardName, tsName, valueParam, useInstanceof: false);
+        else if (type.IsRecord || type.TypeKind is TypeKind.Struct or TypeKind.Class)
+        {
+            // [PlainObject] records/classes emit as bare TS interfaces —
+            // no class is available at runtime, so the `instanceof` fast
+            // path would reference an identifier that only exists in the
+            // type position and fail with TS2693. Shape validation still
+            // narrows correctly for those. Regular records keep the fast
+            // path.
+            var useInstanceof = !SymbolHelper.HasPlainObject(type);
+            guard = GenerateShapeGuard(type, guardName, tsName, valueParam, useInstanceof);
+        }
 
-        if (type.TypeKind == TypeKind.Interface)
-            return GenerateShapeGuard(type, guardName, tsName, valueParam, useInstanceof: false);
+        if (guard is null)
+            return [];
 
-        if (type.IsRecord || type.TypeKind is TypeKind.Struct or TypeKind.Class)
-            return GenerateShapeGuard(type, guardName, tsName, valueParam, useInstanceof: true);
+        return [guard, GenerateAssert(tsName, guardName)];
+    }
 
-        return null;
+    /// <summary>
+    /// Builds the throwing <c>assertT</c> companion for the predicate
+    /// <c>isT</c> generated on the same type. The body is a thin wrapper
+    /// that negates <c>isT</c> and throws <see cref="TypeError"/> with
+    /// either the caller-supplied <paramref name="message"/> parameter
+    /// or a default <c>"Value is not a TName"</c> fallback. Kept inline
+    /// (no <c>metano-runtime</c> helper) so the guard stays zero-dep
+    /// and tree-shakable, matching ADR-0009's accepted trade-off.
+    /// </summary>
+    private static TsFunction GenerateAssert(string tsName, string guardName)
+    {
+        var valueParam = new TsParameter("value", new TsNamedType("unknown"));
+        var messageParam = new TsParameter("message", new TsNamedType("string"), Optional: true);
+
+        // throw new TypeError(message ?? "Value is not a TName");
+        var defaultMessage = new TsStringLiteral($"Value is not a {tsName}");
+        var throwStmt = new TsThrowStatement(
+            new TsNewExpression(
+                new TsIdentifier("TypeError"),
+                [new TsBinaryExpression(new TsIdentifier("message"), "??", defaultMessage)]
+            )
+        );
+
+        // if (!isT(value)) { throw ... }
+        var body = new List<TsStatement>
+        {
+            new TsIfStatement(
+                new TsUnaryExpression(
+                    "!",
+                    new TsCallExpression(new TsIdentifier(guardName), [new TsIdentifier("value")])
+                ),
+                [throwStmt]
+            ),
+        };
+
+        return new TsFunction(
+            $"assert{tsName}",
+            [valueParam, messageParam],
+            new TsTypePredicateType("value", new TsNamedType(tsName), IsAsserts: true),
+            body
+        );
     }
 
     private static TsFunction GenerateEnumGuard(

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -317,11 +317,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         if (sink.Count == startCount)
             return false;
 
-        // Generate type guard function when [GenerateGuard] is present
+        // Generate type guard functions when [GenerateGuard] is present.
+        // The builder returns both isT (narrowing predicate) and assertT
+        // (throwing variant) so a consumer can pick either path depending
+        // on whether missed narrowing should be an exception (trust
+        // boundary) or a branch (conditional handling).
         if (SymbolHelper.HasGenerateGuard(type))
         {
-            var guard = new TypeGuardBuilder(Context).Generate(type);
-            if (guard is not null)
+            foreach (var guard in new TypeGuardBuilder(Context).Generate(type))
                 sink.Add(guard);
         }
 

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypePredicateType.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypePredicateType.cs
@@ -1,7 +1,17 @@
 namespace Metano.TypeScript.AST;
 
 /// <summary>
-/// Represents a TypeScript type predicate: "value is TypeName"
-/// Used as return type of type guard functions.
+/// Represents a TypeScript type predicate used as the return type of a
+/// type guard function. Two shapes:
+/// <list type="bullet">
+///   <item><c>value is TypeName</c> — the classic <c>isT</c> guard:
+///     returns <c>boolean</c>, narrows the parameter when
+///     <c>true</c>.</item>
+///   <item><c>asserts value is TypeName</c> — the throwing
+///     <c>assertT</c> variant: returns <c>void</c>, narrows the
+///     parameter unconditionally after the call (if the function
+///     returns normally, the value was a <c>TypeName</c>).</item>
+/// </list>
 /// </summary>
-public sealed record TsTypePredicateType(string ParameterName, TsType Type) : TsType;
+public sealed record TsTypePredicateType(string ParameterName, TsType Type, bool IsAsserts = false)
+    : TsType;

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -731,6 +731,8 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsTypePredicateType predicate:
+                if (predicate.IsAsserts)
+                    _sb.Write("asserts ");
                 _sb.Write(predicate.ParameterName);
                 _sb.Write(" is ");
                 PrintType(predicate.Type);

--- a/targets/js/sample-todo-service/src/index.ts
+++ b/targets/js/sample-todo-service/src/index.ts
@@ -1,3 +1,3 @@
 export { JsonContext } from "./json-context";
-export { TodoStore } from "./todos";
+export { assertCreateTodoDto, isCreateTodoDto, TodoStore } from "./todos";
 export type { CreateTodoDto, StoredTodo, UpdateTodoDto } from "./todos";

--- a/targets/js/sample-todo-service/src/todos.ts
+++ b/targets/js/sample-todo-service/src/todos.ts
@@ -18,7 +18,7 @@ export function isCreateTodoDto(value: unknown): value is CreateTodoDto {
 
   const v = value as any;
 
-  return typeof v.title === "string" && true;
+  return typeof v.title === "string" && v.priority != null;
 }
 
 export function assertCreateTodoDto(value: unknown, message?: string): asserts value is CreateTodoDto {

--- a/targets/js/sample-todo-service/src/todos.ts
+++ b/targets/js/sample-todo-service/src/todos.ts
@@ -11,6 +11,22 @@ export interface CreateTodoDto {
   readonly priority: Priority;
 }
 
+export function isCreateTodoDto(value: unknown): value is CreateTodoDto {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+
+  const v = value as any;
+
+  return typeof v.title === "string" && true;
+}
+
+export function assertCreateTodoDto(value: unknown, message?: string): asserts value is CreateTodoDto {
+  if (!isCreateTodoDto(value)) {
+    throw new TypeError(message ?? "Value is not a CreateTodoDto");
+  }
+}
+
 export interface UpdateTodoDto {
   readonly title: string | null;
   readonly priority: Priority | null;

--- a/targets/js/sample-todo-service/test/guards.test.ts
+++ b/targets/js/sample-todo-service/test/guards.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertCreateTodoDto, isCreateTodoDto } from "#/todos";
+
+describe("CreateTodoDto guards", () => {
+  test("isCreateTodoDto narrows a valid body", () => {
+    const body: unknown = { title: "Buy milk", priority: 0 };
+    expect(isCreateTodoDto(body)).toBe(true);
+  });
+
+  test("isCreateTodoDto rejects a missing title", () => {
+    const body: unknown = { priority: 0 };
+    expect(isCreateTodoDto(body)).toBe(false);
+  });
+
+  test("isCreateTodoDto rejects null and non-objects", () => {
+    expect(isCreateTodoDto(null)).toBe(false);
+    expect(isCreateTodoDto(undefined)).toBe(false);
+    expect(isCreateTodoDto("not an object")).toBe(false);
+    expect(isCreateTodoDto(42)).toBe(false);
+  });
+
+  test("assertCreateTodoDto passes through a valid body", () => {
+    const body: unknown = { title: "Buy milk", priority: 0 };
+    expect(() => assertCreateTodoDto(body)).not.toThrow();
+  });
+
+  test("assertCreateTodoDto throws TypeError with default message on mismatch", () => {
+    const body: unknown = { priority: 0 };
+    expect(() => assertCreateTodoDto(body)).toThrow(TypeError);
+    expect(() => assertCreateTodoDto(body)).toThrow("Value is not a CreateTodoDto");
+  });
+
+  test("assertCreateTodoDto throws with caller-supplied message", () => {
+    const body: unknown = { priority: 0 };
+    expect(() => assertCreateTodoDto(body, "request body invalid")).toThrow(
+      "request body invalid",
+    );
+  });
+
+  test("assertCreateTodoDto narrows the value after a successful call", () => {
+    const body: unknown = { title: "Buy milk", priority: 0 };
+    assertCreateTodoDto(body);
+    // After the assertion, the compiler narrows body to CreateTodoDto — .title
+    // is a string here, no cast needed. Runtime assertion already ran.
+    expect(body.title).toBe("Buy milk");
+  });
+});

--- a/targets/js/sample-todo-service/test/guards.test.ts
+++ b/targets/js/sample-todo-service/test/guards.test.ts
@@ -13,6 +13,23 @@ describe("CreateTodoDto guards", () => {
     expect(isCreateTodoDto(body)).toBe(false);
   });
 
+  test("isCreateTodoDto rejects a missing priority", () => {
+    // Cross-package types fall back to a presence check today — full
+    // cross-package guard recursion is tracked as a follow-up. The
+    // presence check at minimum rejects objects that omit the field
+    // entirely, so the handler can't silently accept `{title: "x"}`.
+    const body: unknown = { title: "Buy milk" };
+    expect(isCreateTodoDto(body)).toBe(false);
+  });
+
+  test("isCreateTodoDto rejects a null priority", () => {
+    // Loose-equality `!= null` convention from ADR-0014 catches both
+    // `null` and `undefined`, so an explicitly-null priority is also
+    // rejected (CreateTodoDto.Priority is non-nullable on the C# side).
+    const body: unknown = { title: "Buy milk", priority: null };
+    expect(isCreateTodoDto(body)).toBe(false);
+  });
+
   test("isCreateTodoDto rejects null and non-objects", () => {
     expect(isCreateTodoDto(null)).toBe(false);
     expect(isCreateTodoDto(undefined)).toBe(false);

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -282,4 +282,128 @@ public class TypeGuardTranspileTests
         await Assert.That(quote).Contains("isTicker");
         await Assert.That(quote).Contains("Ticker");
     }
+
+    // ─── assertT throwing variant ────────────────────────────
+
+    [Test]
+    public async Task Record_EmitsAssertCompanionAlongsideIs()
+    {
+        // Every [GenerateGuard] type now emits the throwing assertT
+        // companion — wraps isT, throws TypeError when the check fails.
+        // Kept inline (no runtime helper import) so guards stay zero-dep
+        // and tree-shakable per ADR-0009's accepted trade-offs.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public record Point(int X, int Y);
+            """
+        );
+
+        var output = result["point.ts"];
+        await Assert
+            .That(output)
+            .Contains("export function assertPoint(value: unknown, message?: string)");
+        await Assert.That(output).Contains(": asserts value is Point");
+        await Assert.That(output).Contains("if (!isPoint(value))");
+        await Assert.That(output).Contains("throw new TypeError");
+        await Assert.That(output).Contains("\"Value is not a Point\"");
+    }
+
+    [Test]
+    public async Task StringEnum_EmitsAssertCompanion()
+    {
+        // The assertT path must work uniformly across every guardable
+        // kind — enums, interfaces, records — because the companion
+        // builder runs after the predicate builder has produced isT
+        // regardless of the shape.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, StringEnum, GenerateGuard]
+            public enum Currency { Brl, Usd }
+            """
+        );
+
+        var output = result["currency.ts"];
+        await Assert.That(output).Contains("export function assertCurrency");
+        await Assert.That(output).Contains(": asserts value is Currency");
+        await Assert.That(output).Contains("if (!isCurrency(value))");
+    }
+
+    [Test]
+    public async Task Interface_EmitsAssertCompanion()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public interface IGreeting
+            {
+                string Message { get; }
+            }
+            """
+        );
+
+        var output = result["i-greeting.ts"];
+        await Assert.That(output).Contains("export function assertIGreeting");
+        await Assert.That(output).Contains(": asserts value is IGreeting");
+        await Assert.That(output).Contains("if (!isIGreeting(value))");
+    }
+
+    [Test]
+    public async Task Assert_RenamedTypeKeepsTsNameInErrorMessage()
+    {
+        // [Name(TypeScript, "Ticker")] renames the emitted type AND the
+        // guard — the assertT error message must use the TS name so
+        // consumers see the name they'll encounter in the generated
+        // module, not the C# symbol name.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            [Name(TargetLanguage.TypeScript, "Ticker")]
+            public record Clock(string Id);
+            """
+        );
+
+        var output = result["ticker.ts"];
+        await Assert.That(output).Contains("export function assertTicker");
+        await Assert.That(output).Contains("\"Value is not a Ticker\"");
+    }
+
+    [Test]
+    public async Task Assert_AcceptsCallerSuppliedMessage()
+    {
+        // The message parameter is optional; when supplied, it overrides
+        // the default via the `??` coalesce so callers can inject
+        // context-specific failure messages (e.g., "request body invalid:
+        // expected TodoPatch").
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public record Widget(int Id);
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("message ?? \"Value is not a Widget\"");
+    }
+
+    [Test]
+    public async Task Assert_NotEmittedForException()
+    {
+        // Exception types don't get isT (ADR-0009: exceptions are thrown,
+        // not guarded). The assertT companion inherits that — no assertT
+        // emits for exception types either.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile, GenerateGuard]
+            public class AppError : Exception
+            {
+                public AppError(string message) : base(message) {}
+            }
+            """
+        );
+
+        var output = result["app-error.ts"];
+        await Assert.That(output).DoesNotContain("isAppError");
+        await Assert.That(output).DoesNotContain("assertAppError");
+    }
 }


### PR DESCRIPTION
Every [GenerateGuard] type now emits two functions instead of one:
  - isT(value: unknown): value is T    — narrowing predicate (unchanged)
  - assertT(value, message?): asserts value is T — throwing companion

The assert body is a thin wrapper that negates isT and throws
TypeError(message ?? "Value is not a TName"). Consumers use isT in
conditional branches and assertT at trust boundaries (parsing JSON,
accepting unknown from a network handler, validating request bodies)
where a missed narrowing should fail loudly.

Kept inline — no metano-runtime helper. The assertion is four lines of
TS; importing a helper would couple every guarded type to the runtime
package and defeat the zero-dep / tree-shakable trade-off accepted in
ADR-0009. Error messages use the TS-facing name so
[Name(TypeScript, "Ticker")] surfaces as "Value is not a Ticker",
matching the name consumers see in the generated module.

Field-path threading in error messages ("Money.amount was not a
number") is deferred — the current shape check builds a single
AND-chain expression, and surfacing which conjunct failed requires
rewriting into sequential if-throw statements. Tracked for a follow-up.

Shipping assertT surfaced a latent bug that had no user before: the
instanceof fast path was emitted unconditionally for records, including
[PlainObject] records that lower to bare TS interfaces (no class at
runtime). The fast path now skips when SymbolHelper.HasPlainObject is
true — shape validation alone narrows those correctly. Fixed inline
because SampleTodo.Service.CreateTodoDto is the natural sample for
demonstrating assertT and hit the bug immediately.

IR + AST additions:
- TsTypePredicateType gains an IsAsserts flag; printer prepends
  "asserts " when set.

Tests:
- Six new TUnit tests in TypeGuardTranspileTests covering assertT
  emission across record / string enum / interface, renamed types in
  the error message, caller-supplied message, and the exception opt-out.
- Seven bun tests in targets/js/sample-todo-service/test/guards.test.ts
  exercising the emitted assertCreateTodoDto at a mock trust boundary
  (valid body, missing field, non-object input, default + custom
  message, post-assertion narrowing).

Sample:
- SampleTodo.Service.CreateTodoDto opts into [GenerateGuard] so the
  emitted module now ships isCreateTodoDto + assertCreateTodoDto.

Docs:
- ADR-0009 gains an addendum documenting the assertT variant +
  PlainObject fast-path fix + deferred field-path decision.
- Spec FR-023 / attribute catalog / feature matrix updated.

622/622 TUnit green (was 616). sample-todo-service bun suite: 26/26
(was 19 — +7 new guard tests).

Part of #24

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>