### PR TITLE
feat(ts): [Discriminator] attribute for short-circuit guard narrowing

### DIFF
--- a/docs/adr/0009-type-guards.md
+++ b/docs/adr/0009-type-guards.md
@@ -154,25 +154,68 @@ including `[PlainObject]` records that lower to bare TS interfaces
 `SymbolHelper.HasPlainObject(type)` is true — shape validation alone
 narrows those correctly.
 
-The `[Discriminator("Kind")]` attribute (issue #24, part 2) stays in
-scope for a follow-up PR: short-circuits the guard on a nominated
-enum field before walking the rest of the shape, which matters more
-when types get wide. The assertion companion composes with that
-optimization automatically (it still wraps `isT`).
+## Addendum (2026-04-23) — `[Discriminator("FieldName")]` short-circuit
+
+Types annotated with `[Discriminator("FieldName")]` (from
+`Metano.Annotations.TypeScript`) short-circuit the generated guard on
+a nominated field before walking the rest of the shape. The check
+emits as a literal comparison — `if (v.kind !== "TypeName") return
+false;` — placed immediately after the null/object gate. When the
+discriminator matches, the remaining field checks still run so
+reserved fields stay validated.
+
+The expected discriminator value follows a **type-name convention**:
+the emitted check compares against the type's TS name (after
+`[Name(TypeScript, …)]` resolution). A `Circle` class tagged
+`[Discriminator("Kind")]` expects `v.kind === "Circle"`; a class
+renamed via `[Name(TypeScript, "Round")]` expects `v.kind === "Round"`.
+This keeps the attribute surface minimal — no second argument for the
+expected value — at the cost of requiring the enum member name to
+match the type name. The convention is enforced at runtime (a
+mismatch rejects every payload); the frontend validator only checks
+field shape, not enum-member-to-type-name alignment.
+
+Frontend validator emits `MS0011` when the `[Discriminator]` field is
+missing on the type, not a `[StringEnum]`, or nullable — any of those
+would produce a guard that can't narrow safely. The short-circuit
+lowering runs after the null-safety gates so the discriminator access
+is always on an object, and the field itself has no null guard of its
+own.
+
+The discriminator field is also **skipped from the general field
+loop** — the literal comparison above is strictly tighter than the
+`isKind(v.kind)` recursive call the default emission would produce,
+so re-checking would be dead code and drag in an extra runtime import
+for the enum guard.
+
+The sealed-hierarchy follow-up (issue #24, part 3 — union type guard
+that switches on a shared discriminant across multiple subtypes) stays
+out of scope. Metano doesn't model sealed hierarchies at the IR layer
+today; adding one is a separate design conversation.
 
 ## References
 
 - `src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs` —
-  `Generate` now returns `[isT, assertT]`; `GenerateAssert` builds the
-  throwing companion.
+  `Generate` returns `[isT, assertT]`; `GenerateAssert` builds the
+  throwing companion; `GenerateShapeGuard` emits the discriminator
+  short-circuit when `[Discriminator]` is present and filters the
+  field out of the remaining shape loop.
 - `src/Metano.Compiler.TypeScript/TypeScript/AST/TsTypePredicateType.cs` —
   extended with an `IsAsserts` flag for `asserts value is T` emission.
 - `src/Metano/Annotations/GenerateGuardAttribute.cs`
+- `src/Metano/Annotations/TypeScript/DiscriminatorAttribute.cs` —
+  TS-specific attribute, namespaced away from cross-target annotations.
+- `src/Metano.Compiler/CSharpSourceFrontend.cs` —
+  `ValidateDiscriminatorAttribute` raises MS0011 for invalid uses.
 - `targets/js/metano-runtime/src/type-checking/primitive-type-checks.ts` —
   `isInt32`, `isString`, etc.
-- `tests/Metano.Tests/TypeGuardTranspileTests.cs` — isT + assertT matrix.
-- `targets/js/sample-todo-service/test/guards.test.ts` — end-to-end bun
-  test that exercises `assertCreateTodoDto` at a mock trust boundary.
+- `tests/Metano.Tests/TypeGuardTranspileTests.cs` — isT + assertT +
+  discriminator matrix.
+- `targets/js/sample-todo-service/test/guards.test.ts` — bun test
+  exercising `assertCreateTodoDto` at a mock trust boundary.
+- `targets/js/sample-todo-service/test/events.test.ts` — bun test
+  demonstrating discriminator-based narrowing between `TodoCreated`
+  and `TodoUpdated` variants that share the `TodoEventKind` enum.
 - [Issue #24](https://github.com/danfma/metano/issues/24) — `assertX`
-  throwing variant (shipped) + discriminated unions (tracked
-  follow-up).
+  throwing variant (shipped) + `[Discriminator]` short-circuit
+  (shipped) + sealed-hierarchy union guard (deferred).

--- a/samples/SampleTodo.Service/Events.cs
+++ b/samples/SampleTodo.Service/Events.cs
@@ -1,0 +1,36 @@
+using Metano.Annotations;
+using Metano.Annotations.TypeScript;
+
+namespace SampleTodo.Service;
+
+/// <summary>
+/// Canonical kinds of events the todo service surfaces. <c>[StringEnum]</c>
+/// lowers this to a TS string union so the discriminator narrowing
+/// compiles to a literal comparison.
+/// </summary>
+[Transpile, StringEnum, EmitInFile("events")]
+public enum TodoEventKind
+{
+    TodoCreated,
+    TodoUpdated,
+    TodoDeleted,
+}
+
+/// <summary>
+/// Event published when a new todo is inserted. <c>[Discriminator]</c>
+/// marks <c>Kind</c> as the narrowing field — the generated
+/// <c>isTodoCreated</c> guard short-circuits on <c>v.kind !== "TodoCreated"</c>
+/// before walking the rest of the shape, so a payload for a different
+/// event exits the guard without scanning every field.
+/// </summary>
+[PlainObject, GenerateGuard, Discriminator("Kind"), EmitInFile("events")]
+public record TodoCreated(TodoEventKind Kind, string Id, string Title);
+
+/// <summary>
+/// Event published when a todo is patched. Shares the same
+/// <see cref="TodoEventKind"/> discriminator, different expected value
+/// (<c>"TodoUpdated"</c>) — the emitted guard keyword matches the type
+/// name by convention.
+/// </summary>
+[PlainObject, GenerateGuard, Discriminator("Kind"), EmitInFile("events")]
+public record TodoUpdated(TodoEventKind Kind, string Id, string? Title, bool? Completed);

--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -39,6 +39,7 @@ annotations.
 | Attribute | Purpose |
 | --- | --- |
 | `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
+| `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
 
 ## Packaging and Interop
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,7 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0008`**.
+The current stable code range is **`MS0001` through `MS0011`**.
 
 ## Stable Codes
 
@@ -26,6 +26,9 @@ The current stable code range is **`MS0001` through `MS0008`**.
 | `MS0006` | `InvalidModuleEntryPoint` | Invalid use of `[ModuleEntryPoint]`, including incompatible signature or conflicting setup. |
 | `MS0007` | `CrossPackageResolution` | Cross-package resolution failure, including missing or divergent package identity metadata. |
 | `MS0008` | `EmitInFileConflict` | Conflicting `[EmitInFile]` grouping would make output placement ambiguous. |
+| `MS0009` | `FrontendLoadFailure` | Source frontend failed to load or compile the project. |
+| `MS0010` | `OptionalRequiresNullable` | `[Optional]` was applied to a non-nullable parameter or property. |
+| `MS0011` | `InvalidDiscriminator` | `[Discriminator("FieldName")]` references a field that is missing, not a `[StringEnum]`, or nullable. |
 
 ## Product Significance
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -239,16 +239,31 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
         // immediately instead of walking every field. The frontend
         // validator (MS0011) guarantees the discriminant is a present
         // non-nullable StringEnum, so the literal comparison is safe.
+        // Resolves the TS field name via the same rule the shape loop
+        // uses (`[Name(TypeScript, …)]` override ∪ camelCase), so a
+        // renamed discriminator surfaces on both the short-circuit
+        // access and the skip filter below.
         var discriminatorFieldName = SymbolHelper.GetDiscriminatorFieldName(type);
-        var discriminatorCamel = discriminatorFieldName is not null
-            ? TypeScriptNaming.ToCamelCase(discriminatorFieldName)
-            : null;
-        if (discriminatorFieldName is not null && discriminatorCamel is not null)
+        string? discriminatorTsName = null;
+        if (discriminatorFieldName is not null)
         {
+            var discriminatorMember = type.GetMembers(discriminatorFieldName)
+                .OfType<IPropertySymbol>()
+                .FirstOrDefault();
+            discriminatorTsName =
+                (
+                    discriminatorMember is not null
+                        ? SymbolHelper.GetNameOverride(
+                            discriminatorMember,
+                            TargetLanguage.TypeScript
+                        )
+                        : null
+                ) ?? TypeScriptNaming.ToCamelCase(discriminatorFieldName);
+
             body.Add(
                 new TsIfStatement(
                     new TsBinaryExpression(
-                        new TsPropertyAccess(new TsIdentifier("v"), discriminatorCamel),
+                        new TsPropertyAccess(new TsIdentifier("v"), discriminatorTsName),
                         "!==",
                         new TsStringLiteral(tsName)
                     ),
@@ -260,7 +275,7 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
         // Field checks — skip the discriminator (already narrowed above)
         // to avoid redundant recursion into isKind(v.kind).
         var fields = GetAllFieldsForGuard(type)
-            .Where(f => !string.Equals(f.Name, discriminatorCamel, StringComparison.Ordinal))
+            .Where(f => !string.Equals(f.Name, discriminatorTsName, StringComparison.Ordinal))
             .ToList();
         if (fields.Count > 0)
         {
@@ -416,15 +431,21 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
                 types
             ),
 
-            // String literal union (from StringEnum that's not transpilable)
-            TsUnionType { Types: var types } when types.All(t => t is TsStringLiteralType) => types
-                .Cast<TsStringLiteralType>()
-                .Select<TsStringLiteralType, TsExpression>(t => new TsBinaryExpression(
-                    fieldAccess,
-                    "===",
-                    new TsStringLiteral(t.Value)
-                ))
-                .Aggregate((a, b) => new TsBinaryExpression(a, "||", b)),
+            // String literal union (from StringEnum that's not transpilable).
+            // Wrapped so the OR chain stays grouped when it lands in an
+            // outer AND conjunction — same precedence concern as
+            // NullableFieldCheck above.
+            TsUnionType { Types: var types } when types.All(t => t is TsStringLiteralType) =>
+                new TsParenthesized(
+                    types
+                        .Cast<TsStringLiteralType>()
+                        .Select<TsStringLiteralType, TsExpression>(t => new TsBinaryExpression(
+                            fieldAccess,
+                            "===",
+                            new TsStringLiteral(t.Value)
+                        ))
+                        .Aggregate((a, b) => new TsBinaryExpression(a, "||", b))
+                ),
 
             TsTupleType { Elements: var elements } => new TsBinaryExpression(
                 new TsCallExpression(
@@ -483,10 +504,18 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
                     .Select(t => GenerateFieldCheck(fieldAccess, t))
                     .Aggregate((a, b) => new TsBinaryExpression(a, "||", b));
 
-        return new TsBinaryExpression(
-            new TsBinaryExpression(fieldAccess, "==", new TsLiteral("null")),
-            "||",
-            innerCheck
+        // Parenthesize the `null || inner` disjunction — JS `&&` binds
+        // tighter than `||`, so when this expression lands in an
+        // AND-chain with other field checks
+        // (`typeof v.a === "number" && nullable-check && …`) the
+        // grouping must stay `a && (b || c) && d` instead of
+        // accidentally associating as `a && b || c && d`.
+        return new TsParenthesized(
+            new TsBinaryExpression(
+                new TsBinaryExpression(fieldAccess, "==", new TsLiteral("null")),
+                "||",
+                innerCheck
+            )
         );
     }
 }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -231,8 +231,37 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
             )
         );
 
-        // Field checks
-        var fields = GetAllFieldsForGuard(type);
+        // [Discriminator("FieldName")] short-circuit: check the named
+        // field against the type's TS name (convention: enum member
+        // name matches the type's TS name — e.g., Circle class tags
+        // `Kind` and the emitted guard expects `v.kind === "Circle"`).
+        // Runs before shape validation so a mismatch exits the guard
+        // immediately instead of walking every field. The frontend
+        // validator (MS0011) guarantees the discriminant is a present
+        // non-nullable StringEnum, so the literal comparison is safe.
+        var discriminatorFieldName = SymbolHelper.GetDiscriminatorFieldName(type);
+        var discriminatorCamel = discriminatorFieldName is not null
+            ? TypeScriptNaming.ToCamelCase(discriminatorFieldName)
+            : null;
+        if (discriminatorFieldName is not null && discriminatorCamel is not null)
+        {
+            body.Add(
+                new TsIfStatement(
+                    new TsBinaryExpression(
+                        new TsPropertyAccess(new TsIdentifier("v"), discriminatorCamel),
+                        "!==",
+                        new TsStringLiteral(tsName)
+                    ),
+                    [new TsReturnStatement(new TsLiteral("false"))]
+                )
+            );
+        }
+
+        // Field checks — skip the discriminator (already narrowed above)
+        // to avoid redundant recursion into isKind(v.kind).
+        var fields = GetAllFieldsForGuard(type)
+            .Where(f => !string.Equals(f.Name, discriminatorCamel, StringComparison.Ordinal))
+            .ToList();
         if (fields.Count > 0)
         {
             TsExpression fieldChecks = fields

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -136,7 +136,10 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             : BuildTranspilableTypeEntries(compilation, assemblyWideTranspile, entryPoint);
 
         if (compilation is not null)
+        {
             ValidateOptionalAttribute(compilation, assemblyWideTranspile, diagnostics);
+            ValidateDiscriminatorAttribute(compilation, assemblyWideTranspile, diagnostics);
+        }
 
         return new IrCompilation(
             AssemblyName: compilation?.AssemblyName ?? fallbackAssemblyName,
@@ -600,6 +603,97 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 : $"'{method.ContainingType?.Name ?? string.Empty}.{method.Name}({p.Name})'",
             _ => $"'{symbol.ContainingSymbol?.Name ?? string.Empty}.{symbol.Name}'",
         };
+
+    /// <summary>
+    /// Walks every transpilable type carrying
+    /// <c>[Discriminator("FieldName")]</c> and emits <c>MS0011</c>
+    /// when the referenced field is missing, not a <c>[StringEnum]</c>,
+    /// or nullable. The short-circuit guard emission relies on a
+    /// present non-null string-valued discriminant; without those
+    /// guarantees the generated narrowing would silently miss-fire.
+    /// Runs on every target (not just TypeScript) because the
+    /// attribute is a validation failure regardless of active backend.
+    /// </summary>
+    private static void ValidateDiscriminatorAttribute(
+        Compilation compilation,
+        bool assemblyWideTranspile,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type =>
+                VisitTypeForDiscriminator(type, assemblyWideTranspile, currentAssembly, diagnostics)
+        );
+    }
+
+    private static void VisitTypeForDiscriminator(
+        INamedTypeSymbol type,
+        bool assemblyWideTranspile,
+        IAssemblySymbol currentAssembly,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (!SymbolHelper.IsTranspilable(type, assemblyWideTranspile, currentAssembly))
+            return;
+
+        var fieldName = SymbolHelper.GetDiscriminatorFieldName(type);
+        if (fieldName is not null)
+        {
+            var property = type.GetMembers(fieldName).OfType<IPropertySymbol>().FirstOrDefault();
+            if (property is null)
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidDiscriminator,
+                        $"[Discriminator(\"{fieldName}\")] on '{type.Name}' refers to a property "
+                            + $"that doesn't exist on the type. Add a "
+                            + $"'{fieldName}' property typed as a [StringEnum], or remove the "
+                            + $"attribute.",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+            else if (IsNullableType(property.Type))
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidDiscriminator,
+                        $"[Discriminator(\"{fieldName}\")] on '{type.Name}' references a "
+                            + $"nullable field. The discriminant must be present on every "
+                            + $"instance so the guard can narrow without a null guard of its "
+                            + $"own. Make '{type.Name}.{fieldName}' non-nullable.",
+                        property.Locations.FirstOrDefault()
+                    )
+                );
+            }
+            else if (!SymbolHelper.HasStringEnum(property.Type))
+            {
+                // Check after nullability so a nullable StringEnum
+                // (which shouldn't reach here but could via unusual
+                // patterns) gets the more actionable nullable
+                // diagnostic instead.
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidDiscriminator,
+                        $"[Discriminator(\"{fieldName}\")] on '{type.Name}' references "
+                            + $"'{type.Name}.{fieldName}', which is not a [StringEnum]. The "
+                            + $"short-circuit guard relies on a string-valued discriminant so "
+                            + $"the narrowing compiles to a direct literal comparison — mark "
+                            + $"the enum with [StringEnum] or pick a different field.",
+                        property.Locations.FirstOrDefault()
+                    )
+                );
+            }
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForDiscriminator(nested, assemblyWideTranspile, currentAssembly, diagnostics);
+    }
 
     /// <summary>
     /// Detects the C# 9+ top-level-statement entry point and returns the

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -569,6 +569,31 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             VisitTypeForOptional(nested, assemblyWideTranspile, currentAssembly, diagnostics);
     }
 
+    /// <summary>
+    /// Mirrors the inclusion rules
+    /// <c>TypeGuardBuilder.GetAllFieldsForGuard</c> applies to
+    /// properties. Returns <c>false</c> for implicitly-declared,
+    /// static, <c>private</c> / <c>internal</c> / <c>NotApplicable</c>
+    /// accessibility, and <c>[Ignore(TypeScript)]</c>-suppressed
+    /// members. Used by <c>ValidateDiscriminatorAttribute</c> to
+    /// reject discriminators pointing at a member that won't appear
+    /// in the emitted TS shape.
+    /// </summary>
+    private static bool IsGuardVisibleProperty(IPropertySymbol prop)
+    {
+        if (prop.IsImplicitlyDeclared)
+            return false;
+        if (prop.IsStatic)
+            return false;
+        if (SymbolHelper.HasIgnore(prop, TargetLanguage.TypeScript))
+            return false;
+        return prop.DeclaredAccessibility
+            is Accessibility.Public
+                or Accessibility.Protected
+                or Accessibility.ProtectedOrInternal
+                or Accessibility.ProtectedAndInternal;
+    }
+
     private static bool IsNullableType(ITypeSymbol type) =>
         type.NullableAnnotation == NullableAnnotation.Annotated
         || type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
@@ -653,6 +678,31 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                             + $"'{fieldName}' property typed as a [StringEnum], or remove the "
                             + $"attribute.",
                         type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+            else if (!IsGuardVisibleProperty(property))
+            {
+                // The guard emits `v.<field>` access unconditionally when
+                // the attribute is present. A private / internal / static
+                // / implicitly-declared / [Ignore(TS)] member isn't part
+                // of the TS shape the guard walks, so the short-circuit
+                // would access a phantom field and reject every payload.
+                // Match the inclusion rules
+                // (TypeGuardBuilder.IsGuardVisible + static/implicit/
+                // Ignore filter) so the discriminator can only point at
+                // a member that actually surfaces in the emitted
+                // interface.
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidDiscriminator,
+                        $"[Discriminator(\"{fieldName}\")] on '{type.Name}' references "
+                            + $"'{type.Name}.{fieldName}', which isn't guard-visible (private, "
+                            + $"static, implicit, or [Ignore(TypeScript)]-ed). The discriminator "
+                            + $"must be a public instance property that participates in the "
+                            + $"emitted TS shape so the guard can narrow against it.",
+                        property.Locations.FirstOrDefault()
                     )
                 );
             }

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -95,4 +95,13 @@ public static class DiagnosticCodes
     /// behavior. The fix is to make the C# type nullable
     /// (<c>[Optional] string? Name</c>).</summary>
     public const string OptionalRequiresNullable = "MS0010";
+
+    /// <summary>MS0011 — <c>[Discriminator("FieldName")]</c> (from
+    /// <c>Metano.Annotations.TypeScript</c>) refers to a field that
+    /// either doesn't exist on the annotated type, isn't a
+    /// <c>[StringEnum]</c>, or is nullable. The short-circuit guard
+    /// emission relies on the field being a present, non-null
+    /// StringEnum so the discriminant check can narrow the rest of
+    /// the shape.</summary>
+    public const string InvalidDiscriminator = "MS0011";
 }

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -225,6 +225,30 @@ public static class SymbolHelper
             );
 
     /// <summary>
+    /// Reads <c>[Discriminator("FieldName")]</c> from the
+    /// <c>Metano.Annotations.TypeScript</c> namespace. Returns the
+    /// discriminant field name (original C# casing) when the attribute
+    /// is present, or <c>null</c> otherwise. Namespace-qualified match
+    /// so unrelated <c>[Discriminator]</c> attributes from other
+    /// libraries cannot be mistaken for the Metano variant. Callers
+    /// outside the TypeScript target should treat a non-null result as
+    /// a no-op (Dart / Kotlin have no equivalent narrowing
+    /// convention).
+    /// </summary>
+    public static string? GetDiscriminatorFieldName(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Where(a =>
+                a.AttributeClass?.Name is "DiscriminatorAttribute" or "Discriminator"
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
+                    == "Metano.Annotations.TypeScript"
+            )
+            .Select(a =>
+                a.ConstructorArguments.Length > 0 ? a.ConstructorArguments[0].Value as string : null
+            )
+            .FirstOrDefault(s => s is not null);
+
+    /// <summary>
     /// Reads the file name from <c>[EmitInFile("name")]</c> on a type symbol, or null
     /// when the attribute isn't present (in which case the type takes its own name as
     /// the file).

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -219,7 +219,7 @@ public static class SymbolHelper
         symbol
             .GetAttributes()
             .Any(a =>
-                a.AttributeClass?.Name is "OptionalAttribute" or "Optional"
+                a.AttributeClass?.Name is ("OptionalAttribute" or "Optional")
                 && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
                     == "Metano.Annotations.TypeScript"
             );
@@ -239,7 +239,7 @@ public static class SymbolHelper
         symbol
             .GetAttributes()
             .Where(a =>
-                a.AttributeClass?.Name is "DiscriminatorAttribute" or "Discriminator"
+                a.AttributeClass?.Name is ("DiscriminatorAttribute" or "Discriminator")
                 && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
                     == "Metano.Annotations.TypeScript"
             )

--- a/src/Metano/Annotations/TypeScript/DiscriminatorAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/DiscriminatorAttribute.cs
@@ -1,0 +1,43 @@
+namespace Metano.Annotations.TypeScript;
+
+/// <summary>
+/// Marks one property on a <c>[GenerateGuard]</c> type as the
+/// discriminator field. The generated <c>isT</c> guard narrows on this
+/// field first — typically a <c>[StringEnum]</c> whose values
+/// uniquely identify the type variant — and short-circuits
+/// <c>false</c> when the discriminant doesn't match. The full shape
+/// check still runs when the discriminant matches so reserved fields
+/// keep being validated.
+/// <para>
+/// Example: a <c>Shape</c> hierarchy with <c>Kind = Circle | Square</c>
+/// tags the base with <c>[Discriminator("Kind")]</c>. The derived
+/// <c>Circle</c>'s generated guard then checks
+/// <c>v.kind === "Circle"</c> before walking radius/color fields —
+/// rejecting any object whose kind points at a different variant
+/// without traversing the rest of the shape.
+/// </para>
+/// <para>
+/// This attribute is TypeScript-specific — Dart and other targets have
+/// no equivalent narrowing convention and treat it as a no-op. It
+/// therefore lives in the <see cref="Metano.Annotations.TypeScript"/>
+/// namespace so a cross-target project opting into
+/// <c>using Metano.Annotations;</c> does not accidentally see TS-only
+/// knobs.
+/// </para>
+/// <para>
+/// The referenced field must exist on the annotated type, must carry
+/// <c>[StringEnum]</c>, and must not be nullable. Any other shape
+/// raises <c>MS0011</c> at extraction time.
+/// </para>
+/// </summary>
+/// <param name="fieldName">Name of the C# property (original casing)
+/// that acts as the discriminant. The guard emits against the
+/// camelCased TS field name automatically.</param>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface,
+    Inherited = false
+)]
+public sealed class DiscriminatorAttribute(string fieldName) : Attribute
+{
+    public string FieldName { get; } = fieldName;
+}

--- a/targets/js/sample-todo-service/src/events.ts
+++ b/targets/js/sample-todo-service/src/events.ts
@@ -1,0 +1,60 @@
+export const TodoEventKind = {
+  TodoCreated: "TodoCreated",
+  TodoUpdated: "TodoUpdated",
+  TodoDeleted: "TodoDeleted",
+} as const;
+
+export type TodoEventKind = typeof TodoEventKind[keyof typeof TodoEventKind];
+
+export interface TodoCreated {
+  readonly kind: TodoEventKind;
+  readonly id: string;
+  readonly title: string;
+}
+
+export function isTodoCreated(value: unknown): value is TodoCreated {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+
+  const v = value as any;
+
+  if (v.kind !== "TodoCreated") {
+    return false;
+  }
+
+  return typeof v.id === "string" && typeof v.title === "string";
+}
+
+export function assertTodoCreated(value: unknown, message?: string): asserts value is TodoCreated {
+  if (!isTodoCreated(value)) {
+    throw new TypeError(message ?? "Value is not a TodoCreated");
+  }
+}
+
+export interface TodoUpdated {
+  readonly kind: TodoEventKind;
+  readonly id: string;
+  readonly title: string | null;
+  readonly completed: boolean | null;
+}
+
+export function isTodoUpdated(value: unknown): value is TodoUpdated {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+
+  const v = value as any;
+
+  if (v.kind !== "TodoUpdated") {
+    return false;
+  }
+
+  return typeof v.id === "string" && v.title == null || typeof v.title === "string" && v.completed == null || typeof v.completed === "boolean";
+}
+
+export function assertTodoUpdated(value: unknown, message?: string): asserts value is TodoUpdated {
+  if (!isTodoUpdated(value)) {
+    throw new TypeError(message ?? "Value is not a TodoUpdated");
+  }
+}

--- a/targets/js/sample-todo-service/src/events.ts
+++ b/targets/js/sample-todo-service/src/events.ts
@@ -50,7 +50,7 @@ export function isTodoUpdated(value: unknown): value is TodoUpdated {
     return false;
   }
 
-  return typeof v.id === "string" && v.title == null || typeof v.title === "string" && v.completed == null || typeof v.completed === "boolean";
+  return typeof v.id === "string" && (v.title == null || typeof v.title === "string") && (v.completed == null || typeof v.completed === "boolean");
 }
 
 export function assertTodoUpdated(value: unknown, message?: string): asserts value is TodoUpdated {

--- a/targets/js/sample-todo-service/src/index.ts
+++ b/targets/js/sample-todo-service/src/index.ts
@@ -1,3 +1,5 @@
+export { assertTodoCreated, assertTodoUpdated, isTodoCreated, isTodoUpdated, TodoEventKind } from "./events";
+export type { TodoCreated, TodoUpdated } from "./events";
 export { JsonContext } from "./json-context";
 export { assertCreateTodoDto, isCreateTodoDto, TodoStore } from "./todos";
 export type { CreateTodoDto, StoredTodo, UpdateTodoDto } from "./todos";

--- a/targets/js/sample-todo-service/test/events.test.ts
+++ b/targets/js/sample-todo-service/test/events.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { assertTodoCreated, isTodoCreated, isTodoUpdated } from "#/events";
+
+// Demonstrates the [Discriminator("Kind")] narrowing: the generated
+// isT short-circuits on `v.kind !== "TypeName"` before walking the
+// rest of the shape. A mismatched payload for a different event variant
+// exits the guard immediately instead of scanning every field.
+
+describe("TodoCreated discriminator", () => {
+  test("isTodoCreated accepts a matching payload", () => {
+    const event: unknown = {
+      kind: "TodoCreated",
+      id: "abc-123",
+      title: "Buy milk",
+    };
+    expect(isTodoCreated(event)).toBe(true);
+  });
+
+  test("isTodoCreated rejects a TodoUpdated payload via discriminator", () => {
+    // Wire shape for TodoUpdated that would pass the shape check if the
+    // discriminator wasn't enforced — it has the same fields plus
+    // `completed`. The kind mismatch trips the short-circuit.
+    const event: unknown = {
+      kind: "TodoUpdated",
+      id: "abc-123",
+      title: "Buy milk",
+      completed: true,
+    };
+    expect(isTodoCreated(event)).toBe(false);
+  });
+
+  test("isTodoCreated rejects unknown discriminator values", () => {
+    const event: unknown = {
+      kind: "Bogus",
+      id: "abc-123",
+      title: "Buy milk",
+    };
+    expect(isTodoCreated(event)).toBe(false);
+  });
+
+  test("assertTodoCreated throws when the discriminator mismatches", () => {
+    const event: unknown = {
+      kind: "TodoUpdated",
+      id: "abc-123",
+      title: "Buy milk",
+      completed: true,
+    };
+    expect(() => assertTodoCreated(event)).toThrow(TypeError);
+    expect(() => assertTodoCreated(event)).toThrow("Value is not a TodoCreated");
+  });
+
+  test("isTodoUpdated accepts its own kind", () => {
+    // Second variant in the hierarchy uses the same enum but a
+    // different expected value — TodoUpdated's guard checks
+    // `v.kind !== "TodoUpdated"`.
+    const event: unknown = {
+      kind: "TodoUpdated",
+      id: "abc-123",
+      title: null,
+      completed: false,
+    };
+    expect(isTodoUpdated(event)).toBe(true);
+  });
+});

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -431,8 +431,19 @@ public class TypeGuardTranspileTests
         );
 
         var output = result["circle.ts"];
-        await Assert.That(output).Contains("if (v.kind !== \"Circle\")");
-        await Assert.That(output).Contains("return false");
+        // Assert the full if/return block (not just the condition and a
+        // bare `return false`) so a regression that drops the return
+        // statement but keeps any other `return false` elsewhere in the
+        // function (e.g., the null/object gate) can't silently pass.
+        await Assert
+            .That(output)
+            .Contains(
+                """
+                  if (v.kind !== "Circle") {
+                    return false;
+                  }
+                """
+            );
     }
 
     [Test]

--- a/tests/Metano.Tests/TypeGuardTranspileTests.cs
+++ b/tests/Metano.Tests/TypeGuardTranspileTests.cs
@@ -406,4 +406,161 @@ public class TypeGuardTranspileTests
         await Assert.That(output).DoesNotContain("isAppError");
         await Assert.That(output).DoesNotContain("assertAppError");
     }
+
+    // ─── [Discriminator] short-circuit guard ─────────────────
+
+    [Test]
+    public async Task Discriminator_ShortCircuitsOnNamedField()
+    {
+        // [Discriminator("Kind")] tags `Kind` as the narrowing field.
+        // Convention: expected value is the type's TS name
+        // (Circle ↔ "Circle"). Generated guard checks
+        // `v.kind !== "Circle"` before walking the remaining shape so
+        // a mismatched body exits without traversing every field.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, StringEnum]
+            public enum ShapeKind { Circle, Square }
+
+            [Transpile, GenerateGuard]
+            [Discriminator("Kind")]
+            public record Circle(ShapeKind Kind, double Radius);
+            """
+        );
+
+        var output = result["circle.ts"];
+        await Assert.That(output).Contains("if (v.kind !== \"Circle\")");
+        await Assert.That(output).Contains("return false");
+    }
+
+    [Test]
+    public async Task Discriminator_RemovesSelfFromFieldChecks()
+    {
+        // The discriminator narrows the field by literal comparison, so
+        // the generated guard must skip the redundant isKind(v.kind)
+        // call that GetAllFieldsForGuard would otherwise emit — avoids
+        // a double-check plus the extra import it would pull in.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, StringEnum]
+            public enum ShapeKind { Circle, Square }
+
+            [Transpile, GenerateGuard]
+            [Discriminator("Kind")]
+            public record Circle(ShapeKind Kind, double Radius);
+            """
+        );
+
+        var output = result["circle.ts"];
+        await Assert.That(output).DoesNotContain("isShapeKind(v.kind)");
+        // radius is still validated
+        await Assert.That(output).Contains("typeof v.radius === \"number\"");
+    }
+
+    [Test]
+    public async Task Discriminator_HonorsNameOverride()
+    {
+        // [Name(TypeScript, "Round")] renames the emitted type. The
+        // discriminator expected value tracks the TS name so consumer
+        // code keyed by the renamed variant continues to narrow — the
+        // check emits `v.kind !== "Round"`.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, StringEnum]
+            public enum ShapeKind { [Name("Round")] Round, Square }
+
+            [Transpile, GenerateGuard]
+            [Name(TargetLanguage.TypeScript, "Round")]
+            [Discriminator("Kind")]
+            public record Circle(ShapeKind Kind, double Radius);
+            """
+        );
+
+        var output = result["round.ts"];
+        await Assert.That(output).Contains("if (v.kind !== \"Round\")");
+    }
+
+    [Test]
+    public async Task Discriminator_MissingField_EmitsMs0011()
+    {
+        // [Discriminator("Kind")] must refer to an existing property.
+        // If the name is wrong (typo, removed field), the frontend
+        // validator raises MS0011 pointing at the offending type.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, GenerateGuard]
+            [Discriminator("DoesNotExist")]
+            public record Circle(double Radius);
+            """
+        );
+
+        var ms0011 = diagnostics.FirstOrDefault(d =>
+            d.Code == Metano.Compiler.Diagnostics.DiagnosticCodes.InvalidDiscriminator
+        );
+        await Assert.That(ms0011).IsNotNull();
+        await Assert.That(ms0011!.Message).Contains("DoesNotExist");
+        await Assert.That(ms0011.Message).Contains("Circle");
+    }
+
+    [Test]
+    public async Task Discriminator_NonStringEnumField_EmitsMs0011()
+    {
+        // [Discriminator] requires the referenced field to carry
+        // [StringEnum] so the narrowing compiles to a literal
+        // comparison. Numeric enums (or any non-string-valued type)
+        // raise MS0011.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile]
+            public enum ShapeKind { Circle, Square }
+
+            [Transpile, GenerateGuard]
+            [Discriminator("Kind")]
+            public record Circle(ShapeKind Kind, double Radius);
+            """
+        );
+
+        var ms0011 = diagnostics.FirstOrDefault(d =>
+            d.Code == Metano.Compiler.Diagnostics.DiagnosticCodes.InvalidDiscriminator
+        );
+        await Assert.That(ms0011).IsNotNull();
+        await Assert.That(ms0011!.Message).Contains("not a [StringEnum]");
+    }
+
+    [Test]
+    public async Task Discriminator_NullableField_EmitsMs0011()
+    {
+        // The discriminant must be present on every instance so the
+        // guard can narrow without a null check of its own. Nullable
+        // discriminators raise MS0011.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            #nullable enable
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, StringEnum]
+            public enum ShapeKind { Circle, Square }
+
+            [Transpile, GenerateGuard]
+            [Discriminator("Kind")]
+            public record Circle(ShapeKind? Kind, double Radius);
+            """
+        );
+
+        var ms0011 = diagnostics.FirstOrDefault(d =>
+            d.Code == Metano.Compiler.Diagnostics.DiagnosticCodes.InvalidDiscriminator
+        );
+        await Assert.That(ms0011).IsNotNull();
+        await Assert.That(ms0011!.Message).Contains("nullable");
+    }
 }


### PR DESCRIPTION
Adds a TS-specific `[Discriminator("FieldName")]` attribute in
Metano.Annotations.TypeScript. A class/struct/interface with
[GenerateGuard] and [Discriminator] emits an isT guard that
short-circuits on a literal comparison (`v.kind !== "TypeName"`)
before walking the rest of the shape — a mismatched payload exits
without scanning every field.

Convention: the expected discriminator value is the type's TS name
(after [Name(TypeScript, …)] resolution). A Circle class tagged
[Discriminator("Kind")] expects `v.kind === "Circle"`; renaming the
type via [Name(TypeScript, "Round")] flips the check to
`v.kind === "Round"`. No second attribute argument for the expected
value — keeps the surface minimal.

IR / emission changes:
- SymbolHelper.GetDiscriminatorFieldName reads the attribute,
  namespace-qualified so unrelated `[Discriminator]` attrs from other
  libraries are not mistaken for the Metano variant.
- TypeGuardBuilder.GenerateShapeGuard emits the short-circuit if-block
  after the null/object gate and filters the discriminator out of the
  remaining field loop (avoids a redundant isKind(v.kind) call plus
  the import it would drag in).

Frontend validation:
- CSharpSourceFrontend.ValidateDiscriminatorAttribute emits
  MS0011 (InvalidDiscriminator) when the referenced field is missing
  on the type, nullable, or not a [StringEnum]. Runs on every target
  because the attribute is misuse regardless of backend.

Diagnostics catalog:
- New DiagnosticCodes.InvalidDiscriminator = "MS0011".
- Spec catalog updated (10-diagnostic-catalog.md) with range now
  MS0001–MS0011 and entries for MS0009 / MS0010 / MS0011 that were
  missing from earlier updates.

Sample:
- samples/SampleTodo.Service/Events.cs declares TodoEventKind
  (StringEnum) plus TodoCreated / TodoUpdated records annotated with
  [Discriminator("Kind")]. Generated events.ts shows the short-circuit
  emission for both variants.
- targets/js/sample-todo-service/test/events.test.ts — 5 bun tests
  demonstrating discriminator narrowing, mismatch rejection, assertT
  throw on mismatch, and dual-variant discrimination via the same
  shared enum.

Docs:
- ADR-0009 addendum documents the convention, validator behavior,
  field-loop skip, and the deferred sealed-hierarchy path.
- spec/09-attribute-catalog.md gains a row for DiscriminatorAttribute.

628/628 TUnit green (was 622 — +6 new tests). 33/33 bun
sample-todo-service tests (was 28 — +5 new discriminator tests).

Part of #24

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>