### PR TITLE
feat(ts): --namespace-barrels opt-in root barrel (#22)

### DIFF
--- a/docs/adr/0006-namespace-first-barrel-imports.md
+++ b/docs/adr/0006-namespace-first-barrel-imports.md
@@ -79,9 +79,9 @@ barrel via `export * from "./issues/domain"; export * from "./planning/domain"; 
 — defeats tree-shaking as described above. An alternative shape using
 `export namespace` blocks to mirror the C# hierarchy preserves
 tree-shaking in principle but changes every consumer's import surface.
-Neither is acceptable as the default, so the feature is tracked as an
-**opt-in flag** (`--namespace-barrels`) in
-[issue #22](https://github.com/danfma/metano/issues/22).
+Neither is acceptable as the default, so the feature ships as an
+**opt-in flag** (`--namespace-barrels`, MSBuild property
+`MetanoNamespaceBarrels`) — see the addendum below.
 
 `CyclicReferenceDetector` normalizes `#`, `#/...`, and `./...` in its
 graph, so cycles across any of the three forms surface as MS0005
@@ -140,3 +140,67 @@ diagnostics before tsgo chokes on them.
   `specs/same-namespace-relative-imports-plan.md`) were removed as part
   of the documentation reorganization (issue #14). `git log --follow`
   preserves them if the full plan text is ever needed.
+
+## Addendum (2026-04-23) — `--namespace-barrels` opt-in
+
+Ships the root-barrel follow-up tracked in issue #22. Packages that
+opt in via `--namespace-barrels` (CLI) or `<MetanoNamespaceBarrels>true</MetanoNamespaceBarrels>`
+(MSBuild, routed through `Metano.Build.targets`) receive an
+additional `src/index.ts` that aggregates every leaf barrel under
+nested `export namespace` blocks mirroring the C# namespace hierarchy:
+
+```ts
+import * as $Issues_Application from "./issues/application";
+import * as $Issues_Domain from "./issues/domain";
+import * as $Planning_Domain from "./planning/domain";
+import * as $SharedKernel from "./shared-kernel";
+
+export namespace Issues {
+  export import Application = $Issues_Application;
+  export import Domain = $Issues_Domain;
+}
+export namespace Planning {
+  export import Domain = $Planning_Domain;
+}
+export import SharedKernel = $SharedKernel;
+```
+
+Consumers can then write `import { Issues, Planning, SharedKernel } from "@scope/pkg"`
+and walk into nested namespaces. Leaf barrels continue to emit so the
+existing `import { Issue } from "@scope/pkg/issues/domain"` path keeps
+working — the root barrel is strictly additive.
+
+Tree-shaking stays intact. Each subpath binds to a single
+`import * as` identifier; bundlers that can't follow an
+`export * from "./**"` chain handle namespace imports + named
+re-exports just fine. Verified on Bun + tsgo; the approach matches
+the pattern shipped by `@effect/platform` and other TS-heavy
+libraries.
+
+When the project already has types at the bare root (a non-empty
+root `index.ts` leaf), the namespace-aggregation statements are
+**appended** to that existing barrel so bare-root exports and the
+namespace-aggregation block coexist in a single file.
+
+The import alias follows the convention `$<SegmentA>_<SegmentB>_…`
+(PascalCased path segments joined with `_`, prefixed with `$`).
+The `$` prefix keeps the local binding distinct from any namespace
+name surfaced in the `export import` statement — single-segment
+leaves (`shared-kernel` → `$SharedKernel`) would otherwise collide
+with the re-exported identifier and trip a TDZ
+`Cannot access 'X' before initialization` at runtime.
+
+The flag is **not** flipped on by default. Two concerns stay open:
+
+- Tree-shaking claim needs verification across the wider toolchain
+  matrix (webpack, rspack, Parcel) before we'd switch the default.
+  Bun, tsgo, esbuild, Vite all drop unused branches correctly in
+  spot checks.
+- Surface cost: flipping the default changes every downstream
+  consumer's import surface. A major-version bump with migration
+  notes is the right vehicle, not a minor-version toggle.
+
+`SampleIssueTracker` opts into the flag via
+`MetanoNamespaceBarrels` in its `.csproj` so the generated
+`targets/js/sample-issue-tracker/src/index.ts` exercises the shape
+end-to-end (see `test/namespace-barrels.test.ts`).

--- a/samples/SampleIssueTracker/SampleIssueTracker.csproj
+++ b/samples/SampleIssueTracker/SampleIssueTracker.csproj
@@ -4,6 +4,13 @@
     <IsPackable>false</IsPackable>
     <MetanoOutputDir>../../targets/js/sample-issue-tracker/src</MetanoOutputDir>
     <MetanoClean>true</MetanoClean>
+    <!--
+      Opt into the root namespace barrel (ADR-0006 follow-up, issue #22)
+      so consumers can import `{ Issues, Planning, SharedKernel }` from
+      the package root in addition to the existing leaf barrels. The
+      aggregation shape stays tree-shakable under current bundlers.
+    -->
+    <MetanoNamespaceBarrels>true</MetanoNamespaceBarrels>
     <MetanoCompilerProject>../../src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj</MetanoCompilerProject>
   </PropertyGroup>
 

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -45,6 +45,9 @@
       <_MetanoArgs Condition="'$(MetanoSkipPackageJson)' == 'true'"
         >$(_MetanoArgs) --skip-package-json</_MetanoArgs
       >
+      <_MetanoArgs Condition="'$(MetanoNamespaceBarrels)' == 'true'"
+        >$(_MetanoArgs) --namespace-barrels</_MetanoArgs
+      >
       <_MetanoArgs Condition="'$(MetanoExtraArgs)' != ''"
         >$(_MetanoArgs) $(MetanoExtraArgs)</_MetanoArgs
       >

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -16,6 +16,7 @@ public class Commands
     /// <param name="dist">Path (relative to packageRoot) where the JS build output lives (default: ./dist)</param>
     /// <param name="srcRoot">TypeScript source root relative to packageRoot (default: inferred from first segment of output path). Used to compute the dist prefix when output targets a subdirectory (e.g., src/domain/).</param>
     /// <param name="skipPackageJson">Skip generating/updating package.json</param>
+    /// <param name="namespaceBarrels">Emit an additional src/index.ts root barrel mirroring the C# namespace hierarchy via `export namespace` blocks (opt-in; see ADR-0006).</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -25,10 +26,11 @@ public class Commands
         string? packageRoot = null,
         string dist = "./dist",
         string? srcRoot = null,
-        bool skipPackageJson = false
+        bool skipPackageJson = false,
+        bool namespaceBarrels = false
     )
     {
-        var target = new TypeScriptTarget();
+        var target = new TypeScriptTarget { NamespaceBarrels = namespaceBarrels };
 
         var options = new TranspileOptions(
             ProjectPath: project,

--- a/src/Metano.Compiler.TypeScript/Transformation/BarrelFileGenerator.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/BarrelFileGenerator.cs
@@ -16,7 +16,68 @@ namespace Metano.Transformation;
 /// </summary>
 public static class BarrelFileGenerator
 {
-    public static IReadOnlyList<TsSourceFile> Generate(IReadOnlyList<TsSourceFile> typeFiles)
+    /// <summary>
+    /// Generates the barrel files. When <paramref name="namespaceBarrels"/> is
+    /// <c>true</c>, additionally aggregates every leaf barrel into a
+    /// root <c>src/index.ts</c> via nested <c>export namespace</c>
+    /// blocks that mirror the C# namespace hierarchy. Consumers can
+    /// then import from the package root (<c>import { Issues } from "@scope/pkg"</c>)
+    /// and walk into nested namespaces. Tree-shaking stays intact
+    /// because the root barrel binds each subpath to a single
+    /// namespace import — no <c>export *</c> aggregation.
+    /// <para>
+    /// When the project already has types at the bare root namespace,
+    /// the namespace-aggregation statements are appended to the
+    /// existing root leaf so both the bare-root re-exports and the
+    /// nested namespace bindings coexist in a single
+    /// <c>index.ts</c>.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<TsSourceFile> Generate(
+        IReadOnlyList<TsSourceFile> typeFiles,
+        bool namespaceBarrels = false
+    )
+    {
+        var leafBarrels = GenerateLeafBarrels(typeFiles);
+        if (!namespaceBarrels)
+            return leafBarrels;
+
+        var aggregationStatements = BuildNamespaceAggregationStatements(leafBarrels);
+        if (aggregationStatements.Count == 0)
+            return leafBarrels;
+
+        // Merge with an existing root leaf when present so bare-root
+        // re-exports and the namespace-aggregation block share a
+        // single index.ts.
+        var merged = new List<TsSourceFile>(leafBarrels.Count + 1);
+        var foundRoot = false;
+        foreach (var barrel in leafBarrels)
+        {
+            if (
+                !foundRoot && barrel.FileName.Equals("index.ts", StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                foundRoot = true;
+                var combined = new List<TsTopLevel>(
+                    barrel.Statements.Count + aggregationStatements.Count
+                );
+                combined.AddRange(barrel.Statements);
+                combined.AddRange(aggregationStatements);
+                merged.Add(barrel with { Statements = combined });
+            }
+            else
+            {
+                merged.Add(barrel);
+            }
+        }
+        if (!foundRoot)
+            merged.Add(new TsSourceFile("index.ts", aggregationStatements));
+        return merged;
+    }
+
+    private static IReadOnlyList<TsSourceFile> GenerateLeafBarrels(
+        IReadOnlyList<TsSourceFile> typeFiles
+    )
     {
         // Group files by their directory
         var dirToFiles = new Dictionary<string, List<TsSourceFile>>();
@@ -119,4 +180,144 @@ public static class BarrelFileGenerator
     /// and namespaces are values.
     /// </summary>
     private static bool IsTypeOnlyExport(TsTopLevel node) => node is TsTypeAlias or TsInterface;
+
+    /// <summary>
+    /// Builds the namespace-aggregation statements (imports +
+    /// <c>export namespace</c> blocks) that walk the leaf-barrel
+    /// directory tree. Returns an empty list when there are no
+    /// subdirectories to aggregate — bare-root-only projects stay
+    /// leaf-only.
+    /// </summary>
+    private static IReadOnlyList<TsTopLevel> BuildNamespaceAggregationStatements(
+        IReadOnlyList<TsSourceFile> leafBarrels
+    )
+    {
+        // Collect the directory of every non-root leaf barrel — those
+        // are the subpaths the root should aggregate.
+        var leafDirs = leafBarrels
+            .Select(b => Path.GetDirectoryName(b.FileName)?.Replace('\\', '/') ?? "")
+            .Where(d => d.Length > 0)
+            .Distinct()
+            .OrderBy(d => d, StringComparer.Ordinal)
+            .ToList();
+
+        if (leafDirs.Count == 0)
+            return [];
+
+        // Each leaf dir gets a single namespace import. Alias joins
+        // PascalCased path segments with "_" and prefixes a `$` so the
+        // binding can never collide with an exported namespace name —
+        // a single-segment leaf (`shared-kernel`) would otherwise
+        // produce `SharedKernel` both as the import alias AND as the
+        // re-exported identifier, causing a TDZ
+        // `Cannot access 'SharedKernel' before initialization`.
+        var dirAliases = leafDirs.ToDictionary(
+            d => d,
+            d => "$" + string.Join("_", d.Split('/').Select(PathSegmentToPascal))
+        );
+
+        var statements = new List<TsTopLevel>();
+
+        // Emit the imports first so the nested namespace block can
+        // reference each alias by name.
+        foreach (var dir in leafDirs)
+        {
+            statements.Add(
+                new TsImport(Names: [dirAliases[dir]], From: $"./{dir}", IsNamespace: true)
+            );
+        }
+
+        // Build a prefix tree of the path segments so the root emits
+        // one `export namespace` per top-level segment with nested
+        // re-exports inside.
+        var root = new NamespaceNode();
+        foreach (var dir in leafDirs)
+        {
+            var segments = dir.Split('/');
+            var cursor = root;
+            for (var i = 0; i < segments.Length; i++)
+            {
+                var pascal = PathSegmentToPascal(segments[i]);
+                if (!cursor.Children.TryGetValue(pascal, out var next))
+                {
+                    next = new NamespaceNode();
+                    cursor.Children[pascal] = next;
+                }
+                cursor = next;
+            }
+            cursor.LeafAlias = dirAliases[dir];
+        }
+
+        foreach (var (name, child) in root.Children.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            statements.Add(BuildNamespaceBlock(name, child));
+
+        return statements;
+    }
+
+    private static TsTopLevel BuildNamespaceBlock(string name, NamespaceNode node)
+    {
+        var members = new List<TsTopLevel>();
+
+        // A leaf of depth-1 (e.g., `SharedKernel` with no children)
+        // collapses to a top-level `export import Alias = Alias;`
+        // instead of an empty `namespace { }`. Still exposes the
+        // binding under the package root.
+        if (node.LeafAlias is not null && node.Children.Count == 0)
+            return new TsExportImportAlias(name, node.LeafAlias);
+
+        if (node.LeafAlias is not null)
+        {
+            // Rare shape: the same path is both a leaf (holds its own
+            // barrel) and a parent of further children. Expose the leaf
+            // binding under a reserved `_` identifier so callers can
+            // still reach it while the children continue as nested
+            // namespaces. The reserved sentinel keeps the ambiguity
+            // explicit instead of silently dropping one side.
+            members.Add(new TsExportImportAlias("_", node.LeafAlias));
+        }
+
+        foreach (
+            var (childName, childNode) in node.Children.OrderBy(
+                kv => kv.Key,
+                StringComparer.Ordinal
+            )
+        )
+            members.Add(BuildNamespaceBlock(childName, childNode));
+
+        return new TsNamespaceDeclaration(
+            Name: name,
+            Functions: [],
+            Exported: true,
+            Members: members
+        );
+    }
+
+    /// <summary>
+    /// Converts a kebab-case (or already-PascalCased) directory segment
+    /// into a PascalCase TS identifier — e.g. <c>shared-kernel</c> →
+    /// <c>SharedKernel</c>. Mirrors the segment casing consumers would
+    /// see walking the namespace tree on the C# side.
+    /// </summary>
+    private static string PathSegmentToPascal(string segment)
+    {
+        if (segment.Length == 0)
+            return segment;
+        var parts = segment.Split('-');
+        var result = new System.Text.StringBuilder(segment.Length);
+        foreach (var part in parts)
+        {
+            if (part.Length == 0)
+                continue;
+            result.Append(char.ToUpperInvariant(part[0]));
+            if (part.Length > 1)
+                result.Append(part, 1, part.Length - 1);
+        }
+        return result.ToString();
+    }
+
+    private sealed class NamespaceNode
+    {
+        public Dictionary<string, NamespaceNode> Children { get; } = new(StringComparer.Ordinal);
+        public string? LeafAlias { get; set; }
+    }
 }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -33,6 +33,14 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     public bool UseIrBodiesWhenCovered { get; init; } = true;
 
     /// <summary>
+    /// Forwarded to <see cref="BarrelFileGenerator.Generate"/>. When
+    /// <c>true</c>, the generator emits <c>src/index.ts</c> mirroring
+    /// the C# namespace hierarchy via <c>export namespace</c> blocks
+    /// (opt-in; see ADR-0006 + issue #22).
+    /// </summary>
+    public bool NamespaceBarrels { get; init; }
+
+    /// <summary>
     /// Diagnostics collected during transformation. Includes warnings about unsupported
     /// language features and other issues that the user should know about.
     /// </summary>
@@ -178,7 +186,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         }
 
         // Generate index.ts barrel files per namespace folder
-        var indexFiles = BarrelFileGenerator.Generate(files);
+        var indexFiles = BarrelFileGenerator.Generate(files, NamespaceBarrels);
         files.AddRange(indexFiles);
 
         // Detect cyclic #/ imports between the generated files and emit MS0005

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsExportImportAlias.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsExportImportAlias.cs
@@ -1,0 +1,10 @@
+namespace Metano.TypeScript.AST;
+
+/// <summary>
+/// A TypeScript <c>export import Alias = Target;</c> statement. Used
+/// inside a namespace block to re-export an imported identifier under
+/// a nested path — <c>--namespace-barrels</c> emits these to mirror
+/// the C# namespace hierarchy in the root barrel. Only valid inside a
+/// <see cref="TsNamespaceDeclaration"/>.
+/// </summary>
+public sealed record TsExportImportAlias(string Alias, string Target) : TsTopLevel;

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsExportImportAlias.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsExportImportAlias.cs
@@ -1,10 +1,13 @@
 namespace Metano.TypeScript.AST;
 
 /// <summary>
-/// A TypeScript <c>export import Alias = Target;</c> statement. Used
-/// inside a namespace block to re-export an imported identifier under
-/// a nested path — <c>--namespace-barrels</c> emits these to mirror
-/// the C# namespace hierarchy in the root barrel. Only valid inside a
-/// <see cref="TsNamespaceDeclaration"/>.
+/// A TypeScript <c>export import Alias = Target;</c> statement used
+/// to re-export an imported identifier under another name or nested
+/// path — <c>--namespace-barrels</c> emits these to mirror the C#
+/// namespace hierarchy in the root barrel. The statement may appear
+/// at file scope OR as a member of a
+/// <see cref="TsNamespaceDeclaration"/>. Single-segment leaves
+/// (e.g., <c>shared-kernel</c>) emit at file scope;
+/// multi-segment paths nest inside <c>export namespace</c> blocks.
 /// </summary>
 public sealed record TsExportImportAlias(string Alias, string Target) : TsTopLevel;

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsImport.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsImport.cs
@@ -23,5 +23,6 @@ public sealed record TsImport(
     string From,
     bool TypeOnly = false,
     bool IsDefault = false,
-    IReadOnlySet<string>? TypeOnlyNames = null
+    IReadOnlySet<string>? TypeOnlyNames = null,
+    bool IsNamespace = false
 ) : TsTopLevel;

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsImport.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsImport.cs
@@ -3,10 +3,19 @@ namespace Metano.TypeScript.AST;
 /// <summary>
 /// A TypeScript import statement.
 /// <list type="bullet">
-///   <item><see cref="IsDefault"/> = false → <c>import { A, B } from "from";</c>
-///   (named imports). <see cref="Names"/> can list one or many.</item>
+///   <item><see cref="IsDefault"/> = false and <see cref="IsNamespace"/> = false →
+///   <c>import { A, B } from "from";</c> (named imports).
+///   <see cref="Names"/> can list one or many.</item>
 ///   <item><see cref="IsDefault"/> = true → <c>import A from "from";</c> (default
 ///   import). <see cref="Names"/> must contain exactly one entry.</item>
+///   <item><see cref="IsNamespace"/> = true → <c>import * as Alias from "from";</c>
+///   (namespace import). <see cref="Names"/> must contain exactly one entry
+///   (the alias); <see cref="IsDefault"/> and <see cref="TypeOnlyNames"/> must
+///   stay at their defaults — they don't combine with <c>import * as</c>.
+///   <see cref="TypeOnly"/> may combine (<c>import type * as A from "from";</c>).
+///   Emitted by <c>--namespace-barrels</c> to bind each subpath under a local
+///   alias so the aggregation block can re-export it via
+///   <see cref="TsExportImportAlias"/>.</item>
 /// </list>
 /// Combine with <see cref="TypeOnly"/> for <c>import type</c> form. The two flags can
 /// also combine: <c>import type A from "from";</c>.
@@ -16,7 +25,8 @@ namespace Metano.TypeScript.AST;
 /// is false but some names are types and others are values, producing
 /// <c>import { Foo, type Bar } from "from";</c>. When <see cref="TypeOnly"/> is true
 /// the per-name set is irrelevant (the whole statement is type-only). The set
-/// must be a subset of <see cref="Names"/>.</para>
+/// must be a subset of <see cref="Names"/>. Only meaningful when
+/// <see cref="IsDefault"/> and <see cref="IsNamespace"/> are both false.</para>
 /// </summary>
 public sealed record TsImport(
     string[] Names,

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -236,6 +236,13 @@ public sealed class Printer(string indent = "  ")
                 _sb.Write(n.IsDefault ? $"export default {n.Name};" : $"export {{ {n.Name} }};");
                 _sb.WriteLn();
                 break;
+            case TsExportImportAlias n:
+                // `export import Alias = Target;` — namespace aliasing
+                // under --namespace-barrels. Valid only inside a
+                // `namespace { … }` block; the root barrel generator
+                // never emits this at file scope.
+                _sb.Write($"export import {n.Alias} = {n.Target};");
+                break;
         }
     }
 
@@ -244,7 +251,17 @@ public sealed class Printer(string indent = "  ")
         _sb.Write("import ");
         if (import.TypeOnly)
             _sb.Write("type ");
-        if (import.IsDefault)
+        if (import.IsNamespace)
+        {
+            // `import * as Foo from "...";` — namespace import, single
+            // alias in Names[0]. Used by the root barrel generated under
+            // --namespace-barrels to bind a subpath's exports under a
+            // local identifier so the outer namespace block can re-export
+            // it via TsExportImportAlias.
+            _sb.Write("* as ");
+            _sb.Write(import.Names[0]);
+        }
+        else if (import.IsDefault)
         {
             // `import Foo from "...";` — single name, no braces.
             _sb.Write(import.Names[0]);

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -237,10 +237,14 @@ public sealed class Printer(string indent = "  ")
                 _sb.WriteLn();
                 break;
             case TsExportImportAlias n:
-                // `export import Alias = Target;` — namespace aliasing
-                // under --namespace-barrels. Valid only inside a
-                // `namespace { … }` block; the root barrel generator
-                // never emits this at file scope.
+                // `export import Alias = Target;` — namespace-style
+                // aliasing emitted by --namespace-barrels. Printed
+                // wherever a TsExportImportAlias appears in the AST,
+                // including file scope as well as inside a
+                // `namespace { … }` block. Single-segment leaves
+                // (`shared-kernel` → `$SharedKernel`) land at file
+                // scope; multi-segment paths nest inside `export
+                // namespace` blocks.
                 _sb.Write($"export import {n.Alias} = {n.Target};");
                 break;
         }

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -53,6 +53,16 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     public bool LastIsExecutable { get; private set; }
 
+    /// <summary>
+    /// When <c>true</c>, <see cref="BarrelFileGenerator"/> emits an
+    /// additional <c>src/index.ts</c> root barrel that aggregates every
+    /// leaf barrel under nested <c>export namespace</c> blocks mirroring
+    /// the C# namespace hierarchy. Opt-in via <c>--namespace-barrels</c>;
+    /// the default stays leaf-only so tree-shaking under current
+    /// bundlers continues to work without surprises (see ADR-0006).
+    /// </summary>
+    public bool NamespaceBarrels { get; init; }
+
     public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
     {
         if (compilation is null)
@@ -62,7 +72,10 @@ public sealed class TypeScriptTarget : ITranspilerTarget
                     + "TypeScript transformer reads everything it needs from IrCompilation."
             );
 
-        var transformer = new TypeTransformer(ir, compilation);
+        var transformer = new TypeTransformer(ir, compilation)
+        {
+            NamespaceBarrels = NamespaceBarrels,
+        };
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
         // Prefer the frontend-populated package name; the underlying Roslyn read

--- a/targets/js/sample-issue-tracker/src/index.ts
+++ b/targets/js/sample-issue-tracker/src/index.ts
@@ -1,1 +1,17 @@
 export { JsonContext } from "./json-context";
+import * as $Issues_Application from "./issues/application";
+import * as $Issues_Domain from "./issues/domain";
+import * as $Planning_Domain from "./planning/domain";
+import * as $SharedKernel from "./shared-kernel";
+
+export namespace Issues {
+  export import Application = $Issues_Application;
+
+  export import Domain = $Issues_Domain;
+}
+
+export namespace Planning {
+  export import Domain = $Planning_Domain;
+}
+
+export import SharedKernel = $SharedKernel;

--- a/targets/js/sample-issue-tracker/test/namespace-barrels.test.ts
+++ b/targets/js/sample-issue-tracker/test/namespace-barrels.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+// SampleIssueTracker opts into the `--namespace-barrels` root barrel
+// (see its .csproj `MetanoNamespaceBarrels` property). The emitted
+// `src/index.ts` aggregates every leaf barrel under nested
+// `export namespace` blocks mirroring the C# namespace hierarchy.
+// This test exercises root-level imports so a regression that drops
+// the namespace-aggregation emission surfaces as a type error at
+// build time and a runtime failure here.
+
+// Uses the `#` self-alias (`./src/index.ts`) instead of the external
+// package specifier — Bun workspace self-referencing is fragile for
+// tests and the `#` alias resolves to the same barrel either way.
+import { Issues, Planning, SharedKernel } from "#";
+
+describe("namespace-barrels root access", () => {
+  test("Issues namespace exposes Application + Domain branches", () => {
+    expect(typeof Issues.Application).toBe("object");
+    expect(typeof Issues.Domain).toBe("object");
+  });
+
+  test("Planning namespace exposes Domain branch", () => {
+    expect(typeof Planning.Domain).toBe("object");
+  });
+
+  test("SharedKernel is bound at the package root", () => {
+    // Single-segment leaves collapse to a bare `export import` at the
+    // root — consumers get the namespace object directly without a
+    // wrapping block.
+    expect(typeof SharedKernel).toBe("object");
+  });
+
+  test("nested enum is reachable through the namespace tree", () => {
+    // Issues.Domain.IssuePriority is a [StringEnum] — values survive
+    // the re-export chain. Literal values carry the lowercase override
+    // from the C# side.
+    const priority = Issues.Domain.IssuePriority.High;
+    expect(priority).toBe("high");
+  });
+});

--- a/tests/Metano.Tests/NamespaceBarrelsTranspileTests.cs
+++ b/tests/Metano.Tests/NamespaceBarrelsTranspileTests.cs
@@ -1,0 +1,171 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Covers the <c>--namespace-barrels</c> opt-in. Shipping types across
+/// sub-namespaces produces one leaf <c>index.ts</c> per directory by
+/// default; with the flag set, <see cref="Metano.Transformation.BarrelFileGenerator"/>
+/// additionally emits a root <c>src/index.ts</c> aggregating the leaves
+/// under nested <c>export namespace</c> blocks. Tree-shaking stays
+/// intact because each subpath is bound to a single namespace import —
+/// no <c>export *</c> aggregation at the root (see ADR-0006).
+/// </summary>
+public class NamespaceBarrelsTranspileTests
+{
+    [Test]
+    public async Task NamespaceBarrels_EmitsRootIndex_WhenSubNamespacesExist()
+    {
+        // Two sibling sub-namespaces (`Issues.Domain`, `Planning.Domain`)
+        // with no bare-root types exercises the root-barrel emission.
+        // Without the flag there's no `index.ts`; with the flag the
+        // root aggregates both leaves under nested `export namespace`
+        // blocks so `import { Issues, Planning } from "@pkg"` resolves.
+        var result = TranspileHelper.TranspileWithNamespaceBarrels(
+            """
+            namespace App.Issues.Domain
+            {
+                [Transpile]
+                public record Issue(string Id);
+            }
+
+            namespace App.Planning.Domain
+            {
+                [Transpile]
+                public record Sprint(string Key);
+            }
+            """
+        );
+
+        await Assert.That(result).ContainsKey("index.ts");
+        var root = result["index.ts"];
+
+        // Each leaf directory gets a namespace import aliased as the
+        // underscore-joined PascalCased path.
+        await Assert.That(root).Contains("import * as $Issues_Domain from \"./issues/domain\"");
+        await Assert.That(root).Contains("import * as $Planning_Domain from \"./planning/domain\"");
+
+        // Nested namespace blocks mirror the C# tree.
+        await Assert.That(root).Contains("export namespace Issues");
+        await Assert.That(root).Contains("export namespace Planning");
+        await Assert.That(root).Contains("export import Domain = $Issues_Domain");
+        await Assert.That(root).Contains("export import Domain = $Planning_Domain");
+    }
+
+    [Test]
+    public async Task NamespaceBarrels_FlattensTopLevelLeaf_WhenSingleSegment()
+    {
+        // A top-level single-segment leaf (like `SharedKernel`) doesn't
+        // need an enclosing namespace block — it collapses to a bare
+        // `export import SharedKernel = SharedKernel;` at the root so
+        // the binding surfaces under the package root directly. Pairs
+        // with a sibling `Issues` namespace to force the root to sit
+        // at `App` instead of collapsing onto `App.SharedKernel`.
+        var result = TranspileHelper.TranspileWithNamespaceBarrels(
+            """
+            namespace App.SharedKernel
+            {
+                [Transpile]
+                public record OperationResult(bool Success);
+            }
+
+            namespace App.Issues.Domain
+            {
+                [Transpile]
+                public record Issue(string Id);
+            }
+            """
+        );
+
+        await Assert.That(result).ContainsKey("index.ts");
+        var root = result["index.ts"];
+
+        await Assert.That(root).Contains("import * as $SharedKernel from \"./shared-kernel\"");
+        await Assert.That(root).Contains("export import SharedKernel = $SharedKernel;");
+        await Assert.That(root).DoesNotContain("export namespace SharedKernel");
+    }
+
+    [Test]
+    public async Task NamespaceBarrels_MergesWithBareRootLeaf()
+    {
+        // Project with both a bare-root type and sub-namespaces: the
+        // existing root leaf barrel (re-exporting the bare-root type)
+        // gets the namespace-aggregation block appended, so both
+        // `import { Root } from "@pkg"` and
+        // `import { Issues } from "@pkg"` resolve from a single
+        // index.ts.
+        var result = TranspileHelper.TranspileWithNamespaceBarrels(
+            """
+            namespace App
+            {
+                [Transpile]
+                public record Root(string Id);
+            }
+
+            namespace App.Issues.Domain
+            {
+                [Transpile]
+                public record Issue(string Id);
+            }
+            """
+        );
+
+        await Assert.That(result).ContainsKey("index.ts");
+        var root = result["index.ts"];
+        // Bare-root leaf re-export stays.
+        await Assert.That(root).Contains("export { Root } from \"./root\"");
+        // Plus the namespace-aggregation block for the sub-namespace.
+        await Assert.That(root).Contains("import * as $Issues_Domain from \"./issues/domain\"");
+        await Assert.That(root).Contains("export namespace Issues");
+    }
+
+    [Test]
+    public async Task NamespaceBarrels_OffByDefault_ProducesNoRootIndex()
+    {
+        // Baseline: without the flag, sub-namespace-only projects get no
+        // root index — matches the pre-existing leaf-only default from
+        // ADR-0006. Two sibling namespaces under `App` force the root
+        // to sit at `App` without any types at the bare root.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App.Issues.Domain
+            {
+                [Transpile]
+                public record Issue(string Id);
+            }
+
+            namespace App.Planning.Domain
+            {
+                [Transpile]
+                public record Sprint(string Key);
+            }
+            """
+        );
+
+        await Assert.That(result).DoesNotContainKey("index.ts");
+    }
+
+    [Test]
+    public async Task NamespaceBarrels_PreservesLeafBarrels()
+    {
+        // The root aggregation is additive — leaf barrels still emit
+        // under their own directories so consumers that import from
+        // `@pkg/issues/domain` continue to work.
+        var result = TranspileHelper.TranspileWithNamespaceBarrels(
+            """
+            namespace App.Issues.Domain
+            {
+                [Transpile]
+                public record Issue(string Id);
+            }
+
+            namespace App.Planning.Domain
+            {
+                [Transpile]
+                public record Sprint(string Key);
+            }
+            """
+        );
+
+        await Assert.That(result).ContainsKey("issues/domain/index.ts");
+        await Assert.That(result).ContainsKey("index.ts");
+    }
+}

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -128,12 +128,17 @@ public static class TranspileHelper
     private static (
         Dictionary<string, string> Files,
         IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic> Diagnostics
-    ) TranspileCore(CSharpCompilation compilation, bool useIrBodies = true)
+    ) TranspileCore(
+        CSharpCompilation compilation,
+        bool useIrBodies = true,
+        bool namespaceBarrels = false
+    )
     {
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
         var transformer = new TypeTransformer(ir, compilation)
         {
             UseIrBodiesWhenCovered = useIrBodies,
+            NamespaceBarrels = namespaceBarrels,
         };
         var files = transformer.TransformAll();
         var printer = new Printer();
@@ -170,6 +175,22 @@ public static class TranspileHelper
     /// </summary>
     public static Dictionary<string, string> TranspileConsoleApp(string csharpSource) =>
         Transpile(csharpSource, OutputKind.ConsoleApplication);
+
+    /// <summary>
+    /// Variant of <see cref="Transpile"/> that enables the
+    /// <c>--namespace-barrels</c> opt-in — exercises the root
+    /// <c>src/index.ts</c> emission path with nested
+    /// <c>export namespace</c> blocks.
+    /// </summary>
+    public static Dictionary<string, string> TranspileWithNamespaceBarrels(string csharpSource)
+    {
+        var compilation = CompileAssembly(
+            csharpSource,
+            "TestAssembly",
+            OutputKind.DynamicallyLinkedLibrary
+        );
+        return TranspileCore(compilation, namespaceBarrels: true).Files;
+    }
 
     /// <summary>
     /// Like <see cref="Transpile"/> but enables the Phase 5.10b IR-driven body pipeline.


### PR DESCRIPTION
## Summary

- Adds \`--namespace-barrels\` CLI flag + \`MetanoNamespaceBarrels\` MSBuild property. Emits \`src/index.ts\` aggregating every leaf barrel under nested \`export namespace\` blocks mirroring the C# namespace hierarchy.
- Tree-shaking preserved — each subpath binds to a single namespace import (no \`export *\` aggregation). Verified on Bun + tsgo.
- Additive — leaf barrels still emit, existing \`@scope/pkg/issues/domain\` subpath imports keep working.
- Bare-root types coexist: aggregation statements append to the existing root leaf when present.

## Test plan

- [x] 633/633 TUnit green (5 new tests in \`NamespaceBarrelsTranspileTests\`)
- [x] \`dotnet csharpier check .\` passes
- [x] \`sample-issue-tracker\` opts into the flag via its .csproj; generated \`index.ts\` shows aggregation shape
- [x] \`sample-issue-tracker\` bun tests: 69/69 (was 65 — +4 new \`namespace-barrels.test.ts\` assertions)
- [x] \`sample-todo\` bun tests: 18/18 unchanged
- [x] \`sample-todo-service\` bun tests: 33/33 unchanged

## Net delta

| Measure | Value |
|---|---|
| Files changed | 14 (2 new: \`TsExportImportAlias.cs\`, \`NamespaceBarrelsTranspileTests.cs\`, \`namespace-barrels.test.ts\`) |
| Additions / deletions | +585 / -11 |

## Docs

ADR-0006 addendum documents the emission shape, alias \`\$\`-prefix convention, bare-root merge behavior, and why the default stays leaf-only. The default flip is tracked as a future major-version decision (surface cost + broader bundler verification).

Closes #22