### PR TITLE
test(sample-issue-tracker): business-logic bun coverage (#26)

### DIFF
--- a/targets/js/sample-issue-tracker/test/issues/application/issue-queries-edges.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/application/issue-queries-edges.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  openIssues,
+  statusCounts,
+  issuesForAssignee,
+  readyForReview,
+} from "#/issues/application/issue-queries";
+import { IssueStatus } from "#/issues/domain/issue-status";
+import { IssuePriority } from "#/issues/domain/issue-priority";
+import { UserId } from "#/shared-kernel/user-id";
+import { makeIssue } from "../../helpers";
+
+// Edges the base issue-queries.test.ts doesn't pin:
+//   * empty input returns empty containers
+//   * openIssues excludes Done AND Cancelled (both are isClosed = true)
+//   * issuesForAssignee applies the C# ordering
+//     (status asc, then priority desc)
+//   * readyForReview rejects matching-status but wrong-priority
+//   * statusCounts leaves unobserved statuses absent from the map
+
+describe("IssueQueries edges", () => {
+  test("openIssues on empty list returns empty list", () => {
+    expect(openIssues([])).toEqual([]);
+  });
+
+  test("openIssues excludes Cancelled as well as Done", () => {
+    const issues = [
+      makeIssue({ title: "Open", priority: IssuePriority.Medium }),
+      makeIssue({ title: "Done", priority: IssuePriority.Medium }),
+      makeIssue({ title: "Cancelled", priority: IssuePriority.Medium }),
+    ];
+    issues[1]!.status = IssueStatus.Done;
+    issues[2]!.status = IssueStatus.Cancelled;
+    const result = openIssues(issues);
+    expect(result.length).toBe(1);
+    expect(result[0]?.title).toBe("Open");
+  });
+
+  test("issuesForAssignee orders by status ASC then priority DESC", () => {
+    const alice = UserId.create("alice");
+    const issues = [
+      makeIssue({ title: "InReview-Low" }),
+      makeIssue({ title: "Backlog-Urgent" }),
+      makeIssue({ title: "Backlog-Low" }),
+    ];
+    issues[0]!.assignTo(alice);
+    issues[0]!.status = IssueStatus.InReview;
+    issues[0]!.changePriority(IssuePriority.Low);
+
+    issues[1]!.assignTo(alice);
+    issues[1]!.status = IssueStatus.Backlog;
+    issues[1]!.changePriority(IssuePriority.Urgent);
+
+    issues[2]!.assignTo(alice);
+    issues[2]!.status = IssueStatus.Backlog;
+    issues[2]!.changePriority(IssuePriority.Low);
+
+    const result = issuesForAssignee(issues, alice);
+    // Backlog sorts before InReview (string literal comparison on the
+    // generated StringEnum values). Within Backlog, Urgent precedes
+    // Low. The final element is the InReview issue.
+    expect(result.length).toBe(3);
+    expect(result[0]?.title).toBe("Backlog-Urgent");
+    expect(result[1]?.title).toBe("Backlog-Low");
+    expect(result[2]?.title).toBe("InReview-Low");
+  });
+
+  test("readyForReview rejects InProgress with Low priority", () => {
+    const issues = [
+      makeIssue({ status: IssueStatus.InProgress, priority: IssuePriority.Low }),
+      makeIssue({ status: IssueStatus.InProgress, priority: IssuePriority.Medium }),
+    ];
+    const result = readyForReview(issues, 10);
+    expect(result).toEqual([]);
+  });
+
+  test("readyForReview rejects InProgress+High but different status", () => {
+    const issues = [
+      makeIssue({ status: IssueStatus.Backlog, priority: IssuePriority.Urgent }),
+      makeIssue({ status: IssueStatus.Done, priority: IssuePriority.Urgent }),
+      makeIssue({ status: IssueStatus.Ready, priority: IssuePriority.High }),
+    ];
+    const result = readyForReview(issues, 10);
+    expect(result).toEqual([]);
+  });
+
+  test("statusCounts omits unobserved statuses", () => {
+    const issues = [
+      makeIssue({ status: IssueStatus.Backlog }),
+      makeIssue({ status: IssueStatus.Ready }),
+    ];
+    const counts = statusCounts(issues);
+    expect(counts.has(IssueStatus.Backlog)).toBe(true);
+    expect(counts.has(IssueStatus.Ready)).toBe(true);
+    expect(counts.has(IssueStatus.Done)).toBe(false);
+    expect(counts.has(IssueStatus.Cancelled)).toBe(false);
+  });
+});

--- a/targets/js/sample-issue-tracker/test/issues/application/issue-service-workflows.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/application/issue-service-workflows.test.ts
@@ -129,7 +129,7 @@ describe("IssueService workflows", () => {
     expect(readyHigh.items[0]?.status).toBe(IssueStatus.Ready);
   });
 
-  test("invalid status transition surfaces as thrown InvalidOperation", async () => {
+  test("invalid status transition surfaces as a thrown Error", async () => {
     const { service } = buildService();
     const created = await service.createAsync(
       "Task",
@@ -138,15 +138,18 @@ describe("IssueService workflows", () => {
       IssuePriority.Medium,
     );
     // Backlog → Done is disallowed; the underlying Issue.transitionTo
-    // throws and the async wrapper propagates. OperationResult shape
-    // doesn't swallow runtime exceptions today — this test pins that
-    // expectation so a future change to the dispatcher surfaces.
+    // throws (the C# `InvalidOperationException` lowers to a plain JS
+    // `Error`) and the async wrapper propagates the rejection.
+    // OperationResult shape doesn't swallow runtime exceptions today —
+    // this test pins that expectation so a future change to the
+    // dispatcher surfaces. The message format is part of the contract
+    // so assert against it instead of just `toThrow()`.
     await expect(
       service.transitionAsync(
         created.value!.id,
         IssueStatus.Done,
         UserId.create("alice"),
       ),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/Cannot transition issue from/);
   });
 });

--- a/targets/js/sample-issue-tracker/test/issues/application/issue-service-workflows.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/application/issue-service-workflows.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { IssueService } from "#/issues/application/issue-service";
+import { InMemoryIssueRepository } from "#/issues/application/in-memory-issue-repository";
+import { IssueId } from "#/issues/domain/issue-id";
+import { IssueStatus } from "#/issues/domain/issue-status";
+import { IssuePriority } from "#/issues/domain/issue-priority";
+import { IssueType } from "#/issues/domain/issue-type";
+import { UserId } from "#/shared-kernel/user-id";
+import { PageRequest } from "#/shared-kernel/page-request";
+
+// End-to-end workflows that exercise chained service operations +
+// OperationResult error propagation. Existing issue-service.test.ts
+// spot-checks individual calls; these cover the plumbing between them.
+
+function buildService() {
+  const repo = new InMemoryIssueRepository();
+  return { repo, service: new IssueService(repo) };
+}
+
+describe("IssueService workflows", () => {
+  test("create → assign → planSprint → transition reaches Ready", async () => {
+    const { service } = buildService();
+    const created = await service.createAsync(
+      "End-to-end",
+      "flow",
+      IssueType.Story,
+      IssuePriority.High,
+    );
+    expect(created.success).toBe(true);
+    const id = created.value!.id;
+
+    const assigned = await service.assignAsync(id, UserId.create("alice"));
+    expect(assigned.value?.assigneeId).toBe("alice" as any);
+
+    const planned = await service.planSprintAsync(id, "SPRINT-1");
+    expect(planned.value?.sprintKey).toBe("SPRINT-1");
+
+    const transitioned = await service.transitionAsync(
+      id,
+      IssueStatus.Ready,
+      UserId.create("alice"),
+    );
+    expect(transitioned.value?.status).toBe(IssueStatus.Ready);
+    expect(transitioned.value?.id).toBe(id);
+  });
+
+  test("assignAsync propagates not_found when issue missing", async () => {
+    const { service } = buildService();
+    const result = await service.assignAsync(
+      IssueId.new_(),
+      UserId.create("alice"),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("issue_not_found");
+  });
+
+  test("planSprintAsync propagates not_found when issue missing", async () => {
+    const { service } = buildService();
+    const result = await service.planSprintAsync(IssueId.new_(), "SPRINT-1");
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("issue_not_found");
+  });
+
+  test("transitionAsync propagates not_found when issue missing", async () => {
+    const { service } = buildService();
+    const result = await service.transitionAsync(
+      IssueId.new_(),
+      IssueStatus.Ready,
+      UserId.create("alice"),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("issue_not_found");
+  });
+
+  test("addCommentAsync on existing issue returns ok with accumulated comment", async () => {
+    const { service } = buildService();
+    const created = await service.createAsync(
+      "Issue",
+      "desc",
+      IssueType.Story,
+      IssuePriority.Medium,
+    );
+    const id = created.value!.id;
+    const withComment = await service.addCommentAsync(
+      id,
+      UserId.create("reviewer"),
+      "Looks good",
+    );
+    expect(withComment.success).toBe(true);
+    expect(withComment.value?.commentCount).toBe(1);
+    expect(withComment.value?.comments[0]?.message).toBe("Looks good");
+  });
+
+  test("addCommentAsync propagates not_found when issue missing", async () => {
+    const { service } = buildService();
+    const result = await service.addCommentAsync(
+      IssueId.new_(),
+      UserId.create("alice"),
+      "orphan",
+    );
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("issue_not_found");
+  });
+
+  test("searchAsync honors status + priority filters", async () => {
+    const { service } = buildService();
+    await service.createAsync("Low", "x", IssueType.Bug, IssuePriority.Low);
+    const high = await service.createAsync(
+      "High",
+      "x",
+      IssueType.Bug,
+      IssuePriority.High,
+    );
+    await service.transitionAsync(
+      high.value!.id,
+      IssueStatus.Ready,
+      UserId.create("alice"),
+    );
+
+    const readyHigh = await service.searchAsync(
+      IssueStatus.Ready,
+      IssuePriority.High,
+      null,
+      null,
+      new PageRequest(0, 10),
+    );
+    expect(readyHigh.items.length).toBe(1);
+    expect(readyHigh.items[0]?.priority).toBe(IssuePriority.High);
+    expect(readyHigh.items[0]?.status).toBe(IssueStatus.Ready);
+  });
+
+  test("invalid status transition surfaces as thrown InvalidOperation", async () => {
+    const { service } = buildService();
+    const created = await service.createAsync(
+      "Task",
+      "x",
+      IssueType.Story,
+      IssuePriority.Medium,
+    );
+    // Backlog → Done is disallowed; the underlying Issue.transitionTo
+    // throws and the async wrapper propagates. OperationResult shape
+    // doesn't swallow runtime exceptions today — this test pins that
+    // expectation so a future change to the dispatcher surfaces.
+    await expect(
+      service.transitionAsync(
+        created.value!.id,
+        IssueStatus.Done,
+        UserId.create("alice"),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/targets/js/sample-issue-tracker/test/issues/domain/issue-mutations.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/domain/issue-mutations.test.ts
@@ -15,18 +15,27 @@ import { makeIssue } from "../../helpers";
 //     status names so downstream audit readers can parse the trail
 
 describe("Issue mutations", () => {
-  test("CreatedAt and UpdatedAt start within the same second", () => {
+  test("CreatedAt and UpdatedAt start within one second of each other", () => {
     const issue = makeIssue();
     // Each field initializes via its own `Temporal.Now.zonedDateTimeISO()`
-    // call, which produces distinct nanosecond values even when evaluated
-    // in the same synchronous pass. Assert they land in the same second
-    // instead of pinning exact equality.
-    const createdSec = issue.createdAt.epochNanoseconds / 1_000_000_000n;
-    const updatedSec = issue.updatedAt.epochNanoseconds / 1_000_000_000n;
-    expect(createdSec).toBe(updatedSec);
+    // call, so they can legitimately straddle a wall-clock second
+    // boundary. Assert the absolute delta stays within a second instead
+    // of pinning equal whole seconds (which would flake once per second
+    // in CI).
+    const createdAtNs = issue.createdAt.epochNanoseconds;
+    const updatedAtNs = issue.updatedAt.epochNanoseconds;
+    const deltaNs =
+      createdAtNs >= updatedAtNs
+        ? createdAtNs - updatedAtNs
+        : updatedAtNs - createdAtNs;
+    expect(deltaNs <= 1_000_000_000n).toBe(true);
   });
 
-  test("rename advances UpdatedAt", () => {
+  test("rename does not decrease UpdatedAt", () => {
+    // Weaker than "advances" — `Temporal.Now` resolution can coincide
+    // for two synchronous calls, so a strict `>` would flake. What we
+    // actually guarantee (and want to pin): `touch` never rewinds the
+    // timestamp.
     const issue = makeIssue();
     const before = issue.updatedAt.epochNanoseconds;
     issue.rename("New title");

--- a/targets/js/sample-issue-tracker/test/issues/domain/issue-mutations.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/domain/issue-mutations.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { Issue } from "#/issues/domain/issue";
+import { IssueId } from "#/issues/domain/issue-id";
+import { IssueStatus } from "#/issues/domain/issue-status";
+import { IssuePriority } from "#/issues/domain/issue-priority";
+import { IssueType } from "#/issues/domain/issue-type";
+import { UserId } from "#/shared-kernel/user-id";
+import { makeIssue } from "../../helpers";
+
+// Covers invariants the existing issue.test.ts doesn't pin:
+//   * UpdatedAt advances on every mutation
+//   * CreatedAt + Id + Type stay constant across mutations
+//   * Multiple comments accumulate in insertion order
+//   * transitionTo records a system comment containing the prev/next
+//     status names so downstream audit readers can parse the trail
+
+describe("Issue mutations", () => {
+  test("CreatedAt and UpdatedAt start within the same second", () => {
+    const issue = makeIssue();
+    // Each field initializes via its own `Temporal.Now.zonedDateTimeISO()`
+    // call, which produces distinct nanosecond values even when evaluated
+    // in the same synchronous pass. Assert they land in the same second
+    // instead of pinning exact equality.
+    const createdSec = issue.createdAt.epochNanoseconds / 1_000_000_000n;
+    const updatedSec = issue.updatedAt.epochNanoseconds / 1_000_000_000n;
+    expect(createdSec).toBe(updatedSec);
+  });
+
+  test("rename advances UpdatedAt", () => {
+    const issue = makeIssue();
+    const before = issue.updatedAt.epochNanoseconds;
+    issue.rename("New title");
+    expect(issue.updatedAt.epochNanoseconds >= before).toBe(true);
+    // Plus the rename itself took effect.
+    expect(issue.title).toBe("New title");
+  });
+
+  test("CreatedAt never changes after mutations", () => {
+    const issue = makeIssue();
+    const createdAt = issue.createdAt.epochNanoseconds;
+    issue.rename("first");
+    issue.describe("second");
+    issue.changePriority(IssuePriority.High);
+    issue.assignTo(UserId.create("alice"));
+    expect(issue.createdAt.epochNanoseconds).toBe(createdAt);
+  });
+
+  test("Id is read-only across mutations", () => {
+    const issue = makeIssue();
+    const id = issue.id;
+    issue.rename("x");
+    issue.transitionTo(IssueStatus.Ready, UserId.create("alice"));
+    expect(issue.id).toBe(id);
+  });
+
+  test("Type is read-only across mutations", () => {
+    const id = IssueId.new_();
+    const issue = new Issue(
+      id,
+      "Title",
+      "Description",
+      IssueType.Bug,
+      IssuePriority.Medium,
+    );
+    const type = issue.type;
+    issue.rename("x");
+    issue.changePriority(IssuePriority.High);
+    expect(issue.type).toBe(type);
+  });
+
+  test("addComment accumulates in insertion order", () => {
+    const issue = makeIssue();
+    issue.addComment(UserId.create("alice"), "first");
+    issue.addComment(UserId.create("bob"), "second");
+    issue.addComment(UserId.create("alice"), "third");
+    expect(issue.commentCount).toBe(3);
+    expect(issue.comments[0]?.message).toBe("first");
+    expect(issue.comments[1]?.message).toBe("second");
+    expect(issue.comments[2]?.message).toBe("third");
+  });
+
+  test("transitionTo records a system comment describing the change", () => {
+    const issue = makeIssue();
+    issue.transitionTo(IssueStatus.Ready, UserId.create("alice"));
+    const note = issue.comments[0]?.message ?? "";
+    // C# enum values render through string interpolation via their
+    // ToString(); the transpiled StringEnum emits lowercase literals
+    // (`"backlog"`, `"ready"`) because IssueStatus has `[Name("...")]`
+    // overrides that lower-case each member. Assert against the
+    // emitted literals, not the C# identifier case.
+    expect(note).toContain(IssueStatus.Backlog);
+    expect(note).toContain(IssueStatus.Ready);
+    expect(note).toContain("alice");
+  });
+
+  test("lane tracks status + priority combinations", () => {
+    const issue = makeIssue({
+      status: IssueStatus.Ready,
+      priority: IssuePriority.Urgent,
+    });
+    expect(issue.lane).toBe("expedite");
+
+    issue.status = IssueStatus.Ready;
+    issue.changePriority(IssuePriority.Medium);
+    expect(issue.lane).toBe("ready");
+
+    issue.status = IssueStatus.InProgress;
+    expect(issue.lane).toBe("building");
+  });
+});

--- a/targets/js/sample-issue-tracker/test/issues/domain/issue-workflow-matrix.test.ts
+++ b/targets/js/sample-issue-tracker/test/issues/domain/issue-workflow-matrix.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { IssueWorkflow } from "#/issues/domain/issue-workflow";
+import { IssueStatus } from "#/issues/domain/issue-status";
+
+// Exhaustive from × to matrix. Pins each allowed set against the
+// C# authoritative switch in IssueWorkflow.cs. A regression in the
+// generated TS (e.g., a missing `or` branch on the discriminated
+// switch) shows up here as a specific pair flipping sides.
+
+type TransitionCase = {
+  readonly from: IssueStatus;
+  readonly allowed: ReadonlySet<IssueStatus>;
+};
+
+const ALL_STATUSES: readonly IssueStatus[] = [
+  IssueStatus.Backlog,
+  IssueStatus.Ready,
+  IssueStatus.InProgress,
+  IssueStatus.InReview,
+  IssueStatus.Done,
+  IssueStatus.Cancelled,
+];
+
+const CASES: readonly TransitionCase[] = [
+  {
+    from: IssueStatus.Backlog,
+    allowed: new Set([IssueStatus.Ready, IssueStatus.Cancelled]),
+  },
+  {
+    from: IssueStatus.Ready,
+    allowed: new Set([IssueStatus.InProgress, IssueStatus.Cancelled]),
+  },
+  {
+    from: IssueStatus.InProgress,
+    allowed: new Set([
+      IssueStatus.InReview,
+      IssueStatus.Backlog,
+      IssueStatus.Cancelled,
+    ]),
+  },
+  {
+    from: IssueStatus.InReview,
+    allowed: new Set([
+      IssueStatus.Done,
+      IssueStatus.InProgress,
+      IssueStatus.Cancelled,
+    ]),
+  },
+  { from: IssueStatus.Done, allowed: new Set() },
+  { from: IssueStatus.Cancelled, allowed: new Set() },
+];
+
+describe("IssueWorkflow transition matrix", () => {
+  for (const { from, allowed } of CASES) {
+    describe(`from ${from}`, () => {
+      test("getAllowedTransitions returns exactly the expected set", () => {
+        const actual = new Set(IssueWorkflow.getAllowedTransitions(from));
+        expect(actual.size).toBe(allowed.size);
+        for (const s of allowed) {
+          expect(actual.has(s)).toBe(true);
+        }
+      });
+
+      for (const to of ALL_STATUSES) {
+        const isAllowed = allowed.has(to);
+        test(`canTransition(${from} → ${to}) === ${isAllowed}`, () => {
+          expect(IssueWorkflow.canTransition(from, to)).toBe(isAllowed);
+        });
+      }
+    });
+  }
+
+  test("terminal states (Done, Cancelled) have no outgoing transitions", () => {
+    expect(IssueWorkflow.getAllowedTransitions(IssueStatus.Done)).toEqual([]);
+    expect(IssueWorkflow.getAllowedTransitions(IssueStatus.Cancelled)).toEqual(
+      [],
+    );
+  });
+});

--- a/targets/js/sample-issue-tracker/test/planning/domain/sprint.test.ts
+++ b/targets/js/sample-issue-tracker/test/planning/domain/sprint.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { Temporal } from "@js-temporal/polyfill";
+import { Sprint } from "#/planning/domain/sprint";
+import { IssueId } from "#/issues/domain/issue-id";
+
+function d(iso: string): Temporal.PlainDate {
+  return Temporal.PlainDate.from(iso);
+}
+
+describe("Sprint", () => {
+  test("durationDays is inclusive of both endpoints", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration 1",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    expect(sprint.durationDays).toBe(14);
+  });
+
+  test("durationDays is 1 when start equals end", () => {
+    const sprint = new Sprint(
+      "SPRINT-0",
+      "Spike",
+      d("2026-01-01"),
+      d("2026-01-01"),
+    );
+    expect(sprint.durationDays).toBe(1);
+  });
+
+  test.skip("isActiveOn includes start and end dates", () => {
+    // SKIPPED: tracked in issue #90. Generated TS lowers
+    // C# `date >= startDate && date <= endDate` to raw JS `>=` / `<=`,
+    // which Temporal.PlainDate rejects at runtime with
+    //   `TypeError: Do not use built-in arithmetic operators with
+    //    Temporal objects. When comparing, use
+    //    Temporal.PlainDate.compare(obj1, obj2) […]`
+    // Unskip this block when the lowering routes Temporal comparisons
+    // through `Temporal.PlainDate.compare`.
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration 1",
+      d("2026-01-05"),
+      d("2026-01-10"),
+    );
+    expect(sprint.isActiveOn(d("2026-01-05"))).toBe(true);
+    expect(sprint.isActiveOn(d("2026-01-07"))).toBe(true);
+    expect(sprint.isActiveOn(d("2026-01-10"))).toBe(true);
+    expect(sprint.isActiveOn(d("2026-01-04"))).toBe(false);
+    expect(sprint.isActiveOn(d("2026-01-11"))).toBe(false);
+  });
+
+  test("plan adds a unique IssueId", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    const a = IssueId.create("issue-a");
+    const b = IssueId.create("issue-b");
+
+    sprint.plan(a);
+    sprint.plan(b);
+    expect(sprint.plannedCount).toBe(2);
+  });
+
+  test("plan deduplicates when the same IssueId is added twice", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    const a = IssueId.create("issue-a");
+    sprint.plan(a);
+    sprint.plan(a);
+    expect(sprint.plannedCount).toBe(1);
+  });
+
+  test("unplan removes a specific IssueId", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    const a = IssueId.create("issue-a");
+    const b = IssueId.create("issue-b");
+    sprint.plan(a);
+    sprint.plan(b);
+    sprint.unplan(a);
+    expect(sprint.plannedCount).toBe(1);
+    const planned = Array.from(sprint.plannedIssues);
+    expect(planned).toContain(b);
+    expect(planned).not.toContain(a);
+  });
+
+  test("rename updates the Name but leaves Key", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Old",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    sprint.rename("New");
+    expect(sprint.name).toBe("New");
+    expect(sprint.key).toBe("SPRINT-1");
+  });
+
+  test("reschedule updates both boundaries", () => {
+    const sprint = new Sprint(
+      "SPRINT-1",
+      "Iteration",
+      d("2026-01-01"),
+      d("2026-01-14"),
+    );
+    sprint.reschedule(d("2026-02-01"), d("2026-02-28"));
+    expect(sprint.startDate.toString()).toBe("2026-02-01");
+    expect(sprint.endDate.toString()).toBe("2026-02-28");
+    expect(sprint.durationDays).toBe(28);
+  });
+});


### PR DESCRIPTION
## Summary

Pure test-writing PR — zero transpiler code changes. Adds 5 new bun test files exercising **semantic** parity between generated TS and the C# source for SampleIssueTracker:

- \`issues/domain/issue-workflow-matrix.test.ts\` — exhaustive \`from × to\` transition matrix
- \`issues/domain/issue-mutations.test.ts\` — UpdatedAt / CreatedAt / Id / Type invariants, comment order, transition comment shape
- \`issues/application/issue-service-workflows.test.ts\` — chained ops + OperationResult not-found propagation across \`assign\` / \`planSprint\` / \`transition\` / \`addComment\`
- \`issues/application/issue-queries-edges.test.ts\` — empty list, closed-variant exclusion, ordering, limit edge cases
- \`planning/domain/sprint.test.ts\` — zero tests before; covers durationDays, plan/unplan, rename/reschedule

## New issues surfaced

- **#90** — C# DateOnly comparisons lower to raw JS \`>=\` / \`<=\` but Temporal.PlainDate rejects those operators at runtime. \`Sprint.isActiveOn\` trips it. One test skipped with inline reference; unskip after lowering lands.

## Test plan

- [x] 633/633 TUnit green (unchanged — no transpiler code touched)
- [x] 141/142 bun tests pass in sample-issue-tracker (+72 new; 1 skip tracked in #90)
- [x] sample-todo + sample-todo-service bun suites unchanged

## Net delta

5 new files, +562 / -0.

Closes #26