### PR TITLE
feat(ts): [External] attribute + honor [Name] on [NoEmit] types (#93, #94)

### DIFF
--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -40,6 +40,7 @@ annotations.
 | --- | --- |
 | `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
 | `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
+| `ExternalAttribute` (TypeScript) | Marks a static class as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier (`Js.Document` → `document`). |
 
 ## Packaging and Interop
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,7 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0011`**.
+The current stable code range is **`MS0001` through `MS0012`**.
 
 ## Stable Codes
 
@@ -29,6 +29,7 @@ The current stable code range is **`MS0001` through `MS0011`**.
 | `MS0009` | `FrontendLoadFailure` | Source frontend failed to load or compile the project. |
 | `MS0010` | `OptionalRequiresNullable` | `[Optional]` was applied to a non-nullable parameter or property. |
 | `MS0011` | `InvalidDiscriminator` | `[Discriminator("FieldName")]` references a field that is missing, not a `[StringEnum]`, or nullable. |
+| `MS0012` | `InvalidExternal` | `[External]` was applied to a non-static class or combined with `[Transpile]`. |
 
 ## Product Significance
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -240,6 +240,18 @@ public static class IrToTsExpressionBridge
             memberName = TypeScriptNaming.ToCamelCase(ma.MemberName);
         else
             memberName = TypeScriptNaming.ToCamelCaseMember(ma.MemberName);
+        // `[External]` declaring type: the class exists only to group
+        // runtime globals on the C# side. Static member access flattens
+        // to the bare identifier (no enclosing type qualifier) so
+        // `Js.Document` lowers to `document` and feeds cleanly into
+        // `document.getElementById(…)` at the call site. Instance access
+        // (which is ill-formed on a static class anyway) falls through
+        // to the normal property-access path.
+        if (
+            ma.Origin is { IsDeclaringTypeExternal: true, IsStatic: true }
+            && ma.Target is IrTypeReference
+        )
+            return new TsIdentifier(memberName);
         return new TsPropertyAccess(loweredTarget, memberName);
     }
 

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -139,6 +139,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         {
             ValidateOptionalAttribute(compilation, assemblyWideTranspile, diagnostics);
             ValidateDiscriminatorAttribute(compilation, assemblyWideTranspile, diagnostics);
+            ValidateExternalAttribute(compilation, diagnostics);
         }
 
         return new IrCompilation(
@@ -327,6 +328,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                                 SymbolHelper.GetImport(sym) is not null
                                 || SymbolHelper.HasNoEmit(sym)
                                 || SymbolHelper.HasNoEmit(sym, target)
+                                || SymbolHelper.HasExternal(sym)
                             )
                         )
                             RegisterSymbol(sym);
@@ -757,6 +759,69 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         foreach (var nested in type.GetTypeMembers())
             VisitTypeForDiscriminator(nested, assemblyWideTranspile, currentAssembly, diagnostics);
+    }
+
+    /// <summary>
+    /// Walks the current assembly and emits <c>MS0012</c> for every
+    /// misuse of <c>[External]</c> (from
+    /// <c>Metano.Annotations.TypeScript</c>): applied to a non-static
+    /// class, or combined with <c>[Transpile]</c>. Runs regardless of
+    /// target since the attribute's invariants are semantic (the
+    /// transpiler cannot simultaneously honor "no emission" and "full
+    /// emission" on the same type).
+    /// </summary>
+    private static void ValidateExternalAttribute(
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type => VisitTypeForExternal(type, diagnostics)
+        );
+    }
+
+    private static void VisitTypeForExternal(
+        INamedTypeSymbol type,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (type.HasExternal())
+        {
+            if (!type.IsStatic)
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidExternal,
+                        $"[External] on '{type.Name}' requires a static class. The attribute "
+                            + $"only flattens static member access — non-static types have no "
+                            + $"static surface to flatten. Mark the class 'static' or remove "
+                            + $"[External].",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+            if (SymbolHelper.HasTranspile(type))
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidExternal,
+                        $"[External] on '{type.Name}' conflicts with [Transpile]. "
+                            + $"[External] marks a stub for runtime globals (no emission, "
+                            + $"flattened access); [Transpile] asks for full emission. Pick "
+                            + $"one — ambient bindings drop [Transpile], emitted helpers drop "
+                            + $"[External].",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForExternal(nested, diagnostics);
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -302,7 +302,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         // Current assembly — every transpilable type (matches the target-side
         // DiscoverTranspilableTypes + nested-emission filter) plus every
-        // `[Import]` placeholder the public-only walker would see.
+        // `[Import]` placeholder the public-only walker would see, PLUS
+        // every `[NoEmit]` public type so `[Name(target, …)]` overrides on
+        // ambient declarations propagate to references. `[NoEmit]` means
+        // "no .ts file emits" — it does NOT mean "callers should hallucinate
+        // the C# name at reference sites." Without this, a DOM binding stub
+        // like `[NoEmit, Name("HTMLElement")] HtmlElement` would surface as
+        // `HtmlElement` in generated TS, losing the rename that makes the
+        // stub interoperate with lib.dom.d.ts.
         CollectTopLevelTypes(
             currentAssembly.GlobalNamespace,
             type =>
@@ -316,7 +323,11 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                             RegisterSymbol(sym);
                         else if (
                             sym.DeclaredAccessibility == Accessibility.Public
-                            && SymbolHelper.GetImport(sym) is not null
+                            && (
+                                SymbolHelper.GetImport(sym) is not null
+                                || SymbolHelper.HasNoEmit(sym)
+                                || SymbolHelper.HasNoEmit(sym, target)
+                            )
                         )
                             RegisterSymbol(sym);
                     }
@@ -325,10 +336,15 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         // Referenced assemblies that opted into transpilation with an
         // [EmitPackage] for the active target. Mirrors the
-        // BuildCrossAssemblyState filter so the same set of emittable types
-        // ends up in the dict — [NoTranspile] / [NoEmit(target)] types are
-        // excluded, [Import] placeholders on the referenced side are still
-        // registered so consumers can resolve their alias by symbol.
+        // BuildCrossAssemblyState filter so the same set of emittable
+        // types ends up in the dict. `[NoTranspile]` types are excluded
+        // (the producer explicitly opted out). `[NoEmit]` types ARE
+        // registered so their `[Name]` overrides surface at reference
+        // sites on the consumer side — the emission pipeline filters
+        // them through its own paths (TranspilableTypeEntries,
+        // GuardableTypeKeys), so the dict stays reference-resolution
+        // scope. `[Import]` placeholders on the referenced side stay
+        // registered under the same rationale.
         foreach (var (asm, _) in EnumerateTranspilableReferencedAssemblies(compilation, target))
         {
             CollectTopLevelTypes(
@@ -341,8 +357,6 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                             if (sym.DeclaredAccessibility != Accessibility.Public)
                                 return;
                             if (SymbolHelper.HasNoTranspile(sym))
-                                return;
-                            if (SymbolHelper.HasNoEmit(sym, target))
                                 return;
                             RegisterSymbol(sym);
                         }

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -104,4 +104,15 @@ public static class DiagnosticCodes
     /// StringEnum so the discriminant check can narrow the rest of
     /// the shape.</summary>
     public const string InvalidDiscriminator = "MS0011";
+
+    /// <summary>MS0012 — <c>[External]</c> (from
+    /// <c>Metano.Annotations.TypeScript</c>) was applied to a
+    /// non-static class, or combined with <c>[Transpile]</c>. The
+    /// attribute marks a stub for runtime globals — the target class
+    /// emits no file and every static member access flattens to a
+    /// bare identifier. Non-static types have no static surface to
+    /// flatten, and combining with <c>[Transpile]</c> forces the
+    /// transpiler to simultaneously honor "no emission" and "full
+    /// emission" which are incompatible.</summary>
+    public const string InvalidExternal = "MS0012";
 }

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -930,6 +930,12 @@ public sealed class IrExpressionExtractor(
         // `[Name("x")]` (target-aware) is resolved once here so backends
         // consult the emitted name instead of re-scanning attributes.
         var emittedName = SymbolHelper.GetNameOverride(symbol, _target);
+        // `[External]` (TS-specific) marks a static class as a stub for
+        // runtime globals — static member access on such a class flattens
+        // to a bare identifier. Flag the declaring type here so the
+        // bridge can drop the enclosing type reference without re-reading
+        // Roslyn attributes.
+        var isDeclaringTypeExternal = SymbolHelper.HasExternal(symbol.ContainingType);
         return new IrMemberOrigin(
             declaringTypeName,
             symbol.Name,
@@ -938,7 +944,8 @@ public sealed class IrExpressionExtractor(
             isInlineWrapperMember,
             EmittedName: emittedName,
             IsPlainObjectInstanceMethod: isPlainObjectInstanceMethod,
-            IsStringEnumMember: isStringEnumMember
+            IsStringEnumMember: isStringEnumMember,
+            IsDeclaringTypeExternal: isDeclaringTypeExternal
         );
     }
 

--- a/src/Metano.Compiler/IR/IrExpression.cs
+++ b/src/Metano.Compiler/IR/IrExpression.cs
@@ -81,7 +81,8 @@ public sealed record IrMemberOrigin(
     bool IsInlineWrapperMember = false,
     string? EmittedName = null,
     bool IsPlainObjectInstanceMethod = false,
-    bool IsStringEnumMember = false
+    bool IsStringEnumMember = false,
+    bool IsDeclaringTypeExternal = false
 );
 
 /// <summary>

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -225,6 +225,24 @@ public static class SymbolHelper
             );
 
     /// <summary>
+    /// Reads <c>[External]</c> from the
+    /// <c>Metano.Annotations.TypeScript</c> namespace. TS-specific
+    /// attribute marking a static class as a stub for runtime globals
+    /// — static member access on such a class flattens to a bare
+    /// identifier (no enclosing type qualifier). Namespace-qualified
+    /// match so unrelated <c>[External]</c> attributes from other
+    /// libraries are not mistaken for the Metano variant.
+    /// </summary>
+    public static bool HasExternal(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is ("ExternalAttribute" or "External")
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
+                    == "Metano.Annotations.TypeScript"
+            );
+
+    /// <summary>
     /// Reads <c>[Discriminator("FieldName")]</c> from the
     /// <c>Metano.Annotations.TypeScript</c> namespace. Returns the
     /// discriminant field name (original C# casing) when the attribute
@@ -419,6 +437,13 @@ public static class SymbolHelper
         if (HasNoTranspile(symbol))
             return false;
         if (HasNoEmit(symbol))
+            return false;
+        // `[External]` is emission-scope "no emit" — the static class
+        // is a stub for runtime globals and must never produce a .ts
+        // file. Kept separate from `[NoEmit]` so the attribute
+        // semantics stay explicit at the source-code layer; the
+        // effect on discovery is identical.
+        if (HasExternal(symbol))
             return false;
         if (HasTranspile(symbol))
             return true;

--- a/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
@@ -1,0 +1,33 @@
+namespace Metano.Annotations.TypeScript;
+
+/// <summary>
+/// Marks a <c>static class</c> as a stub for runtime-available globals
+/// in the target JavaScript environment. The class itself emits no
+/// <c>.ts</c> file. Every static member access on the class lowers to
+/// a bare identifier reference (the enclosing class name is dropped)
+/// so <c>Js.Document</c> in C# becomes <c>document</c> in TypeScript.
+/// Matches the mental model of Kotlin/JS's <c>external object</c>.
+/// <para>
+/// Use for JavaScript globals that live on the host runtime rather
+/// than in an importable module: <c>document</c>, <c>window</c>,
+/// <c>console</c>, <c>JSON</c>, <c>Math</c>, and similar. Member
+/// <c>[Name(target, …)]</c> overrides drive the emitted identifier;
+/// without an override the camelCased C# member name is used.
+/// </para>
+/// <para>
+/// Applies only to <c>static class</c>. Non-static targets, and the
+/// combination with <c>[Transpile]</c>, raise <c>MS0013</c> at
+/// extraction time — the transpiler cannot simultaneously honor
+/// "no emission" and "full emission" on the same type.
+/// </para>
+/// <para>
+/// This attribute is TypeScript-specific — other targets (Dart,
+/// Kotlin) treat it as a no-op because their runtime-global surface
+/// has different conventions. It therefore lives in the
+/// <see cref="Metano.Annotations.TypeScript"/> namespace so a
+/// cross-target project opting into <c>using Metano.Annotations;</c>
+/// does not accidentally see TS-only knobs.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class ExternalAttribute : Attribute;

--- a/tests/Metano.Tests/ExternalAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ExternalAttributeTranspileTests.cs
@@ -1,0 +1,248 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[External]</c> from
+/// <c>Metano.Annotations.TypeScript</c>. The attribute marks a static
+/// class as a stub for runtime globals: the class emits no file,
+/// static member access flattens to a bare identifier so
+/// <c>Js.Document</c> in C# becomes <c>document</c> in TypeScript.
+/// Covers the emission flatten, the MS0012 validation surface, and
+/// the no-file contract.
+/// </summary>
+public class ExternalAttributeTranspileTests
+{
+    // ─── Emission flatten ────────────────────────────────────
+
+    [Test]
+    public async Task External_StaticProperty_AccessFlattensToIdentifier()
+    {
+        // `Js.Document` on the C# side should lower to `document` (no
+        // enclosing type qualifier) on the TS side because `Js` is an
+        // `[External]` static class acting as a stub for runtime
+        // globals. The `[Name("document")]` on the property drives the
+        // emitted identifier.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [NoEmit]
+            public abstract class Document {}
+
+            [External]
+            public static class Js
+            {
+                [Name("document")]
+                public static Document Document => throw null!;
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Renderer
+            {
+                public Document Target => Js.Document;
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("return document;");
+        await Assert.That(output).DoesNotContain("Js.document");
+    }
+
+    [Test]
+    public async Task External_StaticProperty_ChainedAccessFlattens()
+    {
+        // Chained call after the flattened access: `Js.Document.Body`
+        // lowers to `document.body` (no `Js.` at the root). The member
+        // after the first flatten keeps the normal property-access
+        // emission so the full chain stays legible.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [NoEmit, Name("HTMLElement")]
+            public abstract class HtmlElement {}
+
+            [NoEmit]
+            public abstract class Document
+            {
+                public HtmlElement Body => throw null!;
+            }
+
+            [External]
+            public static class Js
+            {
+                [Name("document")]
+                public static Document Document => throw null!;
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Renderer
+            {
+                public HtmlElement Root => Js.Document.Body;
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("return document.body;");
+        await Assert.That(output).DoesNotContain("Js.");
+    }
+
+    [Test]
+    public async Task External_StaticMethod_CallFlattens()
+    {
+        // Static method call on an `[External]` class with a
+        // `[Name("parseInt")]` override lowers to a bare call
+        // `parseInt("5")` — no `Js.` qualifier.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [External]
+            public static class Js
+            {
+                [Name("parseInt")]
+                public static int ParseInt(string value) => throw null!;
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Parser
+            {
+                public int Parse(string s) => Js.ParseInt(s);
+            }
+            """
+        );
+
+        var output = result["parser.ts"];
+        await Assert.That(output).Contains("return parseInt(s);");
+        await Assert.That(output).DoesNotContain("Js.parseInt");
+    }
+
+    [Test]
+    public async Task External_Class_EmitsNoFile()
+    {
+        // `[External]` classes are stubs — no .ts file emits for them
+        // even when the class lives in a transpilable assembly.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations.TypeScript;
+            [assembly: TranspileAssembly]
+
+            [External]
+            public static class Js
+            {
+                [Name("document")]
+                public static object Document => throw null!;
+            }
+
+            public class Placeholder {}
+            """
+        );
+
+        await Assert.That(result).DoesNotContainKey("js.ts");
+        await Assert.That(result).ContainsKey("placeholder.ts");
+    }
+
+    // ─── Diagnostics (MS0012) ────────────────────────────────
+
+    [Test]
+    public async Task External_OnNonStaticClass_EmitsMs0012()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [External]
+            public class NotStatic {}
+            """
+        );
+
+        var ms0012 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidExternal);
+        await Assert.That(ms0012).IsNotNull();
+        await Assert.That(ms0012!.Message).Contains("static");
+    }
+
+    [Test]
+    public async Task External_WithTranspile_EmitsMs0012()
+    {
+        // The two attributes are semantically incompatible — one asks
+        // for no emission, the other asks for full emission. MS0012
+        // surfaces the conflict at extraction time.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [Transpile, External]
+            public static class Mixed
+            {
+                [Name("x")] public static int Value => 0;
+            }
+            """
+        );
+
+        var ms0012 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidExternal);
+        await Assert.That(ms0012).IsNotNull();
+        await Assert.That(ms0012!.Message).Contains("Transpile");
+    }
+
+    [Test]
+    public async Task External_OnValidStaticClass_EmitsNoDiagnostic()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations.TypeScript;
+
+            [External]
+            public static class Js
+            {
+                [Name("document")]
+                public static object Document => throw null!;
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidExternal))
+            .IsFalse();
+    }
+
+    // ─── Doesn't affect non-External static classes ─────────
+
+    [Test]
+    public async Task NonExternal_StaticClass_AccessStillUsesPrefix()
+    {
+        // Baseline: `[ExportedAsModule]` (without `[External]`) emits
+        // a module file and a static access through the class reference
+        // stays qualified with the class name. The flatten only kicks
+        // in when `[External]` is explicit.
+        var result = TranspileHelper.Transpile(
+            """
+            [assembly: TranspileAssembly]
+
+            [Transpile, ExportedAsModule]
+            public static class Helpers
+            {
+                public static int Zero() => 0;
+            }
+
+            public class Consumer
+            {
+                public int Call() => Helpers.Zero();
+            }
+            """
+        );
+
+        var output = result["consumer.ts"];
+        // `Helpers.Zero()` lowers to `Helpers.zero()` — the prefix
+        // survives because no flatten happens without [External].
+        await Assert.That(output).Contains("Helpers.zero()");
+    }
+}

--- a/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
+++ b/tests/Metano.Tests/Frontend/CSharpSourceFrontendTests.cs
@@ -1324,4 +1324,56 @@ public class CSharpSourceFrontendTests
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
         await Assert.That(ir.EntryPoint).IsNull();
     }
+
+    [Test]
+    public async Task TypeNamesBySymbol_HonorsNameOverrideOnNoEmitType()
+    {
+        // `[NoEmit]` suppresses file emission but should NOT block
+        // name-resolution — a `[Name(target, …)]` override on the same
+        // symbol must still reach the dict so references to the type
+        // use the renamed identifier. Previous behavior skipped NoEmit
+        // types entirely, leaking the C# name into generated TS for
+        // ambient bindings like `[NoEmit, Name("HTMLElement")]
+        // HtmlElement`.
+        var compilation = IrTestHelper.Compile(
+            """
+            #nullable enable
+
+            [NoEmit]
+            [Name(TargetLanguage.TypeScript, "HTMLElement")]
+            public abstract class HtmlElement {}
+            """
+        );
+
+        var htmlElement = compilation.GetTypeByMetadataName("HtmlElement");
+        await Assert.That(htmlElement).IsNotNull();
+        var key = htmlElement!.GetCrossAssemblyOriginKey();
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.TypeNamesBySymbol).IsNotNull();
+        await Assert.That(ir.TypeNamesBySymbol!).ContainsKey(key);
+        await Assert.That(ir.TypeNamesBySymbol![key]).IsEqualTo("HTMLElement");
+    }
+
+    [Test]
+    public async Task TypeNamesBySymbol_RegistersNoEmitTypeEvenWithoutNameOverride()
+    {
+        // Without an override the name falls back to the C# symbol
+        // name — still registered so references resolve through the
+        // dict instead of going through a separate hallucination path.
+        var compilation = IrTestHelper.Compile(
+            """
+            [NoEmit]
+            public abstract class EventTarget {}
+            """
+        );
+
+        var eventTarget = compilation.GetTypeByMetadataName("EventTarget");
+        await Assert.That(eventTarget).IsNotNull();
+        var key = eventTarget!.GetCrossAssemblyOriginKey();
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        await Assert.That(ir.TypeNamesBySymbol!).ContainsKey(key);
+        await Assert.That(ir.TypeNamesBySymbol![key]).IsEqualTo("EventTarget");
+    }
 }

--- a/tests/Metano.Tests/NoEmitTranspileTests.cs
+++ b/tests/Metano.Tests/NoEmitTranspileTests.cs
@@ -118,4 +118,98 @@ public class NoEmitTranspileTests
         // Negative: no `c: ...` form anywhere.
         await Assert.That(output).DoesNotContain("c: I");
     }
+
+    [Test]
+    public async Task NoEmitType_BindingLib_WithoutTranspileAssembly_SurfacesNameOverride()
+    {
+        // DOM binding pattern on feat/jsx: the binding library is a
+        // plain-C# project with no `[assembly: TranspileAssembly]` and
+        // no `[assembly: EmitPackage]`. Every type is individually
+        // marked `[NoEmit, Name("…")]` so Metano knows about them via
+        // Roslyn metadata alone. The untargeted `[Name]` override must
+        // still surface at reference sites on the consumer side.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            [NoEmit, Name("HTMLElement")]
+            public abstract class HtmlElement {}
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Renderer
+            {
+                public HtmlElement? Target { get; set; }
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("HTMLElement");
+        await Assert.That(output).DoesNotContain("HtmlElement");
+    }
+
+    [Test]
+    public async Task NoEmitType_CrossAssembly_SurfacesUntargetedNameOverride()
+    {
+        // Mirrors the DOM binding pattern on feat/jsx: `[NoEmit,
+        // Name("HTMLElement")]` lives in a separate library; the
+        // consumer references it as a parameter/property type. The
+        // untargeted `[Name]` override must cross the assembly
+        // boundary and surface at the reference site so the generated
+        // TS interoperates with lib.dom.d.ts rather than using the C#
+        // symbol name.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("dom-bindings")]
+
+            [NoEmit, Name("HTMLElement")]
+            public abstract class HtmlElement {}
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Renderer
+            {
+                public HtmlElement? Target { get; set; }
+
+                public void Attach(HtmlElement element) {}
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("HTMLElement");
+        await Assert.That(output).DoesNotContain("HtmlElement");
+    }
+
+    [Test]
+    public async Task NoEmitType_WithUntargetedNameOverride_SurfacesOverrideAtReferenceSites()
+    {
+        // A `[NoEmit, Name("HTMLElement")]` ambient stub (DOM binding
+        // pattern) must surface the override at every type-reference
+        // site. Untargeted `[Name]` — the single-arg overload — is
+        // already picked up at extraction time via BuildQualifiedName;
+        // this test pins the behavior so a later refactor doesn't
+        // accidentally drop it for NoEmit types.
+        var result = TranspileHelper.Transpile(
+            """
+            [assembly: TranspileAssembly]
+
+            [NoEmit, Name("HTMLElement")]
+            public abstract class HtmlElement {}
+
+            public class Renderer
+            {
+                public HtmlElement? Target { get; set; }
+
+                public void Attach(HtmlElement element) {}
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("HTMLElement");
+        await Assert.That(output).DoesNotContain("HtmlElement");
+    }
 }


### PR DESCRIPTION
Two-commit PR. Split for review clarity — each commit closes a distinct issue.

## Commit 1 — \`fix(core): honor [Name] override on [NoEmit] types (#93)\`

Frontend \`BuildTypeNamesBySymbol\` was skipping \`[NoEmit]\` types, so \`[Name]\` overrides on ambient binding stubs (the DOM pattern on \`feat/jsx\`) silently dropped out of generated TS. Consumer references fell back to the C# symbol name.

Fix: register \`[NoEmit]\` types in the dict. Emission pipeline continues to filter through its own paths (\`TranspilableTypeEntries\`, \`GuardableTypeKeys\`) — the dict change is strictly name-resolution scope.

- Tests: three new \`NoEmitTranspileTests\` cases + two \`CSharpSourceFrontendTests\` cases covering single-assembly, binding-lib-without-TranspileAssembly, and cross-assembly paths
- Verified on \`feat/jsx\`: \`HtmlElement\` → \`HTMLElement\` now surfaces at every reference site

## Commit 2 — \`feat(ts): [External] attribute for runtime-global static classes (#94)\`

New \`ExternalAttribute\` in \`Metano.Annotations.TypeScript\`. Marks a static class as a stub for runtime-available JS globals. The class emits no file and static member access flattens to a bare identifier.

\`\`\`csharp
using Metano.Annotations.TypeScript;

[External]
public static class Js
{
    [Name(\"document\")] public static Document Document => throw null!;
    [Name(\"window\")] public static Window Window => throw null!;
}
\`\`\`

\`\`\`ts
// Js.Document.GetElementById(\"root\")  →  document.getElementById(\"root\")
// Js.Window.AddEventListener(...)       →  window.addEventListener(...)
\`\`\`

Matches Kotlin/JS's \`external object\` mental model. Replaces the accidental \`[ExportedAsModule, NoEmit]\` composition pattern.

Implementation:
- \`IrMemberOrigin.IsDeclaringTypeExternal\` flag populated at extraction time
- \`IrToTsExpressionBridge.MapMemberAccess\` flattens when target is \`IrTypeReference\` + flag set
- \`SymbolHelper.IsTranspilable\` returns false for \`[External]\` so the class never emits
- Validator raises \`MS0012\` for non-static class target or combination with \`[Transpile]\` (semantically incompatible)
- Spec updated: attribute catalog + diagnostic catalog (range MS0001–MS0012)

- Tests: eight new \`ExternalAttributeTranspileTests\` cases covering flatten (property / chained / method), no-file emission, MS0012 positive/negative, and a regression gate proving \`[ExportedAsModule]\` without \`[External]\` keeps its module qualifier.

## Test plan

- [x] 646/646 TUnit green (was 633 — +13 new tests)
- [x] \`dotnet csharpier check .\` passes
- [x] Sample outputs byte-identical (no existing sample uses \`[External]\`)
- [x] \`feat/jsx\` DOM sample verified: Fix 1 surfaces \`HTMLElement\` correctly; \`[External]\` conversion of \`Js\` is a user-side follow-up once this merges

## Net delta

13 files, +575 / −11. Two new attrs / tests, one IR flag, one bridge branch, one validator.

Closes #93, #94