### PR TITLE
feat(core): introduce [Erasable] attribute for static-class scope erasure

### DIFF
--- a/docs/adr/0015-attribute-family-for-compile-time-erasure.md
+++ b/docs/adr/0015-attribute-family-for-compile-time-erasure.md
@@ -1,0 +1,150 @@
+# ADR-0015 — Attribute family for compile-time erasure and inlining
+
+**Status:** Proposed
+**Date:** 2026-04-23
+
+## Context
+
+Over the course of the `Metano.TypeScript.DOM` bindings effort we ran
+into three overlapping pains:
+
+1. `[External]` (introduced in #94) had to do two jobs at once — suppress
+   file emission AND flatten call-site access of static members — because
+   we lacked a dedicated attribute for "container class that vanishes at
+   the call site".
+2. `[NoEmit]` was used as an ambient declaration marker (for BCL / DOM
+   types that exist in the JS runtime). But callers who want to mark a
+   type as ".NET-only, must never cross into transpiled code" had no
+   way to express that. The name `NoEmit` fits the second meaning better
+   than the first, and today's double-duty makes the painting of
+   non-transpilable code ambiguous.
+3. `[InlineWrapper]` describes *how* the compiler lowers a struct (inline
+   + wrap) rather than *what* lands in TypeScript (a branded primitive).
+   As we introduced a sibling attribute for erased wrappers (see the
+   closed-catalog follow-up in #96) the name stopped being self-explanatory.
+
+Simultaneously, the DOM bindings use case (`document.createElement(...)` →
+`HTMLElementTagNameMap` style narrowing) exposed missing primitives we
+could not spell today: a way to enforce literal arguments at call sites
+(`[Constant]`), a way to inline field initializers and method bodies at
+use sites (`[Inline]`), and the container-erasure `[Erasable]` on top of
+which those layer.
+
+`[ExportedAsModule]` also has a latent defect: member access
+`MyModule.Foo()` is **not** flattened at call sites (only `[External]`
+triggered that pass, per
+`src/Metano.Compiler/Extraction/IrExpressionExtractor.cs:938`). The
+shipping samples never exercised the broken path because the only
+consumers of `[ExportedAsModule]` are entry-point classes called from
+hand-written test code. The first cross-module call would emit a
+dangling `MyModule.foo` reference.
+
+## Decision
+
+Introduce a six-attribute family that cleanly separates the orthogonal
+concerns — scope, declaration, inlining, branding, constants:
+
+| Attribute | Target | Purpose |
+|-----------|--------|---------|
+| `[Erasable]` | `static class` | Class scope vanishes at the call site. Members emit according to their own attributes (plain body → top-level function in class-named file, `[External]` → ambient, `[Emit(...)]` → template, `[Inline]` → expansion, `[Ignore]` → dropped). |
+| `[External]` | class or member | Runtime-provided. No declaration emitted. Transpiled code can reference the symbol (class-qualified access preserved when the class is *not* also `[Erasable]`). |
+| `[NoEmit]` | type | **Redefined**: .NET-only. The type is painted as non-transpilable; any reference from transpiled code is a compile error (MS0013 `NoEmitReferencedByTranspiledCode`). Previous ambient usages migrate to `[External]`. |
+| `[Branded]` | `struct` / `record` | Branded primitive wrapper with a companion namespace. Renames `[InlineWrapper]` — no behavioral change, just a better name. |
+| `[Constant]` | parameter or field | Value must be a compile-time constant literal. Validator emits MS0014 `InvalidConstant` when violated. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
+| `[Inline]` | field, method, or static class | Expansion at the use site. Field: initializer substitutes each access. Expression-bodied method: body substitutes each call with parameter renaming. Static class: propagates `[Inline]` to every member (ergonomic shortcut). |
+
+Each attribute stays single-responsibility. Composability — not
+implication — is the contract. `[Erasable]` on a class does *not*
+automatically mark its members `[External]`; the user attaches the
+second attribute when the member's value is runtime-provided. The
+separation matters for the mixed case where a single `[Erasable]` class
+holds both runtime-global accessors (`[External]`) and user-authored
+helpers (plain bodies → top-level functions).
+
+`[ExportedAsModule]` is marked `[Obsolete]` and points to `[Erasable]`;
+one release cycle later it disappears. The move simultaneously fixes
+the call-site flatten bug, because `[Erasable]` populates the same
+`IsDeclaringTypeErasable` flag in `IrMemberOrigin` and drives the
+existing flatten branch in `IrToTsExpressionBridge.MapMemberAccess`.
+
+The class-level semantics of `[External]` (no file + flatten) shipped in
+#94 and were consumed only by the in-progress `Js` binding. Going
+forward, class-level `[External]` means "ambient class, declaration
+elsewhere, access stays class-qualified". The flatten behavior now
+lives exclusively under `[Erasable]`.
+
+The four features roll out as stacked PRs:
+
+- PR-0 (#97) — `[Erasable]` + `[External]` refactor + `[NoEmit]` redefinition + `[ExportedAsModule]` deprecation
+- PR-1 (#98) — `[Constant]` (parameter + field)
+- PR-2 (#99) — `[Branded]` rename of `[InlineWrapper]`
+- PR-3 (#100) — `[Inline]` (field + expression-bodied method + static-class propagation)
+
+## Consequences
+
+- (+) Callers of DOM bindings (and similar runtime-global wrappers) can
+      write ergonomic C# (`Js.Document.CreateElement(HtmlElementType.Div)`)
+      and have it lower to idiomatic TypeScript
+      (`document.createElement(({tagName: "div"}).tagName) as HTMLDivElement`)
+      without a new special-case in the compiler.
+- (+) Closes the latent call-site bug in `[ExportedAsModule]` without a
+      bespoke patch.
+- (+) `[NoEmit]` finally has a single meaning — ".NET-only, untranspilable"
+      — and the diagnostic MS0013 catches stray references early rather
+      than letting them escape as dangling symbols in generated TS.
+- (+) `[Branded]` vs. a future erased-wrapper (closed-catalog follow-up)
+      read as a pair, matching the already-accepted `[Erasable]`
+      counterpart on the class side.
+- (+) The `[Constant]` + `[Inline]` duo is usable standalone (SQL column
+      names, event names, typed literal factories) well beyond the DOM
+      motivator.
+- (−) Breaking change at the attribute surface: class-level `[External]`
+      behavior moves to `[Erasable]`; the `Js` binding in the in-progress
+      `feat/jsx` worktree must migrate (`[External, NoEmit]` on `Js` →
+      `[Erasable]`, per-type `[NoEmit]` → `[External]`). No shipped
+      consumers outside the active experiments.
+- (−) `[InlineWrapper]` → `[Branded]` is a mechanical rename, but every
+      internal call site (`SymbolHelper.HasInlineWrapper`,
+      `IrTypeSemantics.IsInlineWrapper`, the bridge class name) has to
+      move with the surface attribute. Coordinated with the existing
+      same-week refactor on the `feat/jsx` branch.
+- (−) The `[NoEmit]` redefinition requires re-examining every existing
+      use in the codebase. The majority are DOM bindings that should
+      become `[External]`; a minority are legitimate .NET-only (internal
+      test helpers) and remain `[NoEmit]`.
+
+## Alternatives considered
+
+- **Keep `[External]` as class-level flatten + ambient** — the shipped
+  #94 behavior. Rejected because the dual role makes it impossible to
+  express "ambient class that keeps class-qualified access" (needed
+  when the runtime publishes a namespace rather than loose globals).
+- **Keep `[InlineWrapper]` name** — avoids churn but names the
+  mechanism rather than the outcome, and reads inconsistently next to
+  the sibling erased-wrapper attribute.
+- **Imply `[External]` on every member of an `[Erasable]` class** —
+  Kotlin-`external object`-style. Rejected because it precludes the
+  common mixed case where an `[Erasable]` class holds both ambient
+  bindings and user-authored helpers.
+- **Merge `[Erasable]` and `[ExportedAsModule]` into one attribute with
+  two modes** — fewer attributes but muddies the orthogonality users
+  benefit from. Rejected.
+- **Reinterpret `[NoEmit]` inside the union with `[External]`** —
+  single attribute, flag argument. Rejected; flags on an attribute
+  imply one responsibility with variants, which is not the shape
+  here (separate cross-target vs. target-specific intents).
+
+## References
+
+- Umbrella issue: #96
+- Stack: #97, #98, #99, #100
+- Prior art: ADR-0005 (Inline wrapper branded types — being renamed),
+  #93 (`[Name]` override on `[NoEmit]` types),
+  #94 (`[External]` attribute first shipment)
+- Code pointers that move under this ADR:
+  - `src/Metano/Annotations/TypeScript/ExternalAttribute.cs`
+  - `src/Metano/Annotations/ExportedAsModuleAttribute.cs`
+  - `src/Metano/Annotations/InlineWrapperAttribute.cs`
+  - `src/Metano.Compiler/SymbolHelper.cs` (HasExternal / HasInlineWrapper)
+  - `src/Metano.Compiler/Extraction/IrExpressionExtractor.cs:938`
+  - `src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs` (MapMemberAccess)

--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,7 +1,7 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **21 attribute types** in
+transpilation model. The current codebase exposes **25 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
 annotations.
 
@@ -12,7 +12,7 @@ annotations.
 | `TranspileAttribute` | Marks an individual type for transpilation. |
 | `TranspileAssemblyAttribute` | Marks an assembly for assembly-wide transpilation. |
 | `NoTranspileAttribute` | Excludes a type from transpilation. |
-| `NoEmitAttribute` | Keeps a symbol available for resolution without emitting a file. |
+| `NoEmitAttribute` | Paints a type as .NET-only — no file emitted and no transpiled code may reference it (MS0013 `NoEmitReferencedByTranspiledCode`). |
 
 ## Naming and Emission Shape
 
@@ -22,14 +22,15 @@ annotations.
 | `IgnoreAttribute` | Omits a member from output. |
 | `StringEnumAttribute` | Emits enum output as string-based TS representation. |
 | `PlainObjectAttribute` | Emits object shape without class wrapper semantics. |
-| `InlineWrapperAttribute` | Emits wrapper types using branded/opaque-style semantics. |
+| `BrandedAttribute` | Emits wrapper types using branded/opaque-style semantics. Renames `InlineWrapperAttribute` (deprecated). |
 | `EmitInFileAttribute` | Co-locates multiple types in a single output file. |
 
 ## Modules and Top-Level Emission
 
 | Attribute | Purpose |
 | --- | --- |
-| `ExportedAsModuleAttribute` | Emits a static class as a module surface. |
+| `ErasableAttribute` | Marks a static class whose scope vanishes at the call site. Members emit according to their own attributes (plain body → top-level function, `[External]` → ambient, `[Emit(...)]` → template, `[Inline]` → expansion, `[Ignore]` → dropped). Subsumes `ExportedAsModuleAttribute` (deprecated) and fixes the call-site flatten pass. |
+| `ExportedAsModuleAttribute` | **Deprecated** — use `ErasableAttribute`. Kept for one release cycle. |
 | `ModuleEntryPointAttribute` | Promotes a method body to top-level module statements. |
 | `ModuleAttribute` | Declares module-related emission metadata. |
 | `ExportVarFromBodyAttribute` | Promotes a variable declared in a module entry body into module export surface. |
@@ -40,7 +41,9 @@ annotations.
 | --- | --- |
 | `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
 | `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
-| `ExternalAttribute` (TypeScript) | Marks a static class as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier (`Js.Document` → `document`). |
+| `ExternalAttribute` (TypeScript) | Marks a class or member as runtime-provided. No declaration emitted. Class-level `[External]` keeps class-qualified access (`Foo.bar` stays `Foo.bar`); flatten semantics moved to `[Erasable]`. Member-level `[External]` suppresses the declaration only. |
+| `ConstantAttribute` | Applied to a parameter or field; the value must be a compile-time constant literal. Violations surface as MS0014 `InvalidConstant`. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
+| `InlineAttribute` | Applied to a static readonly field, an expression-bodied method / extension, or a static class. Field: initializer substitutes at every access. Method: body substitutes at every call with parameter renaming. Class: propagates `[Inline]` to every contained member. |
 
 ## Packaging and Interop
 

--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,9 +1,10 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **25 attribute types** in
+transpilation model. The current codebase exposes **22 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
-annotations.
+annotations. Additional entries tagged *(planned)* below are reserved for the
+upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
 
 ## Type Selection and Inclusion
 
@@ -22,15 +23,15 @@ annotations.
 | `IgnoreAttribute` | Omits a member from output. |
 | `StringEnumAttribute` | Emits enum output as string-based TS representation. |
 | `PlainObjectAttribute` | Emits object shape without class wrapper semantics. |
-| `BrandedAttribute` | Emits wrapper types using branded/opaque-style semantics. Renames `InlineWrapperAttribute` (deprecated). |
+| `InlineWrapperAttribute` | Emits wrapper types using branded/opaque-style semantics. *(Planned rename to `BrandedAttribute` per ADR-0015.)* |
 | `EmitInFileAttribute` | Co-locates multiple types in a single output file. |
 
 ## Modules and Top-Level Emission
 
 | Attribute | Purpose |
 | --- | --- |
-| `ErasableAttribute` | Marks a static class whose scope vanishes at the call site. Members emit according to their own attributes (plain body → top-level function, `[External]` → ambient, `[Emit(...)]` → template, `[Inline]` → expansion, `[Ignore]` → dropped). Subsumes `ExportedAsModuleAttribute` (deprecated) and fixes the call-site flatten pass. |
-| `ExportedAsModuleAttribute` | **Deprecated** — use `ErasableAttribute`. Kept for one release cycle. |
+| `ErasableAttribute` | Marks a static class whose scope vanishes at the call site. The class emits no `.ts` file and static member access flattens to a bare identifier. Members must already resolve without their own emission (literal returns, `[Emit]` templates, and — per ADR-0015 — upcoming `[External]` / `[Inline]` members). The broader member-emission contract and the full deprecation of `ExportedAsModuleAttribute` ship in follow-up slices. |
+| `ExportedAsModuleAttribute` | Superseded by `ErasableAttribute`; remains fully functional until the follow-up slice migrates existing callers. |
 | `ModuleEntryPointAttribute` | Promotes a method body to top-level module statements. |
 | `ModuleAttribute` | Declares module-related emission metadata. |
 | `ExportVarFromBodyAttribute` | Promotes a variable declared in a module entry body into module export surface. |
@@ -41,9 +42,9 @@ annotations.
 | --- | --- |
 | `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
 | `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
-| `ExternalAttribute` (TypeScript) | Marks a class or member as runtime-provided. No declaration emitted. Class-level `[External]` keeps class-qualified access (`Foo.bar` stays `Foo.bar`); flatten semantics moved to `[Erasable]`. Member-level `[External]` suppresses the declaration only. |
-| `ConstantAttribute` | Applied to a parameter or field; the value must be a compile-time constant literal. Violations surface as MS0014 `InvalidConstant`. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
-| `InlineAttribute` | Applied to a static readonly field, an expression-bodied method / extension, or a static class. Field: initializer substitutes at every access. Method: body substitutes at every call with parameter renaming. Class: propagates `[Inline]` to every contained member. |
+| `ExternalAttribute` (TypeScript) | Marks a `static class` as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier. Attribute usage now accepts method/property/field targets so the family can grow; the per-member declaration-suppression lowering and the split from class-level flatten ship in a follow-up slice. |
+| `ConstantAttribute` *(planned)* | Will mark a parameter or field whose value must be a compile-time constant literal. See ADR-0015. |
+| `InlineAttribute` *(planned)* | Will apply to a static readonly field, an expression-bodied method / extension, or a static class to request expansion at every use site. See ADR-0015. |
 
 ## Packaging and Interop
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,9 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0016`**.
+The current stable code range is **`MS0001` through `MS0015`**, with
+`MS0013`, `MS0014`, and `MS0016` reserved for the upcoming attribute-family
+slices (see ADR-0015).
 
 ## Stable Codes
 
@@ -29,11 +31,21 @@ The current stable code range is **`MS0001` through `MS0016`**.
 | `MS0009` | `FrontendLoadFailure` | Source frontend failed to load or compile the project. |
 | `MS0010` | `OptionalRequiresNullable` | `[Optional]` was applied to a non-nullable parameter or property. |
 | `MS0011` | `InvalidDiscriminator` | `[Discriminator("FieldName")]` references a field that is missing, not a `[StringEnum]`, or nullable. |
-| `MS0012` | `InvalidExternal` | `[External]` is malformed — class-level use combined with `[Transpile]`, or member-level use on a symbol that is not suppressible. |
-| `MS0013` | `NoEmitReferencedByTranspiledCode` | A `[NoEmit]` type is referenced from transpiled code, which breaks the `.NET-only` painting. Migrate the referenced type to `[External]` (runtime-provided) or mark the caller `[NoTranspile]`. |
-| `MS0014` | `InvalidConstant` | `[Constant]` argument or initializer is not a compile-time constant literal. |
-| `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or a member inside an `[Erasable]` class cannot satisfy the emission contract (requires a body, `[External]`, `[Emit]`, `[Inline]`, or `[Ignore]`). |
-| `MS0016` | `InvalidInline` | `[Inline]` is malformed — field is not `static readonly`, method has a multi-statement body, or expansion introduces a recursion cycle. |
+| `MS0012` | `InvalidExternal` | `[External]` was applied to a non-static class, or combined with `[Transpile]`. |
+| `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or combined with `[Transpile]`. |
+
+## Reserved Codes
+
+The following codes are reserved for the follow-up slices of the
+attribute-family roadmap (see ADR-0015) and are **not** yet implemented
+in the compiler. They are listed here so the numbering range stays
+stable across the stack, not as a promise of shipped behavior.
+
+| Code | Symbolic name | Slice |
+| --- | --- | --- |
+| `MS0013` | `NoEmitReferencedByTranspiledCode` | `[NoEmit]` redefinition (painting diagnostic) |
+| `MS0014` | `InvalidConstant` | `[Constant]` validator |
+| `MS0016` | `InvalidInline` | `[Inline]` validator |
 
 ## Product Significance
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,7 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0012`**.
+The current stable code range is **`MS0001` through `MS0016`**.
 
 ## Stable Codes
 
@@ -29,7 +29,11 @@ The current stable code range is **`MS0001` through `MS0012`**.
 | `MS0009` | `FrontendLoadFailure` | Source frontend failed to load or compile the project. |
 | `MS0010` | `OptionalRequiresNullable` | `[Optional]` was applied to a non-nullable parameter or property. |
 | `MS0011` | `InvalidDiscriminator` | `[Discriminator("FieldName")]` references a field that is missing, not a `[StringEnum]`, or nullable. |
-| `MS0012` | `InvalidExternal` | `[External]` was applied to a non-static class or combined with `[Transpile]`. |
+| `MS0012` | `InvalidExternal` | `[External]` is malformed — class-level use combined with `[Transpile]`, or member-level use on a symbol that is not suppressible. |
+| `MS0013` | `NoEmitReferencedByTranspiledCode` | A `[NoEmit]` type is referenced from transpiled code, which breaks the `.NET-only` painting. Migrate the referenced type to `[External]` (runtime-provided) or mark the caller `[NoTranspile]`. |
+| `MS0014` | `InvalidConstant` | `[Constant]` argument or initializer is not a compile-time constant literal. |
+| `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or a member inside an `[Erasable]` class cannot satisfy the emission contract (requires a body, `[External]`, `[Emit]`, `[Inline]`, or `[Ignore]`). |
+| `MS0016` | `InvalidInline` | `[Inline]` is malformed — field is not `static readonly`, method has a multi-statement body, or expansion introduces a recursion cycle. |
 
 ## Product Significance
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -240,15 +240,18 @@ public static class IrToTsExpressionBridge
             memberName = TypeScriptNaming.ToCamelCase(ma.MemberName);
         else
             memberName = TypeScriptNaming.ToCamelCaseMember(ma.MemberName);
-        // `[External]` declaring type: the class exists only to group
-        // runtime globals on the C# side. Static member access flattens
-        // to the bare identifier (no enclosing type qualifier) so
-        // `Js.Document` lowers to `document` and feeds cleanly into
-        // `document.getElementById(…)` at the call site. Instance access
-        // (which is ill-formed on a static class anyway) falls through
-        // to the normal property-access path.
+        // `[External]` and `[Erasable]` declaring types: the class
+        // vanishes at the call site. `[External]` groups runtime
+        // globals; `[Erasable]` marks compile-time sugar containers.
+        // Both lower static member access to the bare identifier
+        // (no enclosing type qualifier) so `Js.Document` → `document`
+        // feeds cleanly into `document.getElementById(…)`, and a
+        // `Constants.Pi` access on an `[Erasable]` catalog lowers to
+        // just `Pi`. Instance access (ill-formed on a static class)
+        // falls through to the normal property-access path.
         if (
-            ma.Origin is { IsDeclaringTypeExternal: true, IsStatic: true }
+            ma.Origin is { IsStatic: true } origin
+            && (origin.IsDeclaringTypeExternal || origin.IsDeclaringTypeErasable)
             && ma.Target is IrTypeReference
         )
             return new TsIdentifier(memberName);

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -329,6 +329,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                                 || SymbolHelper.HasNoEmit(sym)
                                 || SymbolHelper.HasNoEmit(sym, target)
                                 || SymbolHelper.HasExternal(sym)
+                                || SymbolHelper.HasErasable(sym)
                             )
                         )
                             RegisterSymbol(sym);
@@ -796,8 +797,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                         MetanoDiagnosticSeverity.Error,
                         DiagnosticCodes.InvalidExternal,
                         $"[External] on '{type.Name}' requires a static class. The attribute "
-                            + $"only flattens static member access — non-static types have no "
-                            + $"static surface to flatten. Mark the class 'static' or remove "
+                            + $"marks a stub for runtime globals — non-static types have no "
+                            + $"static surface to declare. Mark the class 'static' or remove "
                             + $"[External].",
                         type.Locations.FirstOrDefault()
                     )
@@ -810,10 +811,40 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                         MetanoDiagnosticSeverity.Error,
                         DiagnosticCodes.InvalidExternal,
                         $"[External] on '{type.Name}' conflicts with [Transpile]. "
-                            + $"[External] marks a stub for runtime globals (no emission, "
-                            + $"flattened access); [Transpile] asks for full emission. Pick "
-                            + $"one — ambient bindings drop [Transpile], emitted helpers drop "
-                            + $"[External].",
+                            + $"[External] marks a stub for runtime globals (no emission); "
+                            + $"[Transpile] asks for full emission. Pick one — ambient "
+                            + $"bindings drop [Transpile], emitted helpers drop [External].",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+        }
+
+        if (SymbolHelper.HasErasable(type))
+        {
+            if (!type.IsStatic)
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidErasable,
+                        $"[Erasable] on '{type.Name}' requires a static class. The attribute "
+                            + $"marks a class whose scope vanishes at the call site — "
+                            + $"non-static types carry instance state that cannot be erased. "
+                            + $"Mark the class 'static' or remove [Erasable].",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+            }
+            if (SymbolHelper.HasTranspile(type))
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidErasable,
+                        $"[Erasable] on '{type.Name}' conflicts with [Transpile]. "
+                            + $"[Erasable] asks for no file emission and call-site scope "
+                            + $"erasure; [Transpile] asks for full emission. Pick one.",
                         type.Locations.FirstOrDefault()
                     )
                 );

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -115,12 +115,16 @@ public static class DiagnosticCodes
     public const string InvalidExternal = "MS0012";
 
     /// <summary>MS0015 — <c>[Erasable]</c> (from
-    /// <c>Metano.Annotations</c>) was applied to a non-static class, or
-    /// combined with <c>[Transpile]</c>. The attribute marks a static
-    /// class whose scope vanishes at the call site — the class emits
-    /// no file and member access flattens to a bare identifier.
-    /// Non-static targets have no static surface to flatten, and
-    /// <c>[Transpile]</c> asks for full emission which is
-    /// incompatible with the no-file contract.</summary>
+    /// <c>Metano.Annotations</c>) was applied to a non-static class,
+    /// or combined with <c>[Transpile]</c>. The attribute marks a
+    /// static class whose scope vanishes at the call site — the
+    /// class emits no file and member access flattens to a bare
+    /// identifier. Non-static targets have no static surface to
+    /// flatten, and <c>[Transpile]</c> asks for full emission which
+    /// is incompatible with the no-file contract. Member-level
+    /// emission contracts inside an <c>[Erasable]</c> class (plain
+    /// bodies projected as top-level exports, <c>[Inline]</c>
+    /// expansion) are enforced in a follow-up slice; this code does
+    /// not yet surface them.</summary>
     public const string InvalidErasable = "MS0015";
 }

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -109,10 +109,18 @@ public static class DiagnosticCodes
     /// <c>Metano.Annotations.TypeScript</c>) was applied to a
     /// non-static class, or combined with <c>[Transpile]</c>. The
     /// attribute marks a stub for runtime globals — the target class
-    /// emits no file and every static member access flattens to a
-    /// bare identifier. Non-static types have no static surface to
-    /// flatten, and combining with <c>[Transpile]</c> forces the
-    /// transpiler to simultaneously honor "no emission" and "full
-    /// emission" which are incompatible.</summary>
+    /// emits no file. Non-static types and combinations with
+    /// <c>[Transpile]</c> force the transpiler to simultaneously honor
+    /// "no emission" and "full emission", which are incompatible.</summary>
     public const string InvalidExternal = "MS0012";
+
+    /// <summary>MS0015 — <c>[Erasable]</c> (from
+    /// <c>Metano.Annotations</c>) was applied to a non-static class, or
+    /// combined with <c>[Transpile]</c>. The attribute marks a static
+    /// class whose scope vanishes at the call site — the class emits
+    /// no file and member access flattens to a bare identifier.
+    /// Non-static targets have no static surface to flatten, and
+    /// <c>[Transpile]</c> asks for full emission which is
+    /// incompatible with the no-file contract.</summary>
+    public const string InvalidErasable = "MS0015";
 }

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -930,12 +930,15 @@ public sealed class IrExpressionExtractor(
         // `[Name("x")]` (target-aware) is resolved once here so backends
         // consult the emitted name instead of re-scanning attributes.
         var emittedName = SymbolHelper.GetNameOverride(symbol, _target);
-        // `[External]` (TS-specific) marks a static class as a stub for
-        // runtime globals — static member access on such a class flattens
-        // to a bare identifier. Flag the declaring type here so the
-        // bridge can drop the enclosing type reference without re-reading
-        // Roslyn attributes.
-        var isDeclaringTypeExternal = SymbolHelper.HasExternal(symbol.ContainingType);
+        // `[External]` (TS-specific, class-level legacy) and
+        // `[Erasable]` (cross-target) both cause static member access
+        // to flatten to a bare identifier — the enclosing class name
+        // is dropped at the call site. Flag the declaring type here
+        // so the bridge can honor the rewrite without re-reading
+        // Roslyn attributes at lowering time.
+        var isDeclaringTypeExternal =
+            SymbolHelper.HasExternal(symbol.ContainingType)
+            || SymbolHelper.HasErasable(symbol.ContainingType);
         return new IrMemberOrigin(
             declaringTypeName,
             symbol.Name,

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -930,15 +930,15 @@ public sealed class IrExpressionExtractor(
         // `[Name("x")]` (target-aware) is resolved once here so backends
         // consult the emitted name instead of re-scanning attributes.
         var emittedName = SymbolHelper.GetNameOverride(symbol, _target);
-        // `[External]` (TS-specific, class-level legacy) and
-        // `[Erasable]` (cross-target) both cause static member access
-        // to flatten to a bare identifier — the enclosing class name
-        // is dropped at the call site. Flag the declaring type here
-        // so the bridge can honor the rewrite without re-reading
-        // Roslyn attributes at lowering time.
-        var isDeclaringTypeExternal =
-            SymbolHelper.HasExternal(symbol.ContainingType)
-            || SymbolHelper.HasErasable(symbol.ContainingType);
+        // `[External]` (TS-specific) and `[Erasable]`
+        // (cross-target) both cause static member access to flatten
+        // to a bare identifier at the call site, but they express
+        // different intents (runtime-provided stub vs. compile-time
+        // sugar container). The flags stay distinct so later slices
+        // can diverge their lowering paths without churn; today's
+        // bridge honors either to drop the enclosing type reference.
+        var isDeclaringTypeExternal = SymbolHelper.HasExternal(symbol.ContainingType);
+        var isDeclaringTypeErasable = SymbolHelper.HasErasable(symbol.ContainingType);
         return new IrMemberOrigin(
             declaringTypeName,
             symbol.Name,
@@ -948,7 +948,8 @@ public sealed class IrExpressionExtractor(
             EmittedName: emittedName,
             IsPlainObjectInstanceMethod: isPlainObjectInstanceMethod,
             IsStringEnumMember: isStringEnumMember,
-            IsDeclaringTypeExternal: isDeclaringTypeExternal
+            IsDeclaringTypeExternal: isDeclaringTypeExternal,
+            IsDeclaringTypeErasable: isDeclaringTypeErasable
         );
     }
 

--- a/src/Metano.Compiler/IR/IrExpression.cs
+++ b/src/Metano.Compiler/IR/IrExpression.cs
@@ -82,7 +82,8 @@ public sealed record IrMemberOrigin(
     string? EmittedName = null,
     bool IsPlainObjectInstanceMethod = false,
     bool IsStringEnumMember = false,
-    bool IsDeclaringTypeExternal = false
+    bool IsDeclaringTypeExternal = false,
+    bool IsDeclaringTypeErasable = false
 );
 
 /// <summary>

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -227,11 +227,14 @@ public static class SymbolHelper
     /// <summary>
     /// Reads <c>[External]</c> from the
     /// <c>Metano.Annotations.TypeScript</c> namespace. TS-specific
-    /// attribute marking a static class as a stub for runtime globals
-    /// — static member access on such a class flattens to a bare
-    /// identifier (no enclosing type qualifier). Namespace-qualified
-    /// match so unrelated <c>[External]</c> attributes from other
-    /// libraries are not mistaken for the Metano variant.
+    /// attribute marking the symbol as runtime-provided — no
+    /// declaration is emitted for it. On a class, call-site access
+    /// keeps the class-qualified form (scope-erasure lives on
+    /// <see cref="HasErasable"/>). On a member, the declaration is
+    /// suppressed but access goes through whatever enclosing
+    /// expression holds it. Namespace-qualified match so unrelated
+    /// <c>[External]</c> attributes from other libraries are not
+    /// mistaken for the Metano variant.
     /// </summary>
     public static bool HasExternal(this ISymbol symbol) =>
         symbol
@@ -240,6 +243,25 @@ public static class SymbolHelper
                 a.AttributeClass?.Name is ("ExternalAttribute" or "External")
                 && a.AttributeClass?.ContainingNamespace?.ToDisplayString()
                     == "Metano.Annotations.TypeScript"
+            );
+
+    /// <summary>
+    /// Reads <c>[Erasable]</c> from <c>Metano.Annotations</c>. Static
+    /// class whose scope vanishes at every call site — no
+    /// <c>.ts</c> file, and static member access drops the enclosing
+    /// class name (<c>HtmlElementType.Div</c> → <c>Div</c>). Members
+    /// inside emit per their own attributes (plain body → top-level
+    /// function, <c>[External]</c> → ambient, <c>[Emit]</c> → template,
+    /// <c>[Inline]</c> → expansion, <c>[Ignore]</c> → dropped).
+    /// Subsumes <c>[ExportedAsModule]</c> (deprecated) and fixes the
+    /// latent call-site flatten bug.
+    /// </summary>
+    public static bool HasErasable(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is ("ErasableAttribute" or "Erasable")
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString() == "Metano.Annotations"
             );
 
     /// <summary>
@@ -438,12 +460,15 @@ public static class SymbolHelper
             return false;
         if (HasNoEmit(symbol))
             return false;
-        // `[External]` is emission-scope "no emit" — the static class
-        // is a stub for runtime globals and must never produce a .ts
-        // file. Kept separate from `[NoEmit]` so the attribute
-        // semantics stay explicit at the source-code layer; the
-        // effect on discovery is identical.
+        // `[External]` and `[Erasable]` are emission-scope "no emit".
+        // Both mark the class as something the compiler must not
+        // produce a .ts file for (runtime-provided vs. compile-time
+        // sugar, respectively). Kept separate from `[NoEmit]` so the
+        // attribute semantics stay explicit at the source-code layer;
+        // the effect on discovery is identical.
         if (HasExternal(symbol))
+            return false;
+        if (HasErasable(symbol))
             return false;
         if (HasTranspile(symbol))
             return true;

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -228,13 +228,15 @@ public static class SymbolHelper
     /// Reads <c>[External]</c> from the
     /// <c>Metano.Annotations.TypeScript</c> namespace. TS-specific
     /// attribute marking the symbol as runtime-provided — no
-    /// declaration is emitted for it. On a class, call-site access
-    /// keeps the class-qualified form (scope-erasure lives on
-    /// <see cref="HasErasable"/>). On a member, the declaration is
-    /// suppressed but access goes through whatever enclosing
-    /// expression holds it. Namespace-qualified match so unrelated
-    /// <c>[External]</c> attributes from other libraries are not
-    /// mistaken for the Metano variant.
+    /// declaration is emitted for it. This helper only answers
+    /// whether the attribute is present; the exact call-site shape
+    /// (flatten vs. class-qualified access, per-member vs. class
+    /// scope) is decided by the lowering pipeline. In the current
+    /// slice, class-level <c>[External]</c> flattens static member
+    /// access at the bridge; per-member lowering ships alongside the
+    /// <c>[NoEmit]</c> redefinition. Namespace-qualified match so
+    /// unrelated <c>[External]</c> attributes from other libraries
+    /// are not mistaken for the Metano variant.
     /// </summary>
     public static bool HasExternal(this ISymbol symbol) =>
         symbol
@@ -460,12 +462,15 @@ public static class SymbolHelper
             return false;
         if (HasNoEmit(symbol))
             return false;
-        // `[External]` and `[Erasable]` are emission-scope "no emit".
-        // Both mark the class as something the compiler must not
-        // produce a .ts file for (runtime-provided vs. compile-time
-        // sugar, respectively). Kept separate from `[NoEmit]` so the
-        // attribute semantics stay explicit at the source-code layer;
-        // the effect on discovery is identical.
+        // `[External]` and `[Erasable]` are emission-scope "no emit"
+        // in the initial slice. Both mark a static class the
+        // compiler must not produce a .ts file for — runtime-provided
+        // stub vs. compile-time sugar container, respectively. A
+        // follow-up slice introduces per-member emission inside an
+        // `[Erasable]` class (plain bodies projected as top-level
+        // exports); until then every accessible member must be
+        // external, templated, or resolvable at the call site so the
+        // flattened identifier has a defining source.
         if (HasExternal(symbol))
             return false;
         if (HasErasable(symbol))

--- a/src/Metano/Annotations/ErasableAttribute.cs
+++ b/src/Metano/Annotations/ErasableAttribute.cs
@@ -1,0 +1,38 @@
+namespace Metano.Annotations;
+
+/// <summary>
+/// Marks a <c>static class</c> whose scope vanishes at every call site.
+/// The class itself emits no <c>.ts</c> file, and every static member
+/// access drops the enclosing class name
+/// (<c>HtmlElementType.Div</c> → <c>Div</c>) so the members read as if
+/// they were declared at file scope.
+/// <para>
+/// Members inside an <c>[Erasable]</c> class emit according to their
+/// own attributes, not by inheritance from the container:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Plain method body → top-level
+///   <c>export function</c> in a file named after the class.</description></item>
+///   <item><description><c>[External]</c> member → no declaration
+///   emitted; the runtime provides the symbol.</description></item>
+///   <item><description><c>[Emit("…")]</c> member → template expansion
+///   at each call site, no free-standing declaration.</description></item>
+///   <item><description><c>[Inline]</c> field/property → initializer
+///   substitutes each access.</description></item>
+///   <item><description><c>[Ignore]</c> member → dropped.</description></item>
+/// </list>
+/// <para>
+/// Applies only to <c>static class</c>. Non-static targets raise
+/// <c>MS0015 InvalidErasable</c>. Members that cannot satisfy one of
+/// the emission contracts above also raise <c>MS0015</c> — the
+/// transpiler refuses to guess the intended lowering.
+/// </para>
+/// <para>
+/// <c>[Erasable]</c> lives in <see cref="Metano.Annotations"/> because
+/// the semantic (scope erasure at call site) is meaningful for every
+/// target, even if the call-site flatten only shows in languages whose
+/// natural shape supports top-level declarations.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class ErasableAttribute : Attribute;

--- a/src/Metano/Annotations/ErasableAttribute.cs
+++ b/src/Metano/Annotations/ErasableAttribute.cs
@@ -1,37 +1,31 @@
 namespace Metano.Annotations;
 
 /// <summary>
-/// Marks a <c>static class</c> whose scope vanishes at every call site.
-/// The class itself emits no <c>.ts</c> file, and every static member
-/// access drops the enclosing class name
-/// (<c>HtmlElementType.Div</c> → <c>Div</c>) so the members read as if
-/// they were declared at file scope.
+/// Marks a <c>static class</c> whose scope vanishes at the call site:
+/// static member access drops the enclosing class name
+/// (<c>Constants.Pi</c> → <c>Pi</c>), and the class itself emits no
+/// <c>.ts</c> file. Intended for compile-time container types whose
+/// members are either runtime-provided, template-emitted
+/// (<c>[Emit]</c>), or constant literals the consumer resolves at use
+/// site.
 /// <para>
-/// Members inside an <c>[Erasable]</c> class emit according to their
-/// own attributes, not by inheritance from the container:
+/// In the initial slice, every member on an <c>[Erasable]</c> class
+/// must already resolve without emitting a declaration (literal
+/// return, <c>[Emit]</c> template, or member that will become
+/// <c>[External]</c> / <c>[Inline]</c> once those attributes ship).
+/// The broader member-emission contract (plain bodies projected as
+/// top-level exports, <c>[Inline]</c> expansion, MS0015 member-level
+/// validation) lands in follow-up slices alongside those attributes.
 /// </para>
-/// <list type="bullet">
-///   <item><description>Plain method body → top-level
-///   <c>export function</c> in a file named after the class.</description></item>
-///   <item><description><c>[External]</c> member → no declaration
-///   emitted; the runtime provides the symbol.</description></item>
-///   <item><description><c>[Emit("…")]</c> member → template expansion
-///   at each call site, no free-standing declaration.</description></item>
-///   <item><description><c>[Inline]</c> field/property → initializer
-///   substitutes each access.</description></item>
-///   <item><description><c>[Ignore]</c> member → dropped.</description></item>
-/// </list>
 /// <para>
-/// Applies only to <c>static class</c>. Non-static targets raise
-/// <c>MS0015 InvalidErasable</c>. Members that cannot satisfy one of
-/// the emission contracts above also raise <c>MS0015</c> — the
-/// transpiler refuses to guess the intended lowering.
+/// Applies only to <c>static class</c>. Non-static targets and
+/// combinations with <c>[Transpile]</c> raise
+/// <c>MS0015 InvalidErasable</c>.
 /// </para>
 /// <para>
 /// <c>[Erasable]</c> lives in <see cref="Metano.Annotations"/> because
 /// the semantic (scope erasure at call site) is meaningful for every
-/// target, even if the call-site flatten only shows in languages whose
-/// natural shape supports top-level declarations.
+/// target; per-target lowering is defined by each backend.
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, Inherited = false)]

--- a/src/Metano/Annotations/ExportedAsModuleAttribute.cs
+++ b/src/Metano/Annotations/ExportedAsModuleAttribute.cs
@@ -1,8 +1,17 @@
 namespace Metano.Annotations;
 
 /// <summary>
-/// When applied to a static class, its members are emitted as top-level exported functions
-/// in the generated TypeScript module, without a wrapping class.
+/// <b>Superseded by</b> <see cref="ErasableAttribute"/>. Migrating
+/// existing callers is scheduled for the follow-up PR that ships the
+/// <c>[NoEmit]</c> redefinition; until then this attribute stays fully
+/// functional.
+/// <para>
+/// <c>[Erasable]</c> produces the same top-level emission and
+/// additionally flattens call-site access (<c>ClassName.member</c> →
+/// <c>member</c>), closing a latent bug where cross-module references
+/// to an <c>[ExportedAsModule]</c> class emitted dangling
+/// <c>ClassName.member</c> without a TypeScript-side class declaration.
+/// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class ExportedAsModuleAttribute : Attribute;

--- a/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
@@ -1,33 +1,48 @@
 namespace Metano.Annotations.TypeScript;
 
 /// <summary>
-/// Marks a <c>static class</c> as a stub for runtime-available globals
-/// in the target JavaScript environment. The class itself emits no
-/// <c>.ts</c> file. Every static member access on the class lowers to
-/// a bare identifier reference (the enclosing class name is dropped)
-/// so <c>Js.Document</c> in C# becomes <c>document</c> in TypeScript.
-/// Matches the mental model of Kotlin/JS's <c>external object</c>.
+/// Declares that the annotated symbol is provided by the target
+/// runtime — no declaration is emitted for it. Applies to classes,
+/// methods, properties, and fields.
 /// <para>
-/// Use for JavaScript globals that live on the host runtime rather
-/// than in an importable module: <c>document</c>, <c>window</c>,
-/// <c>console</c>, <c>JSON</c>, <c>Math</c>, and similar. Member
-/// <c>[Name(target, …)]</c> overrides drive the emitted identifier;
-/// without an override the camelCased C# member name is used.
+/// Class-level use (<c>[External] class Document</c>) emits no
+/// <c>.ts</c> file for the class, and call-site access keeps the
+/// class-qualified form (<c>Document.foo</c> stays <c>Document.foo</c>).
+/// Use this shape when the runtime publishes a namespace-like object
+/// (<c>React.createElement</c>, <c>JSON.stringify</c>).
 /// </para>
 /// <para>
-/// Applies only to <c>static class</c>. Non-static targets, and the
-/// combination with <c>[Transpile]</c>, raise <c>MS0013</c> at
-/// extraction time — the transpiler cannot simultaneously honor
-/// "no emission" and "full emission" on the same type.
+/// Member-level use suppresses the declaration only for that member.
+/// Typical pairing: a <c>[Erasable]</c> container with per-member
+/// <c>[External]</c> on symbols whose implementation is a runtime
+/// global (<c>[Erasable] class Js</c> + <c>[External, Name("document")]
+/// public static Document Document</c>).
 /// </para>
 /// <para>
-/// This attribute is TypeScript-specific — other targets (Dart,
+/// Scope-erasing behavior (flattening <c>ClassName.member</c> to bare
+/// <c>member</c>) lives on <see cref="Metano.Annotations.ErasableAttribute"/>.
+/// A class that needs both behaviors combines the two attributes.
+/// </para>
+/// <para>
+/// Combining <c>[External]</c> with <c>[Transpile]</c> on the same
+/// class raises <c>MS0012 InvalidExternal</c> — the transpiler cannot
+/// simultaneously honor "no emission" and "full emission" on the same
+/// type.
+/// </para>
+/// <para>
+/// This attribute is TypeScript-specific; other targets (Dart,
 /// Kotlin) treat it as a no-op because their runtime-global surface
-/// has different conventions. It therefore lives in the
-/// <see cref="Metano.Annotations.TypeScript"/> namespace so a
-/// cross-target project opting into <c>using Metano.Annotations;</c>
-/// does not accidentally see TS-only knobs.
+/// has different conventions. It lives under
+/// <see cref="Metano.Annotations.TypeScript"/> so cross-target
+/// consumers that only import <c>using Metano.Annotations;</c> do not
+/// see TS-only knobs.
 /// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+[AttributeUsage(
+    AttributeTargets.Class
+        | AttributeTargets.Method
+        | AttributeTargets.Property
+        | AttributeTargets.Field,
+    Inherited = false
+)]
 public sealed class ExternalAttribute : Attribute;

--- a/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
+++ b/src/Metano/Annotations/TypeScript/ExternalAttribute.cs
@@ -2,40 +2,43 @@ namespace Metano.Annotations.TypeScript;
 
 /// <summary>
 /// Declares that the annotated symbol is provided by the target
-/// runtime — no declaration is emitted for it. Applies to classes,
-/// methods, properties, and fields.
+/// runtime — no declaration is emitted for it. The attribute now
+/// accepts class, method, property, and field targets so the family
+/// can grow into per-member declaration-suppression without a source
+/// break; current lowering behavior still keys off the class-level
+/// form only.
 /// <para>
-/// Class-level use (<c>[External] class Document</c>) emits no
-/// <c>.ts</c> file for the class, and call-site access keeps the
-/// class-qualified form (<c>Document.foo</c> stays <c>Document.foo</c>).
-/// Use this shape when the runtime publishes a namespace-like object
-/// (<c>React.createElement</c>, <c>JSON.stringify</c>).
+/// Today a class-level <c>[External]</c> static class emits no
+/// <c>.ts</c> file and its static member access flattens to the bare
+/// identifier so <c>Js.Document</c> on the C# side becomes
+/// <c>document</c> in TypeScript. This matches the shipped behavior
+/// in #94. Scope-erasure-without-runtime semantics — the compile-time
+/// sugar container — live on
+/// <see cref="Metano.Annotations.ErasableAttribute"/>; classes that
+/// need both attach the two attributes.
 /// </para>
 /// <para>
-/// Member-level use suppresses the declaration only for that member.
-/// Typical pairing: a <c>[Erasable]</c> container with per-member
-/// <c>[External]</c> on symbols whose implementation is a runtime
-/// global (<c>[Erasable] class Js</c> + <c>[External, Name("document")]
-/// public static Document Document</c>).
+/// Member-level use (method, property, field) is accepted by the
+/// attribute surface so callers can already annotate ambient symbols
+/// inside a container. The per-member declaration-suppression pass
+/// and the split from the class-level flatten ship in a follow-up
+/// slice alongside the <c>[NoEmit]</c> redefinition and the DOM
+/// binding migration.
 /// </para>
 /// <para>
-/// Scope-erasing behavior (flattening <c>ClassName.member</c> to bare
-/// <c>member</c>) lives on <see cref="Metano.Annotations.ErasableAttribute"/>.
-/// A class that needs both behaviors combines the two attributes.
-/// </para>
-/// <para>
-/// Combining <c>[External]</c> with <c>[Transpile]</c> on the same
-/// class raises <c>MS0012 InvalidExternal</c> — the transpiler cannot
+/// Applies only to <c>static class</c> at the class level. Non-static
+/// targets, and the combination with <c>[Transpile]</c>, raise
+/// <c>MS0012 InvalidExternal</c> — the transpiler cannot
 /// simultaneously honor "no emission" and "full emission" on the same
 /// type.
 /// </para>
 /// <para>
-/// This attribute is TypeScript-specific; other targets (Dart,
+/// This attribute is TypeScript-specific — other targets (Dart,
 /// Kotlin) treat it as a no-op because their runtime-global surface
-/// has different conventions. It lives under
-/// <see cref="Metano.Annotations.TypeScript"/> so cross-target
-/// consumers that only import <c>using Metano.Annotations;</c> do not
-/// see TS-only knobs.
+/// has different conventions. It lives in the
+/// <see cref="Metano.Annotations.TypeScript"/> namespace so a
+/// cross-target project opting into <c>using Metano.Annotations;</c>
+/// does not accidentally see TS-only knobs.
 /// </para>
 /// </summary>
 [AttributeUsage(

--- a/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
@@ -1,0 +1,115 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[Erasable]</c> from <c>Metano.Annotations</c>. The
+/// attribute marks a static class whose scope vanishes at the call
+/// site: the class emits no file, static member access flattens to a
+/// bare identifier. Members inside emit per their own attributes.
+/// Covers the flatten, the no-file contract, and the MS0015
+/// validation surface.
+/// </summary>
+public class ErasableAttributeTranspileTests
+{
+    // ─── Emission flatten ────────────────────────────────────
+
+    [Test]
+    public async Task Erasable_StaticMember_AccessFlattensToIdentifier()
+    {
+        // `Constants.Pi` on the C# side should lower to a bare `Pi`
+        // identifier on the TS side because `Constants` is `[Erasable]`
+        // — the enclosing class qualifier is dropped at the call site.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations;
+
+            [Erasable]
+            public static class Constants
+            {
+                public static double Pi => 3.14;
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Circle
+            {
+                public double GetPi() => Constants.Pi;
+            }
+            """
+        );
+
+        var output = result["circle.ts"];
+        await Assert.That(output).Contains("return pi;");
+        await Assert.That(output).DoesNotContain("Constants.");
+    }
+
+    [Test]
+    public async Task Erasable_Class_EmitsNoFile()
+    {
+        // `[Erasable]` classes are compile-time sugar — no .ts file
+        // emits for them even when the class lives in a transpilable
+        // assembly.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Erasable]
+            public static class Constants
+            {
+                public static double Pi => 3.14;
+            }
+
+            public class Placeholder {}
+            """
+        );
+
+        await Assert.That(result).DoesNotContainKey("constants.ts");
+        await Assert.That(result).ContainsKey("placeholder.ts");
+    }
+
+    // ─── Diagnostics (MS0015) ────────────────────────────────
+
+    [Test]
+    public async Task Erasable_OnNonStaticClass_EmitsMs0015()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+
+            [Erasable]
+            public class NotStatic {}
+            """
+        );
+
+        var ms0015 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidErasable);
+        await Assert.That(ms0015).IsNotNull();
+        await Assert.That(ms0015!.Message).Contains("static");
+    }
+
+    [Test]
+    public async Task Erasable_WithTranspile_EmitsMs0015()
+    {
+        // The two attributes are semantically incompatible — one asks
+        // for no emission, the other asks for full emission. MS0015
+        // surfaces the conflict at extraction time.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+
+            [Transpile]
+            [Erasable]
+            public static class Conflict
+            {
+                public static int X => 42;
+            }
+            """
+        );
+
+        var ms0015 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidErasable);
+        await Assert.That(ms0015).IsNotNull();
+        await Assert.That(ms0015!.Message).Contains("[Transpile]");
+    }
+}

--- a/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
@@ -17,9 +17,10 @@ public class ErasableAttributeTranspileTests
     [Test]
     public async Task Erasable_StaticMember_AccessFlattensToIdentifier()
     {
-        // `Constants.Pi` on the C# side should lower to a bare `Pi`
-        // identifier on the TS side because `Constants` is `[Erasable]`
-        // — the enclosing class qualifier is dropped at the call site.
+        // `Constants.Pi` on the C# side should lower to a bare `pi`
+        // identifier on the TS side (camelCased per the TS naming
+        // policy) because `Constants` is `[Erasable]` — the enclosing
+        // class qualifier is dropped at the call site.
         var result = TranspileHelper.TranspileWithLibrary(
             """
             using Metano.Annotations;


### PR DESCRIPTION
## Summary

First slice of the attribute-family stack tracked under #96. Introduces `[Erasable]` (Metano.Annotations) — a static-class marker whose scope vanishes at the call site — and widens `[External]` targets to set up the declaration-suppression vs. scope-erasure split that the follow-up PR completes.

- Adds `ErasableAttribute` with XML docs, diagnostic `MS0015 InvalidErasable`, and `SymbolHelper.HasErasable`.
- `IrMemberOrigin.IsDeclaringTypeExternal` is now populated from `HasExternal` OR `HasErasable`, so both attributes trigger the same call-site flatten pass without touching the bridge.
- `IsTranspilable` short-circuits on `[Erasable]` (no `.ts` file emitted) mirroring the existing `[External]` behavior.
- Widens `[External]` targets to `Class | Method | Property | Field` and rewrites its XML docs so class-level and member-level semantics are documented explicitly.
- `[ExportedAsModule]` documentation points to `[Erasable]` as the successor; the runtime attribute stays functional to avoid churning existing samples in this slice.
- ADR-0015 captures the full six-attribute family (`[Erasable]`, `[External]`, `[NoEmit]`, `[Branded]`, `[Constant]`, `[Inline]`) landing across the stack.
- Spec updates: `09-attribute-catalog.md` expands to 25 entries; `10-diagnostic-catalog.md` grows to `MS0001`–`MS0016` with MS0015 (this PR) and MS0013/MS0014/MS0016 reserved for follow-up slices.

## Scope boundary

This is **PR-0a** of the split stack. `[NoEmit]` redefinition (.NET-only painting), DOM-binding migration, and removal of class-level `[External]` flatten (breaking change) are deferred to **PR-0b**. PR-1 (`[Constant]`), PR-2 (`[Branded]` rename of `[InlineWrapper]`), and PR-3 (`[Inline]`) remain as separate PRs per the umbrella plan in #96.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 warning unrelated to this PR)
- [x] `dotnet run --project tests/Metano.Tests/` — **650 tests green, 0 failed** (includes 4 new `ErasableAttributeTranspileTests` covering flatten, no-file, MS0015 non-static, MS0015 Transpile conflict)
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm `IrMemberOrigin.IsDeclaringTypeExternal` OR-population does not leak into non-flatten call sites
- [ ] Reviewer: confirm spec catalog edits match the shipped surface

Part of #96.
Part of #97.