### PR TITLE
feat(core): wire [Erasable] emission pipeline and migrate samples

### DIFF
--- a/samples/SampleCounter/Program.cs
+++ b/samples/SampleCounter/Program.cs
@@ -6,7 +6,7 @@ namespace SampleCounter;
 // `lib/main.dart`, and we don't have a BCL mapping for `Console.WriteLine` on
 // Dart yet — emitting `Console.writeLine(...)` literally would fail
 // `dart analyze`.
-[ExportedAsModule]
+[Erasable]
 [NoEmit(TargetLanguage.Dart)]
 public static class Program
 {

--- a/samples/SampleIssueTracker/Issues/Application/IssueQueries.cs
+++ b/samples/SampleIssueTracker/Issues/Application/IssueQueries.cs
@@ -4,7 +4,7 @@ using SampleIssueTracker.SharedKernel;
 
 namespace SampleIssueTracker.Issues.Application;
 
-[ExportedAsModule]
+[Erasable]
 public static class IssueQueries
 {
     public static IReadOnlyList<Issue> OpenIssues(IReadOnlyList<Issue> issues) =>

--- a/samples/SampleTodo.Service/Program.cs
+++ b/samples/SampleTodo.Service/Program.cs
@@ -2,7 +2,7 @@ using Metano.Annotations;
 using SampleTodo.Service;
 using SampleTodo.Service.Js.Hono;
 
-[ExportedAsModule]
+[Erasable]
 public static class Program
 {
     [ModuleEntryPoint, ExportVarFromBody("app", AsDefault = true, InPlace = false)]

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeGuardBuilder.cs
@@ -40,14 +40,18 @@ public sealed class TypeGuardBuilder(TypeScriptTransformContext context)
     /// accepting <c>unknown</c> from a network handler) where an
     /// exception is the natural failure mode. Returns an empty list when
     /// the type doesn't need a guard (exceptions, ExportedAsModule,
-    /// types with extension members, types imported from external
-    /// modules).
+    /// Erasable, types with extension members, types imported from
+    /// external modules).
     /// </summary>
     public IReadOnlyList<TsFunction> Generate(INamedTypeSymbol type)
     {
         if (TypeTransformer.IsExceptionType(type))
             return [];
-        if (SymbolHelper.HasExportedAsModule(type) || TypeTransformer.HasExtensionMembers(type))
+        if (
+            SymbolHelper.HasExportedAsModule(type)
+            || SymbolHelper.HasErasable(type)
+            || TypeTransformer.HasExtensionMembers(type)
+        )
             return [];
         if (SymbolHelper.HasImport(type))
             return [];

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -304,7 +304,11 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             EmitTopLevelStatements(ir.EntryPoint.Method, sink);
         }
         else if (
-            (SymbolHelper.HasExportedAsModule(type) || HasExtensionMembers(type)) && type.IsStatic
+            (
+                SymbolHelper.HasExportedAsModule(type)
+                || SymbolHelper.HasErasable(type)
+                || HasExtensionMembers(type)
+            ) && type.IsStatic
         )
         {
             TryEmitModuleViaIr(type, sink);

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -462,18 +462,14 @@ public static class SymbolHelper
             return false;
         if (HasNoEmit(symbol))
             return false;
-        // `[External]` and `[Erasable]` are emission-scope "no emit"
-        // in the initial slice. Both mark a static class the
-        // compiler must not produce a .ts file for — runtime-provided
-        // stub vs. compile-time sugar container, respectively. A
-        // follow-up slice introduces per-member emission inside an
-        // `[Erasable]` class (plain bodies projected as top-level
-        // exports); until then every accessible member must be
-        // external, templated, or resolvable at the call site so the
-        // flattened identifier has a defining source.
+        // `[External]` is emission-scope "no emit": the class is a
+        // stub for runtime globals and must never produce a .ts file.
+        // `[Erasable]` participates in transpilation instead — its
+        // members project as top-level exports in a file named after
+        // the class, while static member access flattens at the call
+        // site. Both are kept separate from `[NoEmit]` so the
+        // attribute semantics stay explicit at the source-code layer.
         if (HasExternal(symbol))
-            return false;
-        if (HasErasable(symbol))
             return false;
         if (HasTranspile(symbol))
             return true;

--- a/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ErasableAttributeTranspileTests.cs
@@ -5,10 +5,11 @@ namespace Metano.Tests;
 /// <summary>
 /// Tests for <c>[Erasable]</c> from <c>Metano.Annotations</c>. The
 /// attribute marks a static class whose scope vanishes at the call
-/// site: the class emits no file, static member access flattens to a
-/// bare identifier. Members inside emit per their own attributes.
-/// Covers the flatten, the no-file contract, and the MS0015
-/// validation surface.
+/// site: static member access flattens to a bare identifier and the
+/// class's members project as top-level exports in a file named
+/// after the class (no TypeScript class wrapper). Covers the
+/// flatten, the module-style emission, and the MS0015 validation
+/// surface.
 /// </summary>
 public class ErasableAttributeTranspileTests
 {
@@ -47,28 +48,59 @@ public class ErasableAttributeTranspileTests
     }
 
     [Test]
-    public async Task Erasable_Class_EmitsNoFile()
+    public async Task Erasable_Methods_EmitAsTopLevelExports()
     {
-        // `[Erasable]` classes are compile-time sugar — no .ts file
-        // emits for them even when the class lives in a transpilable
-        // assembly.
+        // Plain methods on an `[Erasable]` static class lower to
+        // top-level `export function` declarations inside a file named
+        // after the class. The TypeScript class wrapper is dropped so
+        // the call-site flatten (`MathUtils.Add` → `add`) references
+        // a defined export.
         var result = TranspileHelper.Transpile(
             """
             using Metano.Annotations;
             [assembly: TranspileAssembly]
 
             [Erasable]
-            public static class Constants
+            public static class MathUtils
             {
-                public static double Pi => 3.14;
+                public static int Add(int a, int b) => a + b;
             }
-
-            public class Placeholder {}
             """
         );
 
-        await Assert.That(result).DoesNotContainKey("constants.ts");
-        await Assert.That(result).ContainsKey("placeholder.ts");
+        await Assert.That(result).ContainsKey("math-utils.ts");
+        var output = result["math-utils.ts"];
+        await Assert.That(output).Contains("export function add(a: number, b: number)");
+        await Assert.That(output).DoesNotContain("class MathUtils");
+    }
+
+    [Test]
+    public async Task Erasable_MethodCall_AccessFlattensAtCallSite()
+    {
+        // `MathUtils.Add(1, 2)` on the C# side lowers to `add(1, 2)`
+        // at the call site — the enclosing class qualifier is dropped
+        // and the generated top-level function is the import target.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Erasable]
+            public static class MathUtils
+            {
+                public static int Add(int a, int b) => a + b;
+            }
+
+            public class Calculator
+            {
+                public int Sum() => MathUtils.Add(1, 2);
+            }
+            """
+        );
+
+        var output = result["calculator.ts"];
+        await Assert.That(output).Contains("add(1, 2)");
+        await Assert.That(output).DoesNotContain("MathUtils.add");
     }
 
     // ─── Diagnostics (MS0015) ────────────────────────────────


### PR DESCRIPTION
## Summary

Second slice of #96 / #97. Completes the shipped [Erasable] surface by giving the attribute a full emission path (plain methods land as top-level `export function` in a file named after the class, no TypeScript class wrapper) and migrates the existing `[ExportedAsModule]` sample callers onto the successor.

## Changes

**Compiler**
- `SymbolHelper.IsTranspilable` no longer short-circuits on `HasErasable`. The PR-0a contract ("no file") was scaffolding; this slice promotes [Erasable] to a real transpiled shape.
- `TypeTransformer` dispatches [Erasable] static classes through `TryEmitModuleViaIr` alongside `[ExportedAsModule]` and extension-only static classes.
- `TypeGuardBuilder` skips guard generation for [Erasable] classes (parity with the existing `[ExportedAsModule]` branch).

**Samples migrated**
- `SampleCounter/Program.cs` → `[Erasable]`
- `SampleTodo.Service/Program.cs` → `[Erasable]`
- `SampleIssueTracker/Issues/Application/IssueQueries.cs` → `[Erasable]`

Generated `.ts` outputs under `targets/js/` are byte-identical to the previous `[ExportedAsModule]` runs (verified locally).

**Tests**
- `ErasableAttributeTranspileTests` now covers the emission contract: `Erasable_Methods_EmitAsTopLevelExports` pins the file-name + `export function` shape; `Erasable_MethodCall_AccessFlattensAtCallSite` pins the call-site lowering.
- The earlier no-file test is dropped (it described the PR-0a scaffolding contract that this slice supersedes).

## Deferred

`ExportedAsModuleAttribute` keeps its `[Obsolete]` marker disabled in this slice. Flipping it on would cascade into 11 test-file call sites that still rely on the attribute for backward-compat coverage; those migrate in a follow-up PR that then re-enables the deprecation.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **650/650 green**, `ErasableAttributeTranspileTests` expanded from 4 → 5 tests
- [x] `cd targets/js/sample-todo-service && bun run build && bun test` — 33/33 green
- [x] `cd targets/js/sample-issue-tracker && bun run build && bun test` — 141/141 green (1 skip unchanged)
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm dispatch changes don't regress `[ExportedAsModule]` behavior
- [ ] Reviewer: confirm sample migrations produce identical generated output

Part of #96.
Part of #97.