### PR TITLE
feat(core): introduce [Constant] attribute for params and fields

### DIFF
--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,7 +1,7 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **22 attribute types** in
+transpilation model. The current codebase exposes **23 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
 annotations. Additional entries tagged *(planned)* below are reserved for the
 upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
@@ -43,7 +43,7 @@ upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
 | `GenerateGuardAttribute` | Generates a runtime `isT` type guard plus a throwing `assertT(value, message?)` companion that wraps it. |
 | `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
 | `ExternalAttribute` (TypeScript) | Marks a `static class` as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier. Attribute usage now accepts method/property/field targets so the family can grow; the per-member declaration-suppression lowering and the split from class-level flatten ship in a follow-up slice. |
-| `ConstantAttribute` *(planned)* | Will mark a parameter or field whose value must be a compile-time constant literal. See ADR-0015. |
+| `ConstantAttribute` | Applied to a parameter or field; the value must be a compile-time constant literal. Violations surface as MS0014 `InvalidConstant`. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
 | `InlineAttribute` *(planned)* | Will apply to a static readonly field, an expression-bodied method / extension, or a static class to request expansion at every use site. See ADR-0015. |
 
 ## Packaging and Interop

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -13,8 +13,8 @@ Each diagnostic carries:
 - optional source location.
 
 The current stable code range is **`MS0001` through `MS0015`**, with
-`MS0013`, `MS0014`, and `MS0016` reserved for the upcoming attribute-family
-slices (see ADR-0015).
+`MS0013` and `MS0016` reserved for the upcoming attribute-family slices
+(see ADR-0015).
 
 ## Stable Codes
 
@@ -32,6 +32,7 @@ slices (see ADR-0015).
 | `MS0010` | `OptionalRequiresNullable` | `[Optional]` was applied to a non-nullable parameter or property. |
 | `MS0011` | `InvalidDiscriminator` | `[Discriminator("FieldName")]` references a field that is missing, not a `[StringEnum]`, or nullable. |
 | `MS0012` | `InvalidExternal` | `[External]` was applied to a non-static class, or combined with `[Transpile]`. |
+| `MS0014` | `InvalidConstant` | `[Constant]` argument or initializer is not a compile-time constant literal. |
 | `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or combined with `[Transpile]`. |
 
 ## Reserved Codes
@@ -44,7 +45,6 @@ stable across the stack, not as a promise of shipped behavior.
 | Code | Symbolic name | Slice |
 | --- | --- | --- |
 | `MS0013` | `NoEmitReferencedByTranspiledCode` | `[NoEmit]` redefinition (painting diagnostic) |
-| `MS0014` | `InvalidConstant` | `[Constant]` validator |
 | `MS0016` | `InvalidInline` | `[Inline]` validator |
 
 ## Product Significance

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -140,6 +140,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ValidateOptionalAttribute(compilation, assemblyWideTranspile, diagnostics);
             ValidateDiscriminatorAttribute(compilation, assemblyWideTranspile, diagnostics);
             ValidateExternalAttribute(compilation, diagnostics);
+            ValidateConstantAttribute(compilation, assemblyWideTranspile, diagnostics);
         }
 
         return new IrCompilation(
@@ -853,6 +854,187 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         foreach (var nested in type.GetTypeMembers())
             VisitTypeForExternal(nested, diagnostics);
+    }
+
+    /// <summary>
+    /// Validates <c>[Constant]</c> from <c>Metano.Annotations</c>.
+    /// Two checks:
+    /// <list type="bullet">
+    ///   <item>Fields decorated with <c>[Constant]</c> must have an
+    ///   initializer that Roslyn recognizes as a compile-time constant
+    ///   (<see cref="IFieldSymbol.HasConstantValue"/> or a
+    ///   <c>readonly</c> initializer resolvable through
+    ///   <see cref="SemanticModel.GetConstantValue(SyntaxNode, CancellationToken)"/>).</item>
+    ///   <item>Every call site whose target method exposes a
+    ///   <c>[Constant]</c> parameter must pass a constant-valued
+    ///   argument in that position.</item>
+    /// </list>
+    /// Both failures raise <c>MS0014 InvalidConstant</c>. The checks
+    /// run once per compilation and span every syntax tree reachable
+    /// from the current assembly so referenced-assembly consumers
+    /// still surface their own violations.
+    /// </summary>
+    private static void ValidateConstantAttribute(
+        Compilation compilation,
+        bool assemblyWideTranspile,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+
+        // Field-level check: decorated field initializer must reduce
+        // to a Roslyn constant.
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type => VisitTypeForConstantFields(type, compilation, diagnostics)
+        );
+
+        // Call-site check: walk every invocation + object-creation
+        // + constructor-initializer across the compilation's syntax
+        // trees and verify args passed to `[Constant]` parameters
+        // are constant-valued.
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var root = tree.GetRoot();
+
+            foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                ValidateConstantCallSite(
+                    invocation.ArgumentList,
+                    semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol,
+                    semanticModel,
+                    diagnostics
+                );
+
+            foreach (
+                var creation in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>()
+            )
+                ValidateConstantCallSite(
+                    creation.ArgumentList,
+                    semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol,
+                    semanticModel,
+                    diagnostics
+                );
+
+            foreach (
+                var creation in root.DescendantNodes()
+                    .OfType<ImplicitObjectCreationExpressionSyntax>()
+            )
+                ValidateConstantCallSite(
+                    creation.ArgumentList,
+                    semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol,
+                    semanticModel,
+                    diagnostics
+                );
+        }
+    }
+
+    private static void VisitTypeForConstantFields(
+        INamedTypeSymbol type,
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        foreach (var member in type.GetMembers())
+        {
+            if (member is not IFieldSymbol field || !field.HasConstant())
+                continue;
+            if (IsFieldInitializerConstant(field, compilation))
+                continue;
+
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Error,
+                    DiagnosticCodes.InvalidConstant,
+                    $"[Constant] on field {FormatMemberPath(field)} requires a compile-time "
+                        + $"constant initializer. Use a literal token, a 'const' local or "
+                        + $"field, or a 'readonly' field whose initializer is itself constant.",
+                    field.Locations.FirstOrDefault()
+                )
+            );
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForConstantFields(nested, compilation, diagnostics);
+    }
+
+    private static bool IsFieldInitializerConstant(IFieldSymbol field, Compilation compilation)
+    {
+        // `const` fields always satisfy the contract — Roslyn only
+        // accepts them when the initializer folds to a primitive.
+        if (field.HasConstantValue)
+            return true;
+
+        // `readonly` fields need a syntax probe: if the declaration's
+        // initializer reduces to a Roslyn constant in its own
+        // SemanticModel, the value is known at compile time and the
+        // attribute's contract is satisfied.
+        foreach (var reference in field.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is not VariableDeclaratorSyntax declarator)
+                continue;
+            if (declarator.Initializer?.Value is not { } initializer)
+                continue;
+            var semanticModel = compilation.GetSemanticModel(declarator.SyntaxTree);
+            if (semanticModel.GetConstantValue(initializer).HasValue)
+                return true;
+        }
+        return false;
+    }
+
+    private static void ValidateConstantCallSite(
+        BaseArgumentListSyntax? argumentList,
+        IMethodSymbol? target,
+        SemanticModel semanticModel,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (argumentList is null || target is null)
+            return;
+        if (!target.Parameters.Any(p => p.HasConstant()))
+            return;
+
+        var arguments = argumentList.Arguments;
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            var argument = arguments[i];
+            var parameter = ResolveParameter(argument, arguments, i, target);
+            if (parameter is null || !parameter.HasConstant())
+                continue;
+            if (semanticModel.GetConstantValue(argument.Expression).HasValue)
+                continue;
+
+            diagnostics.Add(
+                new MetanoDiagnostic(
+                    MetanoDiagnosticSeverity.Error,
+                    DiagnosticCodes.InvalidConstant,
+                    $"Argument passed to [Constant] parameter '{parameter.Name}' of "
+                        + $"{FormatMemberPath(target)} is not a compile-time constant. "
+                        + $"Use a literal, a 'const' local/field, or a 'readonly' field "
+                        + $"whose initializer is itself constant.",
+                    argument.GetLocation()
+                )
+            );
+        }
+    }
+
+    private static IParameterSymbol? ResolveParameter(
+        ArgumentSyntax argument,
+        SeparatedSyntaxList<ArgumentSyntax> arguments,
+        int positionalIndex,
+        IMethodSymbol target
+    )
+    {
+        // Named argument: look the parameter up by its identifier.
+        if (argument.NameColon?.Name.Identifier.ValueText is { } named)
+            return target.Parameters.FirstOrDefault(p => p.Name == named);
+        // Positional argument: map by position, clamping at the last
+        // parameter so variadic (`params`) slots resolve to the array
+        // parameter rather than walking off the end.
+        if (target.Parameters.Length == 0)
+            return null;
+        var index = Math.Min(positionalIndex, target.Parameters.Length - 1);
+        return target.Parameters[index];
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -860,14 +860,24 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     /// Validates <c>[Constant]</c> from <c>Metano.Annotations</c>.
     /// Two checks:
     /// <list type="bullet">
-    ///   <item>Fields decorated with <c>[Constant]</c> must have an
-    ///   initializer that Roslyn recognizes as a compile-time constant
-    ///   (<see cref="IFieldSymbol.HasConstantValue"/> or a
-    ///   <c>readonly</c> initializer resolvable through
-    ///   <see cref="SemanticModel.GetConstantValue(SyntaxNode, CancellationToken)"/>).</item>
+    ///   <item>Fields decorated with <c>[Constant]</c> must be
+    ///   <c>const</c> or <c>static readonly</c> with an initializer
+    ///   Roslyn reduces to a constant
+    ///   (<see cref="IFieldSymbol.HasConstantValue"/> for <c>const</c>,
+    ///   <see cref="SemanticModel.GetConstantValue(SyntaxNode, CancellationToken)"/>
+    ///   applied to the <c>readonly</c> initializer). Mutable fields
+    ///   are rejected so downstream lowering can trust the value.</item>
     ///   <item>Every call site whose target method exposes a
     ///   <c>[Constant]</c> parameter must pass a constant-valued
-    ///   argument in that position.</item>
+    ///   argument. Literal tokens, <c>const</c> fields/locals, and
+    ///   references to a <c>[Constant]</c>-decorated field
+    ///   (validated above) all qualify. Call-site walk covers
+    ///   <see cref="InvocationExpressionSyntax"/>,
+    ///   <see cref="ObjectCreationExpressionSyntax"/>,
+    ///   <see cref="ImplicitObjectCreationExpressionSyntax"/>, and
+    ///   <see cref="ConstructorInitializerSyntax"/>
+    ///   (<c>: this(...)</c> / <c>: base(...)</c>) so every
+    ///   constructor path is covered.</item>
     /// </list>
     /// Both failures raise <c>MS0014 InvalidConstant</c>. The checks
     /// run once per compilation and span every syntax tree reachable
@@ -903,6 +913,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     invocation.ArgumentList,
                     semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol,
                     semanticModel,
+                    compilation,
                     diagnostics
                 );
 
@@ -913,6 +924,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     creation.ArgumentList,
                     semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol,
                     semanticModel,
+                    compilation,
                     diagnostics
                 );
 
@@ -924,6 +936,22 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     creation.ArgumentList,
                     semanticModel.GetSymbolInfo(creation).Symbol as IMethodSymbol,
                     semanticModel,
+                    compilation,
+                    diagnostics
+                );
+
+            // Constructor chaining: `: this(...)` and `: base(...)`
+            // surface as ConstructorInitializerSyntax. The target
+            // constructor's `[Constant]` parameters must still
+            // receive literal-valued args.
+            foreach (
+                var initializer in root.DescendantNodes().OfType<ConstructorInitializerSyntax>()
+            )
+                ValidateConstantCallSite(
+                    initializer.ArgumentList,
+                    semanticModel.GetSymbolInfo(initializer).Symbol as IMethodSymbol,
+                    semanticModel,
+                    compilation,
                     diagnostics
                 );
         }
@@ -946,9 +974,11 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 new MetanoDiagnostic(
                     MetanoDiagnosticSeverity.Error,
                     DiagnosticCodes.InvalidConstant,
-                    $"[Constant] on field {FormatMemberPath(field)} requires a compile-time "
-                        + $"constant initializer. Use a literal token, a 'const' local or "
-                        + $"field, or a 'readonly' field whose initializer is itself constant.",
+                    $"[Constant] on field {FormatMemberPath(field)} requires a 'const' "
+                        + $"field or a 'readonly' field whose initializer is itself a "
+                        + $"compile-time constant (literal token or 'const' reference). "
+                        + $"Mutable fields cannot carry [Constant] — the value must be "
+                        + $"fixed for downstream lowering to trust it.",
                     field.Locations.FirstOrDefault()
                 )
             );
@@ -964,6 +994,13 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         // accepts them when the initializer folds to a primitive.
         if (field.HasConstantValue)
             return true;
+
+        // Mutable fields are rejected. A field that can be reassigned
+        // after construction cannot guarantee a compile-time value at
+        // every read site, which defeats the purpose of [Constant]
+        // as a narrowing/inlining safety net.
+        if (!field.IsReadOnly)
+            return false;
 
         // `readonly` fields need a syntax probe: if the declaration's
         // initializer reduces to a Roslyn constant in its own
@@ -986,6 +1023,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
         BaseArgumentListSyntax? argumentList,
         IMethodSymbol? target,
         SemanticModel semanticModel,
+        Compilation compilation,
         List<MetanoDiagnostic> diagnostics
     )
     {
@@ -1001,7 +1039,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             var parameter = ResolveParameter(argument, arguments, i, target);
             if (parameter is null || !parameter.HasConstant())
                 continue;
-            if (semanticModel.GetConstantValue(argument.Expression).HasValue)
+            if (IsConstantArgument(argument.Expression, semanticModel, compilation))
                 continue;
 
             diagnostics.Add(
@@ -1010,12 +1048,41 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                     DiagnosticCodes.InvalidConstant,
                     $"Argument passed to [Constant] parameter '{parameter.Name}' of "
                         + $"{FormatMemberPath(target)} is not a compile-time constant. "
-                        + $"Use a literal, a 'const' local/field, or a 'readonly' field "
-                        + $"whose initializer is itself constant.",
+                        + $"Use a literal, a 'const' field/local, or a reference to a "
+                        + $"[Constant]-decorated 'readonly' field whose initializer is "
+                        + $"itself constant.",
                     argument.GetLocation()
                 )
             );
         }
+    }
+
+    /// <summary>
+    /// Accepts as "constant" either a Roslyn-reducible expression
+    /// (literal token, <c>const</c> field/local) or a reference to a
+    /// field carrying <c>[Constant]</c>. The second path piggybacks
+    /// on <see cref="IsFieldInitializerConstant"/>: if a
+    /// <c>readonly</c> field qualifies for the field-level
+    /// validation, it is safe to pass on as a <c>[Constant]</c>
+    /// argument. Roslyn's <see cref="SemanticModel.GetConstantValue"/>
+    /// does not fold <c>readonly</c> field references, so the extra
+    /// resolution happens here rather than in the core check.
+    /// </summary>
+    private static bool IsConstantArgument(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        Compilation compilation
+    )
+    {
+        if (semanticModel.GetConstantValue(expression).HasValue)
+            return true;
+        if (
+            semanticModel.GetSymbolInfo(expression).Symbol is IFieldSymbol field
+            && field.HasConstant()
+            && IsFieldInitializerConstant(field, compilation)
+        )
+            return true;
+        return false;
     }
 
     private static IParameterSymbol? ResolveParameter(

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -114,6 +114,20 @@ public static class DiagnosticCodes
     /// "no emission" and "full emission", which are incompatible.</summary>
     public const string InvalidExternal = "MS0012";
 
+    /// <summary>MS0014 — <c>[Constant]</c> (from
+    /// <c>Metano.Annotations</c>) was applied to a parameter whose
+    /// call-site argument is not a compile-time constant literal, or
+    /// to a field whose initializer is not a compile-time constant
+    /// literal. The attribute's contract requires the value to be
+    /// reducible by the C# compiler (literal token, <c>const</c>
+    /// local/field, or a <c>readonly</c> field whose initializer is
+    /// itself a constant). Method calls, mutable variables, and any
+    /// expression whose value depends on runtime state are rejected
+    /// so downstream lowering (<c>[Emit]</c> templates,
+    /// <c>[Inline]</c> expansion) can substitute the literal form
+    /// without a separate analyzer pass.</summary>
+    public const string InvalidConstant = "MS0014";
+
     /// <summary>MS0015 — <c>[Erasable]</c> (from
     /// <c>Metano.Annotations</c>) was applied to a non-static class,
     /// or combined with <c>[Transpile]</c>. The attribute marks a

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -116,16 +116,16 @@ public static class DiagnosticCodes
 
     /// <summary>MS0014 — <c>[Constant]</c> (from
     /// <c>Metano.Annotations</c>) was applied to a parameter whose
-    /// call-site argument is not a compile-time constant literal, or
-    /// to a field whose initializer is not a compile-time constant
-    /// literal. The attribute's contract requires the value to be
-    /// reducible by the C# compiler (literal token, <c>const</c>
-    /// local/field, or a <c>readonly</c> field whose initializer is
-    /// itself a constant). Method calls, mutable variables, and any
-    /// expression whose value depends on runtime state are rejected
-    /// so downstream lowering (<c>[Emit]</c> templates,
-    /// <c>[Inline]</c> expansion) can substitute the literal form
-    /// without a separate analyzer pass.</summary>
+    /// call-site argument is not a compile-time constant, or to a
+    /// field that cannot carry the attribute. Parameters accept
+    /// Roslyn <c>ConstantValue</c> expressions (literal,
+    /// <c>const</c> field/local) and references to another
+    /// <c>[Constant]</c>-decorated field whose own initializer has
+    /// been validated. Fields must be <c>const</c> or
+    /// <c>readonly</c> with a literal-reducible initializer; mutable
+    /// fields are rejected so downstream lowering (<c>[Emit]</c>
+    /// templates, <c>[Inline]</c> expansion) can substitute the
+    /// literal form without a separate analyzer pass.</summary>
     public const string InvalidConstant = "MS0014";
 
     /// <summary>MS0015 — <c>[Erasable]</c> (from

--- a/src/Metano.Compiler/Extraction/IrClassExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrClassExtractor.cs
@@ -341,7 +341,8 @@ public static class IrClassExtractor
             field.IsStatic,
             IrTypeRefMapper.Map(field.Type, originResolver, target),
             IsReadonly: field.IsReadOnly,
-            Initializer: initializer
+            Initializer: initializer,
+            IsConstant: field.HasConstant()
         )
         {
             Attributes = IrAttributeExtractor.Extract(field),

--- a/src/Metano.Compiler/Extraction/IrConstructorExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrConstructorExtractor.cs
@@ -82,7 +82,8 @@ public static class IrConstructorExtractor
                         IrTypeRefMapper.Map(p.Type, originResolver),
                         p.HasExplicitDefaultValue,
                         ExtractDefaultValue(p, compilation, originResolver),
-                        IsOptional: p.HasOptional()
+                        IsOptional: p.HasOptional(),
+                        IsConstant: p.HasConstant()
                     ),
                     promotion,
                     PromotedVisibility: promotedVisibility,

--- a/src/Metano.Compiler/Extraction/IrInterfaceExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrInterfaceExtractor.cs
@@ -98,7 +98,8 @@ public static class IrInterfaceExtractor
             .Parameters.Select(p => new IrParameter(
                 p.Name,
                 IrTypeRefMapper.Map(p.Type, originResolver),
-                IsOptional: p.HasOptional()
+                IsOptional: p.HasOptional(),
+                IsConstant: p.HasConstant()
             ))
             .ToList();
 

--- a/src/Metano.Compiler/Extraction/IrMethodExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrMethodExtractor.cs
@@ -31,7 +31,8 @@ public static class IrMethodExtractor
                 IrTypeRefMapper.Map(p.Type, originResolver),
                 HasDefaultValue: p.HasExplicitDefaultValue,
                 DefaultValue: ExtractDefaultValue(p, compilation, originResolver),
-                IsOptional: p.HasOptional()
+                IsOptional: p.HasOptional(),
+                IsConstant: p.HasConstant()
             ))
             .ToList();
 

--- a/src/Metano.Compiler/Extraction/IrModuleFunctionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrModuleFunctionExtractor.cs
@@ -148,7 +148,8 @@ public static class IrModuleFunctionExtractor
         var parameters = prop
             .Parameters.Select(p => new IrParameter(
                 p.Name,
-                IrTypeRefMapper.Map(p.Type, originResolver)
+                IrTypeRefMapper.Map(p.Type, originResolver),
+                IsConstant: p.HasConstant()
             ))
             .ToList();
 
@@ -241,7 +242,8 @@ public static class IrModuleFunctionExtractor
                 p.Name,
                 IrTypeRefMapper.Map(p.Type, originResolver),
                 HasDefaultValue: p.HasExplicitDefaultValue,
-                DefaultValue: ExtractDefaultValue(p, compilation, originResolver)
+                DefaultValue: ExtractDefaultValue(p, compilation, originResolver),
+                IsConstant: p.HasConstant()
             ))
         );
 
@@ -338,7 +340,8 @@ public static class IrModuleFunctionExtractor
                 p.Name,
                 IrTypeRefMapper.Map(p.Type, originResolver),
                 HasDefaultValue: p.HasExplicitDefaultValue,
-                DefaultValue: ExtractDefaultValue(p, compilation, originResolver)
+                DefaultValue: ExtractDefaultValue(p, compilation, originResolver),
+                IsConstant: p.HasConstant()
             ))
             .ToList();
 

--- a/src/Metano.Compiler/IR/IrMemberDeclaration.cs
+++ b/src/Metano.Compiler/IR/IrMemberDeclaration.cs
@@ -60,7 +60,8 @@ public sealed record IrFieldDeclaration(
     IrTypeRef Type,
     bool IsReadonly,
     IrExpression? Initializer = null,
-    bool IsCapturedByCtor = false
+    bool IsCapturedByCtor = false,
+    bool IsConstant = false
 ) : IrMemberDeclaration(Name, Visibility, IsStatic);
 
 /// <summary>

--- a/src/Metano.Compiler/IR/IrParameter.cs
+++ b/src/Metano.Compiler/IR/IrParameter.cs
@@ -22,6 +22,14 @@ namespace Metano.Compiler.IR;
 /// requires the parameter to already be nullable — the extractor
 /// emits <c>MS0010</c> for <c>[Optional]</c> on a non-nullable
 /// type.</param>
+/// <param name="IsConstant">Whether the parameter carries
+/// <c>[Constant]</c> (from <c>Metano.Annotations</c>). When
+/// <c>true</c>, every call-site argument must be a compile-time
+/// constant literal; the frontend validator emits <c>MS0014</c> for
+/// violations. Downstream lowering (<c>[Emit]</c> templates,
+/// <c>[Inline]</c> expansion) relies on the flag to guarantee the
+/// value is reducible to a literal without a separate analyzer
+/// pass.</param>
 public sealed record IrParameter(
     string Name,
     IrTypeRef Type,
@@ -29,5 +37,6 @@ public sealed record IrParameter(
     IrExpression? DefaultValue = null,
     bool IsParams = false,
     bool HasExplicitType = true,
-    bool IsOptional = false
+    bool IsOptional = false,
+    bool IsConstant = false
 );

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -248,6 +248,23 @@ public static class SymbolHelper
             );
 
     /// <summary>
+    /// Reads <c>[Constant]</c> from <c>Metano.Annotations</c>. Marks
+    /// a parameter or field whose value must be a compile-time
+    /// constant literal. Used by downstream lowering
+    /// (<c>[Emit]</c> / <c>[Inline]</c>) to guarantee the value is
+    /// known at compile time. Namespace-qualified match so unrelated
+    /// <c>[Constant]</c> attributes from other libraries are not
+    /// mistaken for the Metano variant.
+    /// </summary>
+    public static bool HasConstant(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is ("ConstantAttribute" or "Constant")
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString() == "Metano.Annotations"
+            );
+
+    /// <summary>
     /// Reads <c>[Erasable]</c> from <c>Metano.Annotations</c>. Static
     /// class whose scope vanishes at every call site — no
     /// <c>.ts</c> file, and static member access drops the enclosing

--- a/src/Metano/Annotations/ConstantAttribute.cs
+++ b/src/Metano/Annotations/ConstantAttribute.cs
@@ -1,0 +1,32 @@
+namespace Metano.Annotations;
+
+/// <summary>
+/// Marks a parameter or field whose value must be a compile-time
+/// constant literal. On a parameter, every argument passed at the
+/// call site must resolve to a Roslyn <c>ConstantValue</c>; on a
+/// field, the initializer expression must do the same. Violations
+/// surface as <c>MS0014 InvalidConstant</c>.
+/// <para>
+/// The attribute exists so downstream lowering (<c>[Emit]</c>
+/// templates with literal-only substitution, <c>[Inline]</c>
+/// expansion that needs the caller's value in source form) can
+/// rely on the value being known at compile time without a
+/// separate analyzer pass.
+/// </para>
+/// <para>
+/// Constant propagation follows the Roslyn contract: literal
+/// tokens (<c>"div"</c>, <c>42</c>, <c>true</c>), <c>const</c> locals
+/// and fields, and <c>readonly</c> fields whose initializer is
+/// itself a constant are all accepted. Method calls, variables
+/// without <c>const</c> or <c>readonly</c> modifiers, and any
+/// expression whose value is not reducible by the C# compiler are
+/// rejected.
+/// </para>
+/// <para>
+/// <c>[Constant]</c> lives in <see cref="Metano.Annotations"/>
+/// because the semantic (compile-time literal value) is meaningful
+/// for every target; per-target consumers layer on top.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field, Inherited = false)]
+public sealed class ConstantAttribute : Attribute;

--- a/src/Metano/Annotations/ConstantAttribute.cs
+++ b/src/Metano/Annotations/ConstantAttribute.cs
@@ -2,25 +2,38 @@ namespace Metano.Annotations;
 
 /// <summary>
 /// Marks a parameter or field whose value must be a compile-time
-/// constant literal. On a parameter, every argument passed at the
-/// call site must resolve to a Roslyn <c>ConstantValue</c>; on a
-/// field, the initializer expression must do the same. Violations
-/// surface as <c>MS0014 InvalidConstant</c>.
+/// constant literal. Violations surface as <c>MS0014
+/// InvalidConstant</c>.
+/// <para>
+/// <b>Parameter contract.</b> Every argument passed at the call
+/// site must resolve to one of:
+/// </para>
+/// <list type="bullet">
+///   <item>A Roslyn <c>ConstantValue</c> expression (literal token,
+///   <c>const</c> local, <c>const</c> field).</item>
+///   <item>A reference to another <c>[Constant]</c>-decorated field
+///   whose own initializer has already been validated.</item>
+/// </list>
+/// <para>
+/// References to ordinary <c>readonly</c> fields are <b>not</b>
+/// accepted — Roslyn does not treat them as constant expressions,
+/// and the transpiler refuses to chase the initializer without the
+/// explicit <c>[Constant]</c> attribute on the source field.
+/// </para>
+/// <para>
+/// <b>Field contract.</b> The decorated field must be <c>const</c>
+/// or <c>readonly</c> and carry an initializer that Roslyn reduces
+/// to a constant (literal token or <c>const</c> reference). Mutable
+/// fields are rejected: if the value can be reassigned after
+/// construction, downstream lowering cannot trust it as a compile-time
+/// literal.
+/// </para>
 /// <para>
 /// The attribute exists so downstream lowering (<c>[Emit]</c>
 /// templates with literal-only substitution, <c>[Inline]</c>
 /// expansion that needs the caller's value in source form) can
 /// rely on the value being known at compile time without a
 /// separate analyzer pass.
-/// </para>
-/// <para>
-/// Constant propagation follows the Roslyn contract: literal
-/// tokens (<c>"div"</c>, <c>42</c>, <c>true</c>), <c>const</c> locals
-/// and fields, and <c>readonly</c> fields whose initializer is
-/// itself a constant are all accepted. Method calls, variables
-/// without <c>const</c> or <c>readonly</c> modifiers, and any
-/// expression whose value is not reducible by the C# compiler are
-/// rejected.
 /// </para>
 /// <para>
 /// <c>[Constant]</c> lives in <see cref="Metano.Annotations"/>

--- a/tests/Metano.Tests/ConstantAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ConstantAttributeTranspileTests.cs
@@ -1,0 +1,239 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[Constant]</c> from <c>Metano.Annotations</c>. The
+/// attribute enforces that decorated parameters receive compile-time
+/// constant arguments and decorated fields are initialized with
+/// compile-time constants. Violations surface as MS0014
+/// InvalidConstant. Covers both validation surfaces plus the happy
+/// paths (literal, `const` local/field, `readonly` constant-reducible
+/// field).
+/// </summary>
+public class ConstantAttributeTranspileTests
+{
+    // ─── Parameter validator — positive paths ────────────────
+
+    [Test]
+    public async Task Constant_Parameter_LiteralArgument_Passes()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public void Run() => Runtime.Use("div");
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Constant_Parameter_ConstField_Passes()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                private const string Tag = "div";
+                public void Run() => Runtime.Use(Tag);
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    // ─── Parameter validator — negative paths ────────────────
+
+    [Test]
+    public async Task Constant_Parameter_Variable_EmitsMs0014()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public void Run(string tag) => Runtime.Use(tag);
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+        await Assert.That(ms0014!.Message).Contains("'tag'");
+    }
+
+    [Test]
+    public async Task Constant_Parameter_MethodCall_EmitsMs0014()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public string Compute() => "x";
+                public void Run() => Runtime.Use(Compute());
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+    }
+
+    // ─── Parameter validator — named + positional ────────────
+
+    [Test]
+    public async Task Constant_Parameter_NamedArgument_ResolvesCorrectParameter()
+    {
+        // When the caller uses a named argument, the validator must
+        // resolve the parameter by name rather than position so the
+        // `[Constant]` contract is enforced on the right arg.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Runtime
+            {
+                public static void Use(string loose, [Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public void Run(string runtimeValue) =>
+                    Runtime.Use(loose: runtimeValue, tag: "div");
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    // ─── Field validator ─────────────────────────────────────
+
+    [Test]
+    public async Task Constant_Field_LiteralInitializer_Passes()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public class Tags
+            {
+                [Constant] public static readonly string Div = "div";
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Constant_Field_NonConstantInitializer_EmitsMs0014()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public class Tags
+            {
+                public static string Compute() => "div";
+                [Constant] public static readonly string Div = Compute();
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+        await Assert.That(ms0014!.Message).Contains("Div");
+    }
+
+    // ─── Constructor call site ───────────────────────────────
+
+    [Test]
+    public async Task Constant_ConstructorParameter_LiteralArgument_Passes()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public readonly record struct Tag([Constant] string Value);
+
+            public class Caller
+            {
+                public Tag Make() => new Tag("div");
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Constant_ConstructorParameter_Variable_EmitsMs0014()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public readonly record struct Tag([Constant] string Value);
+
+            public class Caller
+            {
+                public Tag Make(string runtimeValue) => new Tag(runtimeValue);
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+    }
+}

--- a/tests/Metano.Tests/ConstantAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ConstantAttributeTranspileTests.cs
@@ -236,4 +236,145 @@ public class ConstantAttributeTranspileTests
         var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
         await Assert.That(ms0014).IsNotNull();
     }
+
+    // ─── Field chain-of-trust ─────────────────────────────────
+
+    [Test]
+    public async Task Constant_Parameter_ConstantReadonlyField_Passes()
+    {
+        // A reference to a `[Constant]`-decorated readonly field
+        // with a literal initializer is accepted as a constant arg
+        // (chain of trust — the field's own validation already ran).
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Tags
+            {
+                [Constant] public static readonly string Div = "div";
+            }
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public void Run() => Runtime.Use(Tags.Div);
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Constant_Parameter_UndecoratedReadonlyField_EmitsMs0014()
+    {
+        // A plain `readonly` field (no `[Constant]` on the source)
+        // is rejected even when its initializer is a literal —
+        // Roslyn does not fold the reference and the transpiler
+        // refuses to chase the initializer without the explicit
+        // attribute on the source field.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Tags
+            {
+                public static readonly string Div = "div";
+            }
+
+            public static class Runtime
+            {
+                public static void Use([Constant] string tag) {}
+            }
+
+            public class Caller
+            {
+                public void Run() => Runtime.Use(Tags.Div);
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+    }
+
+    // ─── Field mutability ─────────────────────────────────────
+
+    [Test]
+    public async Task Constant_Field_MutableField_EmitsMs0014()
+    {
+        // A mutable field cannot carry `[Constant]` — the value
+        // might be reassigned later and downstream lowering cannot
+        // trust the compile-time reading. Even with a literal
+        // initializer the field fails MS0014.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Tags
+            {
+                [Constant] public static string Div = "div";
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+        await Assert.That(ms0014!.Message).Contains("Div");
+    }
+
+    // ─── Constructor initializer walk ─────────────────────────
+
+    [Test]
+    public async Task Constant_ConstructorInitializer_ThisCall_LiteralArgument_Passes()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public class Caller
+            {
+                public Caller([Constant] string tag) {}
+                public Caller() : this("div") {}
+            }
+            """
+        );
+
+        await Assert
+            .That(diagnostics.Any(d => d.Code == DiagnosticCodes.InvalidConstant))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task Constant_ConstructorInitializer_ThisCall_Variable_EmitsMs0014()
+    {
+        // `: this(...)` chaining with a non-constant arg must still
+        // surface MS0014 — the walk covers ConstructorInitializerSyntax
+        // alongside invocation/object-creation nodes.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public class Caller
+            {
+                public Caller([Constant] string tag) {}
+                public Caller(int _, string runtimeValue) : this(runtimeValue) {}
+            }
+            """
+        );
+
+        var ms0014 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidConstant);
+        await Assert.That(ms0014).IsNotNull();
+    }
 }


### PR DESCRIPTION
## Summary

Third slice of the attribute-family stack tracked under #96. Introduces `[Constant]` (Metano.Annotations) and its frontend validator — enforces that decorated parameters receive compile-time constant arguments and decorated fields have compile-time constant initializers.

## Changes

**Surface**
- `ConstantAttribute` (`AttributeTargets.Parameter | Field`) with XML docs describing the Roslyn `ConstantValue` contract.
- `DiagnosticCodes.InvalidConstant` (MS0014) — promoted from reserved to shipped.
- `SymbolHelper.HasConstant` namespace-qualified against `Metano.Annotations`.

**IR**
- `IrParameter.IsConstant` threaded through every construction site (method / interface / module / constructor / extension extractors).
- `IrFieldDeclaration.IsConstant` populated in `IrClassExtractor`.

**Validator** (`CSharpSourceFrontend.ValidateConstantAttribute`)
- Field-level: decorated fields must have an initializer resolvable by `SemanticModel.GetConstantValue`. `const` fields always qualify; `readonly` fields whose initializer folds to a Roslyn constant also pass.
- Call-site: walks every `InvocationExpression`, `ObjectCreationExpression`, and `ImplicitObjectCreationExpression` across the compilation's syntax trees. Resolves the target method symbol, locates `[Constant]` parameters, verifies the matching argument's `GetConstantValue` is reducible. Named arguments resolve by name; positional arguments map by index with variadic clamping.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **660/660 green**, 9 new `ConstantAttributeTranspileTests`:
  - Positive: literal, `const` field, named-arg, field literal initializer, ctor literal argument
  - Negative: variable, method call, non-constant field initializer, ctor variable argument
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the `ImplicitObjectCreationExpression` walk catches C# 9+ target-typed `new(...)` call sites
- [ ] Reviewer: confirm named-argument resolution maps correctly when a `[Constant]` parameter is reached via positional arg that skips over an earlier optional

## Spec

- `09-attribute-catalog.md`: `ConstantAttribute` promoted from *(planned)* to shipped, attribute count 22 → 23.
- `10-diagnostic-catalog.md`: MS0014 moved from Reserved Codes to Stable Codes.

Part of #96.
Part of #98.