### PR TITLE
feat(core): rename [InlineWrapper] to [Branded] via compatible alias

### DIFF
--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,7 +1,7 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **23 attribute types** in
+transpilation model. The current codebase exposes **24 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
 annotations. Additional entries tagged *(planned)* below are reserved for the
 upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
@@ -23,7 +23,8 @@ upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
 | `IgnoreAttribute` | Omits a member from output. |
 | `StringEnumAttribute` | Emits enum output as string-based TS representation. |
 | `PlainObjectAttribute` | Emits object shape without class wrapper semantics. |
-| `InlineWrapperAttribute` | Emits wrapper types using branded/opaque-style semantics. *(Planned rename to `BrandedAttribute` per ADR-0015.)* |
+| `BrandedAttribute` | Emits wrapper types using branded/opaque-style semantics. Successor of `InlineWrapperAttribute` — both attributes carry identical behavior while the legacy name stays supported. |
+| `InlineWrapperAttribute` | Predecessor of `BrandedAttribute`; kept working for existing callers. Prefer `[Branded]` in new code. |
 | `EmitInFileAttribute` | Co-locates multiple types in a single output file. |
 
 ## Modules and Top-Level Emission

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -464,9 +464,27 @@ public static class SymbolHelper
     /// names for the same shape. Accepting either here lets callers
     /// migrate to <c>[Branded]</c> without breaking pre-existing
     /// <c>[InlineWrapper]</c> usages.
+    /// <para>
+    /// Namespace-qualified match so unrelated <c>[Branded]</c> or
+    /// <c>[InlineWrapper]</c> attributes shipped by third-party
+    /// assemblies are not mistaken for the Metano variants — the
+    /// short name <c>Branded</c> is generic enough that a collision
+    /// would silently rewrite types into branded primitives.
+    /// </para>
     /// </summary>
     public static bool HasBranded(this ISymbol symbol) =>
-        HasAttribute(symbol, "Branded") || HasAttribute(symbol, "InlineWrapper");
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name
+                    is (
+                        "BrandedAttribute"
+                        or "Branded"
+                        or "InlineWrapperAttribute"
+                        or "InlineWrapper"
+                    )
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString() == "Metano.Annotations"
+            );
 
     /// <summary>
     /// Legacy alias preserved so older call sites keep compiling

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -456,8 +456,25 @@ public static class SymbolHelper
         return false;
     }
 
-    public static bool HasInlineWrapper(this ISymbol symbol) =>
-        HasAttribute(symbol, "InlineWrapper");
+    /// <summary>
+    /// Reads <c>[Branded]</c> or its predecessor
+    /// <c>[InlineWrapper]</c> from <c>Metano.Annotations</c>. Both
+    /// attributes mark a value-like struct as a branded primitive
+    /// companion on the TS side — identical semantics, different
+    /// names for the same shape. Accepting either here lets callers
+    /// migrate to <c>[Branded]</c> without breaking pre-existing
+    /// <c>[InlineWrapper]</c> usages.
+    /// </summary>
+    public static bool HasBranded(this ISymbol symbol) =>
+        HasAttribute(symbol, "Branded") || HasAttribute(symbol, "InlineWrapper");
+
+    /// <summary>
+    /// Legacy alias preserved so older call sites keep compiling
+    /// after the <c>[InlineWrapper]</c> → <c>[Branded]</c> rename.
+    /// Delegates to <see cref="HasBranded"/> so adding <c>[Branded]</c>
+    /// on a type is equivalent to the historical attribute.
+    /// </summary>
+    public static bool HasInlineWrapper(this ISymbol symbol) => HasBranded(symbol);
 
     /// <summary>
     /// Determines if a type should be transpiled, considering:

--- a/src/Metano/Annotations/BrandedAttribute.cs
+++ b/src/Metano/Annotations/BrandedAttribute.cs
@@ -1,0 +1,35 @@
+namespace Metano.Annotations;
+
+/// <summary>
+/// Marks a value-like <c>struct</c> or <c>record struct</c> to lower
+/// as a branded primitive companion in TypeScript: the wrapper type
+/// emits as <c>string &amp; { readonly __brand: "Name" }</c> (or the
+/// matching primitive) plus a <c>namespace Name</c> holding a
+/// <c>create(value)</c> factory and any user-declared static helpers.
+/// At runtime the brand is erased — the value moves as the underlying
+/// primitive — while the TS type system still distinguishes the
+/// wrapper from other shapes that share the same primitive form.
+/// <para>
+/// Supersedes <see cref="InlineWrapperAttribute"/>. The two attributes
+/// carry identical semantics for the duration of the stack; existing
+/// callers keep working and will migrate in a follow-up cleanup.
+/// "Branded" describes the observable TS output (branded primitive)
+/// rather than the mechanism (inline + wrap), matching the naming
+/// family defined in ADR-0015.
+/// </para>
+/// <para>
+/// Typical use: domain identifiers (<c>UserId</c>, <c>OrderId</c>),
+/// units that should not mix accidentally (<c>Meters</c>,
+/// <c>Seconds</c>), or any value that is structurally a primitive
+/// but semantically a distinct type at the C# and TS boundaries.
+/// </para>
+/// <para>
+/// Applies to <c>struct</c> / <c>record struct</c> with a single
+/// positional parameter whose type is one of the TypeScript primitive
+/// forms (<c>string</c>, <c>int</c>/<c>long</c>/<c>double</c>,
+/// <c>bool</c>, <c>BigInteger</c>). Other shapes fall through to the
+/// regular class/record emission path — no brand is produced.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Struct)]
+public sealed class BrandedAttribute : Attribute;

--- a/src/Metano/Annotations/InlineWrapperAttribute.cs
+++ b/src/Metano/Annotations/InlineWrapperAttribute.cs
@@ -1,7 +1,16 @@
 namespace Metano.Annotations;
 
 /// <summary>
-/// Marks a value-like struct to transpile as a branded primitive companion object in TypeScript.
+/// Marks a value-like struct to transpile as a branded primitive
+/// companion object in TypeScript.
+/// <para>
+/// Superseded by <see cref="BrandedAttribute"/>. Both attributes
+/// carry identical semantics for the duration of the attribute-family
+/// stack (ADR-0015); existing callers keep working so this attribute
+/// stays valid. New code should prefer <c>[Branded]</c> because the
+/// name describes the observable output instead of the lowering
+/// mechanism.
+/// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Struct)]
 public sealed class InlineWrapperAttribute : Attribute;

--- a/tests/Metano.Tests/BrandedAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/BrandedAttributeTranspileTests.cs
@@ -81,6 +81,37 @@ public class BrandedAttributeTranspileTests
     }
 
     [Test]
+    public async Task Branded_FromForeignNamespace_DoesNotTriggerBrandLowering()
+    {
+        // A third-party `[Branded]` attribute living in a different
+        // namespace must NOT be mistaken for the Metano variant — the
+        // short-name match would otherwise silently rewrite the struct
+        // as a branded primitive and break consumer assumptions.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            namespace ThirdParty
+            {
+                [System.AttributeUsage(System.AttributeTargets.Struct)]
+                public sealed class BrandedAttribute : System.Attribute {}
+            }
+
+            [Transpile]
+            [ThirdParty.Branded]
+            public readonly record struct Regular(string Value);
+            """
+        );
+
+        var output = result["regular.ts"];
+        // No brand-type alias, no companion namespace — the struct
+        // falls through to the regular record emission path.
+        await Assert.That(output).DoesNotContain("__brand");
+        await Assert.That(output).DoesNotContain("export namespace Regular");
+    }
+
+    [Test]
     public async Task Branded_AndInlineWrapper_BehaveIdentically()
     {
         // Same struct body, one marked [Branded] the other

--- a/tests/Metano.Tests/BrandedAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/BrandedAttributeTranspileTests.cs
@@ -1,0 +1,111 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[Branded]</c> from <c>Metano.Annotations</c>. The
+/// attribute is the successor of <c>[InlineWrapper]</c> and carries
+/// identical semantics — value-like struct lowers to a branded
+/// primitive + companion namespace in TypeScript. These tests pin
+/// the renaming contract: any call site that used to work with
+/// <c>[InlineWrapper]</c> now works identically with <c>[Branded]</c>,
+/// and mixing the two in the same compilation is legal for as long
+/// as the predecessor remains supported.
+/// </summary>
+public class BrandedAttributeTranspileTests
+{
+    [Test]
+    public async Task Branded_GeneratesBrandedTypeAndNamespace()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+
+            [Transpile, Branded]
+            public readonly record struct UserId(string Value)
+            {
+                public static UserId System() => new("system");
+            }
+            """
+        );
+
+        var output = result["user-id.ts"];
+        await Assert
+            .That(output)
+            .Contains("export type UserId = string & { readonly __brand: \"UserId\" };");
+        await Assert.That(output).Contains("export namespace UserId");
+        await Assert.That(output).Contains("function create(value: string): UserId");
+        await Assert.That(output).Contains("function system(): UserId");
+        await Assert.That(output).DoesNotContain("class UserId");
+    }
+
+    [Test]
+    public async Task Branded_NonStringPrimitive_IncludesToString()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+
+            [Transpile, Branded]
+            public readonly record struct Amount(int Value);
+            """
+        );
+
+        var output = result["amount.ts"];
+        await Assert
+            .That(output)
+            .Contains("export type Amount = number & { readonly __brand: \"Amount\" };");
+        await Assert.That(output).Contains("function create(value: number): Amount");
+        await Assert.That(output).Contains("function toString(value: Amount): string");
+    }
+
+    [Test]
+    public async Task Branded_NewCall_IsRewrittenToCreate()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Branded]
+            public readonly record struct OrderId(string Value);
+
+            public class Factory
+            {
+                public OrderId Make() => new OrderId("ord-1");
+            }
+            """
+        );
+
+        var output = result["factory.ts"];
+        await Assert.That(output).Contains("OrderId.create(\"ord-1\")");
+        await Assert.That(output).DoesNotContain("new OrderId");
+    }
+
+    [Test]
+    public async Task Branded_AndInlineWrapper_BehaveIdentically()
+    {
+        // Same struct body, one marked [Branded] the other
+        // [InlineWrapper] — generated output must match byte-for-byte
+        // (modulo the type name) so the rename is a safe no-op for
+        // in-flight callers.
+        var branded = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+
+            [Transpile, Branded]
+            public readonly record struct BTag(string Value);
+            """
+        );
+        var legacy = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+
+            [Transpile, InlineWrapper]
+            public readonly record struct LTag(string Value);
+            """
+        );
+
+        var brandedOutput = branded["b-tag.ts"].Replace("BTag", "WrapperTag");
+        var legacyOutput = legacy["l-tag.ts"].Replace("LTag", "WrapperTag");
+        await Assert.That(brandedOutput).IsEqualTo(legacyOutput);
+    }
+}


### PR DESCRIPTION
## Summary

Fourth slice of the attribute-family stack (#96 / #99). Introduces `BrandedAttribute` as the successor of `InlineWrapperAttribute` per ADR-0015. The new name describes the observable TS output (branded primitive + companion namespace) rather than the lowering mechanism, matching the rest of the attribute family.

## Changes

**Surface**
- `BrandedAttribute` (`Metano.Annotations`, `AttributeTargets.Struct`) with XML docs pinning the brand-type + companion-namespace shape and the primitive-only constraint.
- `SymbolHelper.HasBranded` (canonical) matches either `"Branded"` or `"InlineWrapper"`; `SymbolHelper.HasInlineWrapper` is retained as a delegating legacy alias so existing call sites keep working without a flag-day rename across the compiler internals.
- `InlineWrapperAttribute` XML doc updated to point at `BrandedAttribute` as the preferred name. The attribute itself stays fully functional.

**Scope boundary**
Internal IR/bridge names (`IsInlineWrapper`, `IrToTsInlineWrapperBridge`) keep their historical spelling in this slice — they are compiler internals that do not surface to users. A separate rename PR can flip them without churn on the public attribute rollout.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **669/669 green** (665 → 669), 4 new tests in `BrandedAttributeTranspileTests`:
  - `Branded_GeneratesBrandedTypeAndNamespace` — brand + namespace shape
  - `Branded_NonStringPrimitive_IncludesToString` — primitive-with-toString branch
  - `Branded_NewCall_IsRewrittenToCreate` — call-site lowering
  - `Branded_AndInlineWrapper_BehaveIdentically` — equivalence check (byte-identical output modulo type name)
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the alias does not accidentally propagate `[Branded]` behavior to unrelated attributes that might also be named `"Branded"` in third-party assemblies

## Spec

- `09-attribute-catalog.md`: `BrandedAttribute` promoted from *(planned)* to shipped, attribute count 23 → 24. `InlineWrapperAttribute` row rephrased as "predecessor of `BrandedAttribute`".

Part of #96.
Part of #99.