### PR TITLE
feat(core): introduce [Inline] attribute for fields and properties

### DIFF
--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,10 +1,9 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **24 attribute types** in
+transpilation model. The current codebase exposes **25 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
-annotations. Additional entries tagged *(planned)* below are reserved for the
-upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
+annotations.
 
 ## Type Selection and Inclusion
 
@@ -45,7 +44,7 @@ upcoming attribute-family slices (see ADR-0015) and are not yet shipped.
 | `DiscriminatorAttribute` (TypeScript) | Names a `[StringEnum]` field as the discriminator; the generated `isT` short-circuits on a literal comparison against the type name before walking the remaining shape. |
 | `ExternalAttribute` (TypeScript) | Marks a `static class` as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier. Attribute usage now accepts method/property/field targets so the family can grow; the per-member declaration-suppression lowering and the split from class-level flatten ship in a follow-up slice. |
 | `ConstantAttribute` | Applied to a parameter or field; the value must be a compile-time constant literal. Violations surface as MS0014 `InvalidConstant`. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
-| `InlineAttribute` *(planned)* | Will apply to a static readonly field, an expression-bodied method / extension, or a static class to request expansion at every use site. See ADR-0015. |
+| `InlineAttribute` | Applied to a `static readonly` field or a `static` property with an expression-bodied getter; every reference substitutes the member's initializer (or getter expression) at the call site. Method / extension inlining and static-class propagation ship in a follow-up slice. Violations surface as MS0016 `InvalidInline`. |
 
 ## Packaging and Interop
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,8 +12,8 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0015`**, with
-`MS0013` and `MS0016` reserved for the upcoming attribute-family slices
+The current stable code range is **`MS0001` through `MS0016`**, with
+`MS0013` reserved for the upcoming `[NoEmit]` redefinition slice
 (see ADR-0015).
 
 ## Stable Codes
@@ -34,6 +34,7 @@ The current stable code range is **`MS0001` through `MS0015`**, with
 | `MS0012` | `InvalidExternal` | `[External]` was applied to a non-static class, or combined with `[Transpile]`. |
 | `MS0014` | `InvalidConstant` | `[Constant]` argument or initializer is not a compile-time constant literal. |
 | `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or combined with `[Transpile]`. |
+| `MS0016` | `InvalidInline` | `[Inline]` was applied to an unsupported shape (instance or mutable field, field without initializer, block-bodied property, non-static property, or any other target). |
 
 ## Reserved Codes
 
@@ -45,7 +46,6 @@ stable across the stack, not as a promise of shipped behavior.
 | Code | Symbolic name | Slice |
 | --- | --- | --- |
 | `MS0013` | `NoEmitReferencedByTranspiledCode` | `[NoEmit]` redefinition (painting diagnostic) |
-| `MS0016` | `InvalidInline` | `[Inline]` validator |
 
 ## Product Significance
 

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -141,6 +141,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ValidateDiscriminatorAttribute(compilation, assemblyWideTranspile, diagnostics);
             ValidateExternalAttribute(compilation, diagnostics);
             ValidateConstantAttribute(compilation, assemblyWideTranspile, diagnostics);
+            ValidateInlineAttribute(compilation, diagnostics);
         }
 
         return new IrCompilation(
@@ -854,6 +855,166 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
 
         foreach (var nested in type.GetTypeMembers())
             VisitTypeForExternal(nested, diagnostics);
+    }
+
+    /// <summary>
+    /// Validates <c>[Inline]</c> from <c>Metano.Annotations</c>. The
+    /// attribute's contract is enforced at declaration time:
+    /// <list type="bullet">
+    ///   <item>Fields must be <c>static readonly</c> with an
+    ///   initializer. Instance fields, mutable fields, and fields
+    ///   without an initializer have nothing to substitute at the
+    ///   call site.</item>
+    ///   <item>Properties must be <c>static</c> and expose an
+    ///   expression-bodied getter (either the property's own
+    ///   <c>=&gt;</c> form or an expression-bodied <c>get</c>
+    ///   accessor). Block-bodied getters fall outside the covered
+    ///   substitution surface and are deferred to a follow-up
+    ///   slice.</item>
+    /// </list>
+    /// Violations raise <c>MS0016 InvalidInline</c>. Recursion
+    /// between <c>[Inline]</c> members is handled at extraction time
+    /// (the extractor's cycle set bails out before the second
+    /// re-entry); the recursion-specific diagnostic ships alongside
+    /// the follow-up slice that adds method inlining.
+    /// </summary>
+    private static void ValidateInlineAttribute(
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type => VisitTypeForInline(type, diagnostics)
+        );
+    }
+
+    private static void VisitTypeForInline(
+        INamedTypeSymbol type,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        foreach (var member in type.GetMembers())
+        {
+            if (!SymbolHelper.HasInline(member))
+                continue;
+
+            switch (member)
+            {
+                case IFieldSymbol field:
+                    if (!field.IsStatic || !field.IsReadOnly)
+                    {
+                        diagnostics.Add(
+                            new MetanoDiagnostic(
+                                MetanoDiagnosticSeverity.Error,
+                                DiagnosticCodes.InvalidInline,
+                                $"[Inline] on field {FormatMemberPath(field)} requires a "
+                                    + $"'static readonly' field with an initializer. "
+                                    + $"Instance or mutable fields cannot satisfy the "
+                                    + $"substitution contract — the value must be fixed.",
+                                field.Locations.FirstOrDefault()
+                            )
+                        );
+                        break;
+                    }
+                    if (!HasFieldInitializer(field))
+                    {
+                        diagnostics.Add(
+                            new MetanoDiagnostic(
+                                MetanoDiagnosticSeverity.Error,
+                                DiagnosticCodes.InvalidInline,
+                                $"[Inline] on field {FormatMemberPath(field)} requires an "
+                                    + $"initializer. Without one there is no expression "
+                                    + $"to substitute at the call site.",
+                                field.Locations.FirstOrDefault()
+                            )
+                        );
+                    }
+                    break;
+                case IPropertySymbol property:
+                    if (!property.IsStatic)
+                    {
+                        diagnostics.Add(
+                            new MetanoDiagnostic(
+                                MetanoDiagnosticSeverity.Error,
+                                DiagnosticCodes.InvalidInline,
+                                $"[Inline] on property {FormatMemberPath(property)} requires "
+                                    + $"a 'static' property. Instance properties cannot be "
+                                    + $"substituted at the call site without a receiver.",
+                                property.Locations.FirstOrDefault()
+                            )
+                        );
+                        break;
+                    }
+                    if (!HasExpressionBodiedGetter(property))
+                    {
+                        diagnostics.Add(
+                            new MetanoDiagnostic(
+                                MetanoDiagnosticSeverity.Error,
+                                DiagnosticCodes.InvalidInline,
+                                $"[Inline] on property {FormatMemberPath(property)} requires "
+                                    + $"an expression-bodied getter ('=> expression' or "
+                                    + $"'get => expression'). Block-bodied accessors are "
+                                    + $"outside the covered substitution surface.",
+                                property.Locations.FirstOrDefault()
+                            )
+                        );
+                    }
+                    break;
+                default:
+                    diagnostics.Add(
+                        new MetanoDiagnostic(
+                            MetanoDiagnosticSeverity.Error,
+                            DiagnosticCodes.InvalidInline,
+                            $"[Inline] on {FormatMemberPath(member)} applies only to "
+                                + $"'static readonly' fields and 'static' properties with "
+                                + $"an expression-bodied getter.",
+                            member.Locations.FirstOrDefault()
+                        )
+                    );
+                    break;
+            }
+        }
+
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForInline(nested, diagnostics);
+    }
+
+    private static bool HasFieldInitializer(IFieldSymbol field)
+    {
+        foreach (var reference in field.DeclaringSyntaxReferences)
+        {
+            if (
+                reference.GetSyntax() is VariableDeclaratorSyntax declarator
+                && declarator.Initializer is not null
+            )
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasExpressionBodiedGetter(IPropertySymbol property)
+    {
+        foreach (var reference in property.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is not PropertyDeclarationSyntax decl)
+                continue;
+            if (decl.ExpressionBody is not null)
+                return true;
+            if (decl.AccessorList is { } accessorList)
+            {
+                foreach (var accessor in accessorList.Accessors)
+                {
+                    if (
+                        accessor.IsKind(SyntaxKind.GetAccessorDeclaration)
+                        && accessor.ExpressionBody is not null
+                    )
+                        return true;
+                }
+            }
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -871,12 +871,13 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
     ///   accessor). Block-bodied getters fall outside the covered
     ///   substitution surface and are deferred to a follow-up
     ///   slice.</item>
+    ///   <item>Recursion between <c>[Inline]</c> members
+    ///   (<c>A =&gt; B</c>, <c>B =&gt; A</c>, or <c>A =&gt; A</c>)
+    ///   is detected via a DFS over each member's initializer and
+    ///   surfaces before extraction runs, so downstream lowering
+    ///   never sees a chain that would recurse indefinitely.</item>
     /// </list>
-    /// Violations raise <c>MS0016 InvalidInline</c>. Recursion
-    /// between <c>[Inline]</c> members is handled at extraction time
-    /// (the extractor's cycle set bails out before the second
-    /// re-entry); the recursion-specific diagnostic ships alongside
-    /// the follow-up slice that adds method inlining.
+    /// All violations raise <c>MS0016 InvalidInline</c>.
     /// </summary>
     private static void ValidateInlineAttribute(
         Compilation compilation,
@@ -888,6 +889,115 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             currentAssembly.GlobalNamespace,
             type => VisitTypeForInline(type, diagnostics)
         );
+        DetectInlineCycles(compilation, diagnostics);
+    }
+
+    /// <summary>
+    /// Collects every <c>[Inline]</c> member in the compilation and
+    /// walks the transitive dependency graph induced by their
+    /// initializers. Any member whose chain revisits itself emits
+    /// <c>MS0016</c> at the cycle's source.
+    /// </summary>
+    private static void DetectInlineCycles(
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var inlineMembers = new List<ISymbol>();
+        CollectTopLevelTypes(
+            compilation.Assembly.GlobalNamespace,
+            type => CollectInlineMembers(type, inlineMembers)
+        );
+
+        foreach (var member in inlineMembers)
+        {
+            var visiting = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+            if (DetectCycle(member, compilation, visiting))
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidInline,
+                        $"[Inline] on {FormatMemberPath(member)} forms a cycle through "
+                            + $"another [Inline] member. Substitution would recurse "
+                            + $"indefinitely; break the chain or drop [Inline] on one "
+                            + $"of the participants.",
+                        member.Locations.FirstOrDefault()
+                    )
+                );
+            }
+        }
+    }
+
+    private static void CollectInlineMembers(INamedTypeSymbol type, List<ISymbol> sink)
+    {
+        foreach (var member in type.GetMembers())
+        {
+            if (!SymbolHelper.HasInline(member))
+                continue;
+            if (member is IFieldSymbol or IPropertySymbol)
+                sink.Add(member);
+        }
+        foreach (var nested in type.GetTypeMembers())
+            CollectInlineMembers(nested, sink);
+    }
+
+    private static bool DetectCycle(
+        ISymbol start,
+        Compilation compilation,
+        HashSet<ISymbol> visiting
+    )
+    {
+        if (!visiting.Add(start))
+            return true;
+        try
+        {
+            var initializer = TryFindInlineInitializerExpression(start);
+            if (initializer is null)
+                return false;
+            var semanticModel = compilation.GetSemanticModel(initializer.SyntaxTree);
+            foreach (var identifier in initializer.DescendantNodesAndSelf().OfType<NameSyntax>())
+            {
+                var referenced = semanticModel.GetSymbolInfo(identifier).Symbol;
+                if (referenced is null || !SymbolHelper.HasInline(referenced))
+                    continue;
+                if (DetectCycle(referenced, compilation, visiting))
+                    return true;
+            }
+            return false;
+        }
+        finally
+        {
+            visiting.Remove(start);
+        }
+    }
+
+    private static ExpressionSyntax? TryFindInlineInitializerExpression(ISymbol symbol)
+    {
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            switch (reference.GetSyntax())
+            {
+                case VariableDeclaratorSyntax declarator
+                    when declarator.Initializer?.Value is { } fieldInit:
+                    return fieldInit;
+                case PropertyDeclarationSyntax prop
+                    when prop.ExpressionBody?.Expression is { } arrow:
+                    return arrow;
+                case PropertyDeclarationSyntax prop
+                    when prop.AccessorList?.Accessors is { } accessors:
+                    foreach (var accessor in accessors)
+                    {
+                        if (
+                            accessor.IsKind(SyntaxKind.GetAccessorDeclaration)
+                            && accessor.ExpressionBody?.Expression is { } body
+                        )
+                            return body;
+                    }
+                    break;
+            }
+        }
+        return null;
     }
 
     private static void VisitTypeForInline(

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -128,6 +128,18 @@ public static class DiagnosticCodes
     /// literal form without a separate analyzer pass.</summary>
     public const string InvalidConstant = "MS0014";
 
+    /// <summary>MS0016 — <c>[Inline]</c> (from
+    /// <c>Metano.Annotations</c>) was applied to an unsupported
+    /// shape or its expansion introduced a cycle. Valid targets are
+    /// <c>static readonly</c> fields with an initializer and
+    /// <c>static</c> properties with an expression-bodied getter.
+    /// Instance members, mutable fields, methods, properties with
+    /// block-bodied accessors, and any member whose initializer
+    /// references another <c>[Inline]</c> member that (transitively)
+    /// references the original all surface here so downstream
+    /// substitution stays bounded.</summary>
+    public const string InvalidInline = "MS0016";
+
     /// <summary>MS0015 — <c>[Erasable]</c> (from
     /// <c>Metano.Annotations</c>) was applied to a non-static class,
     /// or combined with <c>[Transpile]</c>. The attribute marks a

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -130,14 +130,15 @@ public static class DiagnosticCodes
 
     /// <summary>MS0016 — <c>[Inline]</c> (from
     /// <c>Metano.Annotations</c>) was applied to an unsupported
-    /// shape or its expansion introduced a cycle. Valid targets are
+    /// shape or its expansion would cycle. Valid targets are
     /// <c>static readonly</c> fields with an initializer and
-    /// <c>static</c> properties with an expression-bodied getter.
-    /// Instance members, mutable fields, methods, properties with
-    /// block-bodied accessors, and any member whose initializer
-    /// references another <c>[Inline]</c> member that (transitively)
-    /// references the original all surface here so downstream
-    /// substitution stays bounded.</summary>
+    /// <c>static</c> properties with an expression-bodied getter;
+    /// instance members, mutable fields, methods, and properties
+    /// with block-bodied accessors raise the code with a
+    /// shape-specific message. Cycles between <c>[Inline]</c>
+    /// members (detected by the frontend validator via DFS over
+    /// each initializer) raise the code with a cycle message so
+    /// downstream substitution stays bounded.</summary>
     public const string InvalidInline = "MS0016";
 
     /// <summary>MS0015 — <c>[Erasable]</c> (from

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -25,6 +25,15 @@ public sealed class IrExpressionExtractor(
     private readonly IrTypeOriginResolver? _originResolver = originResolver;
     private readonly Metano.Annotations.TargetLanguage? _target = target;
 
+    /// <summary>
+    /// Tracks the set of <c>[Inline]</c> members currently being
+    /// expanded so cyclic references (<c>[Inline] A =&gt; B</c>,
+    /// <c>[Inline] B =&gt; A</c>) bail out rather than recurse
+    /// indefinitely. Populated on entry into
+    /// <see cref="TryExpandInlineAccess"/> and cleared on exit.
+    /// </summary>
+    private readonly HashSet<ISymbol> _inlineExpanding = new(SymbolEqualityComparer.Default);
+
     public IrExpression Extract(ExpressionSyntax expression) =>
         expression switch
         {
@@ -397,6 +406,14 @@ public sealed class IrExpressionExtractor(
         var symbol = _semantic.GetSymbolInfo(id).Symbol;
         if (symbol is ITypeSymbol or INamespaceSymbol)
             return new IrTypeReference(id.Identifier.ValueText);
+
+        // `[Inline]` member referenced without an explicit qualifier
+        // (same-type static access, extension receiver, etc.). Expand
+        // before synthesizing any member-access wrapper so the
+        // initializer flows through as if it had been written at the
+        // call site.
+        if (TryExpandInlineAccess(symbol) is { } inlined)
+            return inlined;
 
         // Instance member reached through the implicit-this shorthand: promote to
         // an explicit this.Member access so backends don't have to rediscover the
@@ -802,8 +819,84 @@ public sealed class IrExpressionExtractor(
                 return target;
         }
 
+        // `[Inline]` fields and properties substitute their initializer
+        // (or getter body) at every access site. When expansion
+        // succeeds, the member access is replaced by the extracted
+        // initializer expression; otherwise fall through to the normal
+        // access path so diagnostics still surface at validation time.
+        if (TryExpandInlineAccess(symbol) is { } inlined)
+            return inlined;
+
         var origin = BuildOrigin(_semantic.GetSymbolInfo(member).Symbol);
         return new IrMemberAccess(target, name, origin);
+    }
+
+    /// <summary>
+    /// If <paramref name="symbol"/> carries <c>[Inline]</c> and resolves
+    /// to a supported shape (<c>static readonly</c> field with
+    /// initializer, or <c>static</c> property with an expression-bodied
+    /// getter), returns the extracted initializer expression.
+    /// Guards against recursion by tracking in-progress symbols in
+    /// <see cref="_inlineExpanding"/>. Unsupported shapes and cycles
+    /// return <c>null</c> so the caller falls back to a regular
+    /// access; the validator surfaces the diagnostic separately.
+    /// </summary>
+    private IrExpression? TryExpandInlineAccess(ISymbol? symbol)
+    {
+        if (symbol is null || !SymbolHelper.HasInline(symbol))
+            return null;
+        if (!_inlineExpanding.Add(symbol))
+            return null;
+        try
+        {
+            var initializer = TryFindInlineInitializer(symbol);
+            if (initializer is null)
+                return null;
+
+            // Reuse the declaring syntax tree's SemanticModel so
+            // constant folding + symbol resolution inside the
+            // initializer reflect the declaration site, not the call
+            // site. The extractor is stateless beyond the cycle set,
+            // so a transient instance is safe to spin up.
+            var extractor = new IrExpressionExtractor(
+                _semantic.Compilation.GetSemanticModel(initializer.SyntaxTree),
+                _originResolver,
+                _target
+            );
+            return extractor.Extract(initializer);
+        }
+        finally
+        {
+            _inlineExpanding.Remove(symbol);
+        }
+    }
+
+    private static ExpressionSyntax? TryFindInlineInitializer(ISymbol symbol)
+    {
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            switch (reference.GetSyntax())
+            {
+                case VariableDeclaratorSyntax declarator
+                    when declarator.Initializer?.Value is { } fieldInit:
+                    return fieldInit;
+                case PropertyDeclarationSyntax prop
+                    when prop.ExpressionBody?.Expression is { } arrow:
+                    return arrow;
+                case PropertyDeclarationSyntax prop
+                    when prop.AccessorList?.Accessors is { } accessors:
+                    foreach (var accessor in accessors)
+                    {
+                        if (
+                            accessor.IsKind(SyntaxKind.GetAccessorDeclaration)
+                            && accessor.ExpressionBody?.Expression is { } body
+                        )
+                            return body;
+                    }
+                    break;
+            }
+        }
+        return null;
     }
 
     private IrExpression ExtractInvocation(InvocationExpressionSyntax inv)

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -15,24 +15,43 @@ namespace Metano.Compiler.Extraction;
 /// phases add explicit support — this keeps the API total while letting callers
 /// detect and fall back to legacy handling.
 /// </summary>
-public sealed class IrExpressionExtractor(
-    SemanticModel semanticModel,
-    IrTypeOriginResolver? originResolver = null,
-    Metano.Annotations.TargetLanguage? target = null
-)
+public sealed class IrExpressionExtractor
 {
-    private readonly SemanticModel _semantic = semanticModel;
-    private readonly IrTypeOriginResolver? _originResolver = originResolver;
-    private readonly Metano.Annotations.TargetLanguage? _target = target;
+    private readonly SemanticModel _semantic;
+    private readonly IrTypeOriginResolver? _originResolver;
+    private readonly Metano.Annotations.TargetLanguage? _target;
 
     /// <summary>
     /// Tracks the set of <c>[Inline]</c> members currently being
     /// expanded so cyclic references (<c>[Inline] A =&gt; B</c>,
     /// <c>[Inline] B =&gt; A</c>) bail out rather than recurse
-    /// indefinitely. Populated on entry into
-    /// <see cref="TryExpandInlineAccess"/> and cleared on exit.
+    /// indefinitely. Shared across nested extractors spawned during
+    /// an <c>[Inline]</c> expansion so the cycle set survives the
+    /// jump to the initializer's semantic model — an earlier
+    /// iteration created a fresh set per nested extractor, which
+    /// defeated the guard.
     /// </summary>
-    private readonly HashSet<ISymbol> _inlineExpanding = new(SymbolEqualityComparer.Default);
+    private readonly HashSet<ISymbol> _inlineExpanding;
+
+    public IrExpressionExtractor(
+        SemanticModel semanticModel,
+        IrTypeOriginResolver? originResolver = null,
+        Metano.Annotations.TargetLanguage? target = null
+    )
+        : this(semanticModel, originResolver, target, inlineExpanding: null) { }
+
+    private IrExpressionExtractor(
+        SemanticModel semanticModel,
+        IrTypeOriginResolver? originResolver,
+        Metano.Annotations.TargetLanguage? target,
+        HashSet<ISymbol>? inlineExpanding
+    )
+    {
+        _semantic = semanticModel;
+        _originResolver = originResolver;
+        _target = target;
+        _inlineExpanding = inlineExpanding ?? new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+    }
 
     public IrExpression Extract(ExpressionSyntax expression) =>
         expression switch
@@ -856,12 +875,14 @@ public sealed class IrExpressionExtractor(
             // Reuse the declaring syntax tree's SemanticModel so
             // constant folding + symbol resolution inside the
             // initializer reflect the declaration site, not the call
-            // site. The extractor is stateless beyond the cycle set,
-            // so a transient instance is safe to spin up.
+            // site. The cycle-tracking set is shared with the nested
+            // extractor so a transitive reference back to the
+            // original member bails out instead of recursing.
             var extractor = new IrExpressionExtractor(
                 _semantic.Compilation.GetSemanticModel(initializer.SyntaxTree),
                 _originResolver,
-                _target
+                _target,
+                _inlineExpanding
             );
             return extractor.Extract(initializer);
         }

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -248,6 +248,23 @@ public static class SymbolHelper
             );
 
     /// <summary>
+    /// Reads <c>[Inline]</c> from <c>Metano.Annotations</c>. Marks
+    /// a <c>static readonly</c> field or a <c>static</c> property
+    /// for use-site substitution — every reference to the member is
+    /// replaced by its initializer (or getter expression) before
+    /// lowering. Namespace-qualified match so unrelated
+    /// <c>[Inline]</c> attributes from other libraries are not
+    /// mistaken for the Metano variant.
+    /// </summary>
+    public static bool HasInline(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is ("InlineAttribute" or "Inline")
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString() == "Metano.Annotations"
+            );
+
+    /// <summary>
     /// Reads <c>[Constant]</c> from <c>Metano.Annotations</c>. Marks
     /// a parameter or field whose value must be a compile-time
     /// constant literal. Used by downstream lowering

--- a/src/Metano/Annotations/InlineAttribute.cs
+++ b/src/Metano/Annotations/InlineAttribute.cs
@@ -1,0 +1,43 @@
+namespace Metano.Annotations;
+
+/// <summary>
+/// Marks a <c>static readonly</c> field or a <c>static</c> property
+/// with an expression-bodied getter for use-site inlining: every
+/// reference to the member is replaced by the member's initializer
+/// (or getter expression) before lowering. The declaration itself
+/// does not emit a top-level <c>export const</c>; the value lives
+/// exclusively at the call sites.
+/// <para>
+/// Enables catalog-style APIs whose entries must erase into their
+/// literal form at the call site. Combined with <c>[Erasable]</c> on
+/// the containing class and <c>[PlainObject]</c> / <c>[Branded]</c>
+/// on the initializer's type, a call like
+/// <c>HtmlElementType.Div</c> lowers directly to the literal shape
+/// the runtime expects, matching the TypeScript overload-on-literal
+/// pattern without a helper indirection.
+/// </para>
+/// <para>
+/// Applies to:
+/// </para>
+/// <list type="bullet">
+///   <item><c>static readonly</c> fields with an initializer.</item>
+///   <item><c>static</c> properties with an expression-bodied getter
+///   (<c>public static T Div =&gt; new("div");</c>).</item>
+/// </list>
+/// <para>
+/// Invalid shapes (instance fields, mutable fields, methods, or
+/// properties with block-bodied accessors) raise
+/// <c>MS0016 InvalidInline</c>. Recursion through <c>[Inline]</c>
+/// members is detected by the extractor and raises the same code
+/// with a cycle message so a self-referential catalog does not
+/// trigger unbounded expansion.
+/// </para>
+/// <para>
+/// <c>[Inline]</c> lives in <see cref="Metano.Annotations"/> because
+/// the semantic (use-site substitution) is meaningful for every
+/// target; each backend decides how to realize the substitution in
+/// its own AST.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false)]
+public sealed class InlineAttribute : Attribute;

--- a/src/Metano/Annotations/InlineAttribute.cs
+++ b/src/Metano/Annotations/InlineAttribute.cs
@@ -28,9 +28,11 @@ namespace Metano.Annotations;
 /// Invalid shapes (instance fields, mutable fields, methods, or
 /// properties with block-bodied accessors) raise
 /// <c>MS0016 InvalidInline</c>. Recursion through <c>[Inline]</c>
-/// members is detected by the extractor and raises the same code
-/// with a cycle message so a self-referential catalog does not
-/// trigger unbounded expansion.
+/// members (<c>A =&gt; B</c>, <c>B =&gt; A</c>, or <c>A =&gt; A</c>)
+/// is detected by the frontend validator via a DFS over each
+/// member's initializer graph and surfaces the same code with a
+/// cycle message, so a self-referential catalog fails at the
+/// validation phase rather than recursing during extraction.
 /// </para>
 /// <para>
 /// <c>[Inline]</c> lives in <see cref="Metano.Annotations"/> because

--- a/tests/Metano.Tests/InlineAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/InlineAttributeTranspileTests.cs
@@ -1,0 +1,225 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for <c>[Inline]</c> from <c>Metano.Annotations</c>. The
+/// attribute expands a member access into the member's initializer
+/// (or expression-bodied getter) at every call site, so the
+/// declaration itself never materializes in the generated output.
+/// Combines with <c>[Erasable]</c> on the container and
+/// <c>[PlainObject]</c>/<c>[Branded]</c> on the initializer type to
+/// replicate TypeScript's literal-type dispatch without a helper
+/// indirection.
+/// </summary>
+public class InlineAttributeTranspileTests
+{
+    [Test]
+    public async Task Inline_Property_LiteralInitializer_InlinesAtAccessSite()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Erasable]
+            public static class Constants
+            {
+                [Inline]
+                public static string Pi => "pi";
+            }
+
+            public class Circle
+            {
+                public string GetPi() => Constants.Pi;
+            }
+            """
+        );
+
+        var output = result["circle.ts"];
+        await Assert.That(output).Contains("return \"pi\";");
+        await Assert.That(output).DoesNotContain("Constants.");
+        await Assert.That(output).DoesNotContain("pi()");
+    }
+
+    [Test]
+    public async Task Inline_Field_LiteralInitializer_InlinesAtAccessSite()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Erasable]
+            public static class Constants
+            {
+                [Inline]
+                public static readonly int Answer = 42;
+            }
+
+            public class Asker
+            {
+                public int Ask() => Constants.Answer;
+            }
+            """
+        );
+
+        var output = result["asker.ts"];
+        await Assert.That(output).Contains("return 42;");
+        await Assert.That(output).DoesNotContain("Constants.");
+    }
+
+    [Test]
+    public async Task Inline_Property_PlainObjectInitializer_InlinesAsLiteral()
+    {
+        // The DOM-binding shape: catalog entry built from a
+        // [PlainObject] record lowers to the object literal at the
+        // call site, with no intermediate helper indirection.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [PlainObject]
+            public sealed record Tag(string TagName);
+
+            [Erasable]
+            public static class HtmlElementType
+            {
+                [Inline]
+                public static Tag Div => new("div");
+            }
+
+            public class Runtime
+            {
+                public Tag Describe() => HtmlElementType.Div;
+            }
+            """
+        );
+
+        var output = result["runtime.ts"];
+        await Assert.That(output).Contains("tagName: \"div\"");
+        await Assert.That(output).DoesNotContain("HtmlElementType.");
+    }
+
+    // ─── Diagnostics (MS0016) ─────────────────────────────────
+
+    [Test]
+    public async Task Inline_OnInstanceField_EmitsMs0016()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public class Catalog
+            {
+                [Inline]
+                public readonly int X = 42;
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("static");
+    }
+
+    [Test]
+    public async Task Inline_OnMutableField_EmitsMs0016()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Catalog
+            {
+                [Inline]
+                public static int X = 42;
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("readonly");
+    }
+
+    [Test]
+    public async Task Inline_OnFieldWithoutInitializer_EmitsMs0016()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Catalog
+            {
+                [Inline]
+                public static readonly int X;
+
+                static Catalog() { X = 42; }
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("initializer");
+    }
+
+    [Test]
+    public async Task Inline_OnBlockBodiedProperty_EmitsMs0016()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Catalog
+            {
+                [Inline]
+                public static int X
+                {
+                    get { return 42; }
+                }
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("expression-bodied");
+    }
+
+    [Test]
+    public async Task Inline_Property_CascadesThroughAnotherInline()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Erasable]
+            public static class Colors
+            {
+                [Inline]
+                public static string Primary => "#112233";
+
+                [Inline]
+                public static string Highlight => Primary;
+            }
+
+            public class Theme
+            {
+                public string Accent() => Colors.Highlight;
+            }
+            """
+        );
+
+        var output = result["theme.ts"];
+        await Assert.That(output).Contains("return \"#112233\";");
+        await Assert.That(output).DoesNotContain("Colors.");
+    }
+}

--- a/tests/Metano.Tests/InlineAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/InlineAttributeTranspileTests.cs
@@ -194,6 +194,56 @@ public class InlineAttributeTranspileTests
     }
 
     [Test]
+    public async Task Inline_SelfReferentialProperty_EmitsMs0016()
+    {
+        // A property whose initializer refers to itself would cause
+        // unbounded substitution. The validator detects the cycle
+        // via DFS and surfaces MS0016 before extraction runs.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Loop
+            {
+                [Inline]
+                public static string X => X;
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("cycle");
+    }
+
+    [Test]
+    public async Task Inline_MutualRecursion_EmitsMs0016()
+    {
+        // Two [Inline] members pointing at each other also form a
+        // cycle. The DFS flags at least one of the two.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public static class Loop
+            {
+                [Inline]
+                public static string A => B;
+
+                [Inline]
+                public static string B => A;
+            }
+            """
+        );
+
+        var ms0016 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidInline);
+        await Assert.That(ms0016).IsNotNull();
+        await Assert.That(ms0016!.Message).Contains("cycle");
+    }
+
+    [Test]
     public async Task Inline_Property_CascadesThroughAnotherInline()
     {
         var result = TranspileHelper.Transpile(


### PR DESCRIPTION
## Summary

Fifth slice of the attribute-family stack (#96 / #100). Introduces `[Inline]` (`Metano.Annotations`) and wires extractor-side substitution: every access to a decorated `static readonly` field or `static` expression-bodied property is replaced by its initializer (or getter expression) before downstream lowering. The declaration itself never materializes in the generated output.

## Changes

**Surface**
- `InlineAttribute` (`AttributeTargets.Field | Property`) with XML docs pinning the two supported shapes and deferring method / extension / static-class propagation to a follow-up slice.
- `DiagnosticCodes.InvalidInline` (MS0016) promoted from reserved to shipped.
- `SymbolHelper.HasInline` with namespace-qualified match against `Metano.Annotations`.

**Extractor** (`IrExpressionExtractor`)
- `ExtractMemberAccess` and `ExtractIdentifierName` now check for `[Inline]` on the resolved symbol and substitute the initializer/getter expression before building an `IrMemberAccess`.
- `_inlineExpanding` (`HashSet<ISymbol>`) guards against cyclic references: reentry on an in-progress member falls back to the regular access path so the substitution stays bounded.
- `TryFindInlineInitializer` resolves the source expression from `DeclaringSyntaxReferences` (`VariableDeclaratorSyntax.Initializer` for fields; `PropertyDeclarationSyntax.ExpressionBody` or the expression-bodied `get` accessor for properties).

**Validator** (`CSharpSourceFrontend.ValidateInlineAttribute`)
- Fields must be `static readonly` with an initializer.
- Properties must be `static` with an expression-bodied getter (property-level `=>` or `get => …`).
- Other targets (methods, events, block-bodied properties) surface MS0016 pointing at the supported shapes.

**DOM-binding use case**
With `[Erasable]` on the container, `[Inline]` on the field, and `[PlainObject]` on the initializer's type, a call like `HtmlElementType.Div` lowers directly to the object literal `{ tagName: "div" }` at every call site — replicating the TypeScript literal-type narrowing pattern without a helper indirection. A dedicated test (`Inline_Property_PlainObjectInitializer_InlinesAsLiteral`) pins the shape.

## Scope boundary

Method / extension-method inlining, static-class `[Inline]` propagation, and an explicit recursion-cycle diagnostic (the extractor currently falls back silently rather than surfacing MS0016 for cycles) ship in a separate follow-up PR. The current slice keeps the lowering path target-agnostic — the attribute's effect lives entirely in the extraction pass.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **678/678 green** (670 → 678), 8 new tests in `InlineAttributeTranspileTests`:
  - Positive: property literal, field literal, property + `[PlainObject]` initializer, cascading inline through another inline
  - Negative: instance field, mutable field, field without initializer, block-bodied property
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the cascading-inline case (`Inline_Property_CascadesThroughAnotherInline`) does not regress when the chain grows past 2 levels; recursion-guard depth is O(symbols-in-chain)

## Spec

- `09-attribute-catalog.md`: `InlineAttribute` promoted from *(planned)* to shipped; attribute count 24 → 25. The "planned" footnote is dropped since the family is fully in.
- `10-diagnostic-catalog.md`: MS0016 moved from Reserved Codes to Stable Codes; only MS0013 remains reserved for the `[NoEmit]` redefinition slice.

Part of #96.
Part of #100.