### PR TITLE
fix(core): guard [Inline] expansion against cross-assembly SyntaxTrees

### DIFF
--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -955,6 +955,14 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             var initializer = TryFindInlineInitializerExpression(start);
             if (initializer is null)
                 return false;
+            // Cross-assembly guard: an `[Inline]` member pulled from
+            // a referenced assembly carries a SyntaxTree that belongs
+            // to the declaring compilation, not ours. The cycle walk
+            // cannot inspect initializers outside the current
+            // compilation — skip them. A follow-up slice covers the
+            // cross-assembly case.
+            if (!compilation.ContainsSyntaxTree(initializer.SyntaxTree))
+                return false;
             var semanticModel = compilation.GetSemanticModel(initializer.SyntaxTree);
             foreach (var identifier in initializer.DescendantNodesAndSelf().OfType<NameSyntax>())
             {

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -872,6 +872,18 @@ public sealed class IrExpressionExtractor
             if (initializer is null)
                 return null;
 
+            // Cross-assembly guard: when the `[Inline]` member lives
+            // in a referenced assembly, its SyntaxTree belongs to the
+            // declaring compilation, not ours. Calling
+            // `GetSemanticModel` with a tree the current compilation
+            // does not own throws `ArgumentException` ("SyntaxTree is
+            // not part of the compilation"). Cross-assembly inline
+            // substitution is tracked as a follow-up — for now the
+            // caller falls through to a regular member access so the
+            // transpiler does not crash.
+            if (!_semantic.Compilation.ContainsSyntaxTree(initializer.SyntaxTree))
+                return null;
+
             // Reuse the declaring syntax tree's SemanticModel so
             // constant folding + symbol resolution inside the
             // initializer reflect the declaration site, not the call

--- a/tests/Metano.Tests/InlineAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/InlineAttributeTranspileTests.cs
@@ -102,6 +102,48 @@ public class InlineAttributeTranspileTests
         await Assert.That(output).DoesNotContain("HtmlElementType.");
     }
 
+    // ─── Cross-assembly ───────────────────────────────────────
+
+    [Test]
+    public async Task Inline_CrossAssembly_DoesNotCrashAndSkipsExpansion()
+    {
+        // Regression for issue #109: an [Inline] member declared in a
+        // referenced assembly carries a SyntaxTree that belongs to
+        // the declaring compilation, not ours. Calling
+        // GetSemanticModel on that tree used to throw
+        // ArgumentException. Cross-assembly inline expansion is
+        // deferred to a follow-up — for now the transpiler must bail
+        // out cleanly and fall back to a regular member access.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations;
+
+            [Erasable]
+            public static class Constants
+            {
+                [Inline]
+                public static int Answer => 42;
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Asker
+            {
+                public int Ask() => Constants.Answer;
+            }
+            """
+        );
+
+        // The consumer still emits without crashing. Inline expansion
+        // does NOT happen across the assembly boundary in this slice,
+        // so the caller sees the Erasable-class-flattened bare
+        // identifier; the follow-up will wire cross-assembly
+        // expansion so the literal substitutes properly.
+        var output = result["asker.ts"];
+        await Assert.That(output).Contains("return answer;");
+    }
+
     // ─── Diagnostics (MS0016) ─────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Summary

Fixes #109. Transpiling `SampleCounterWithDomView` on the `feat/jsx` branch threw `System.ArgumentException: SyntaxTree is not part of the compilation` from `IrExpressionExtractor.TryExpandInlineAccess`. The `[Inline]` slice shipped in PR #105 assumed the initializer's SyntaxTree belonged to the current compilation; that assumption breaks whenever the decorated member lives in a referenced assembly (DOM bindings library on `feat/jsx`).

## Fix

Both call sites now short-circuit with `Compilation.ContainsSyntaxTree` before asking for a `SemanticModel`:

- `IrExpressionExtractor.TryExpandInlineAccess` returns `null` when the initializer's tree is out of scope. The caller falls through to a regular member access; the declaring assembly's `[Erasable]` flatten still produces valid TypeScript, so the generated output remains usable even if the literal substitution is deferred.
- `CSharpSourceFrontend.DetectCycle` applies the same guard — the validator's DFS cannot walk initializers outside the current compilation, so it skips them rather than crashing.

Cross-assembly inline expansion is tracked as a follow-up under the broader `[Inline]` roadmap in #107 (method / extension / class propagation) and requires the declaring assembly to pre-serialize the inline IR so consumers can replay the substitution. That is a feature, not a correctness gap for this slice.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **681/681 green** (680 → 681), one new regression test:
  - `Inline_CrossAssembly_DoesNotCrashAndSkipsExpansion` wires a referenced library with `[Erasable] class Constants { [Inline] public static int Answer => 42 }` and a consumer `Asker.Ask() => Constants.Answer`. The consumer transpiles without throwing and emits the Erasable-flattened `answer` identifier.
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the fallback behavior (bare flattened identifier) is acceptable as an interim, given cross-assembly inline expansion is planned for #107

Closes #109.