### PR TITLE
feat(ts): --strip-interface-prefix opt-in for C# interface names

### DIFF
--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,7 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0016`**, with
+The current stable code range is **`MS0001` through `MS0017`**, with
 `MS0013` reserved for the upcoming `[NoEmit]` redefinition slice
 (see ADR-0015).
 
@@ -35,6 +35,7 @@ The current stable code range is **`MS0001` through `MS0016`**, with
 | `MS0014` | `InvalidConstant` | `[Constant]` argument or initializer is not a compile-time constant literal. |
 | `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or combined with `[Transpile]`. |
 | `MS0016` | `InvalidInline` | `[Inline]` was applied to an unsupported shape (instance or mutable field, field without initializer, block-bodied property, non-static property, or any other target). |
+| `MS0017` | `InterfacePrefixCollision` | Stripping the `I` prefix from an interface name (under `--strip-interface-prefix`) would collide with another top-level type in the same namespace. Keeps the prefix so the consumer surface stays compilable. |
 
 ## Reserved Codes
 

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -48,6 +48,9 @@
       <_MetanoArgs Condition="'$(MetanoNamespaceBarrels)' == 'true'"
         >$(_MetanoArgs) --namespace-barrels</_MetanoArgs
       >
+      <_MetanoArgs Condition="'$(MetanoStripInterfacePrefix)' == 'true'"
+        >$(_MetanoArgs) --strip-interface-prefix</_MetanoArgs
+      >
       <_MetanoArgs Condition="'$(MetanoExtraArgs)' != ''"
         >$(_MetanoArgs) $(MetanoExtraArgs)</_MetanoArgs
       >

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -16,6 +16,8 @@
       MetanoSrcRoot          (optional)  TS source root relative to package root (default: inferred)
       MetanoSkipPackageJson  (optional)  true to skip package.json generation (default: false)
       MetanoShowTimings      (optional)  true to print timing info (default: false)
+      MetanoNamespaceBarrels (optional)  true to emit a root src/index.ts barrel mirroring C# namespaces (default: false)
+      MetanoStripInterfacePrefix (optional)  true to drop the `I` prefix from interface names when the second letter is uppercase (default: false). Collisions with sibling types surface MS0017.
       MetanoExtraArgs        (optional)  Additional CLI arguments
   -->
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
@@ -9,7 +9,11 @@ namespace Metano.TypeScript.Bridge;
 /// </summary>
 public static class IrToTsInterfaceBridge
 {
-    public static void Convert(IrInterfaceDeclaration ir, List<TsTopLevel> statements)
+    public static void Convert(
+        IrInterfaceDeclaration ir,
+        List<TsTopLevel> statements,
+        string? nameOverride = null
+    )
     {
         var properties = new List<TsProperty>();
         var methods = new List<TsInterfaceMethod>();
@@ -34,7 +38,12 @@ public static class IrToTsInterfaceBridge
             }
         }
 
-        var tsName = IrToTsNamingPolicy.ToTypeName(ir.Name, ir.Attributes);
+        // A transformer-provided override (e.g.,
+        // `--strip-interface-prefix`) takes precedence over the naming
+        // policy so the emitted declaration matches the name the
+        // transformer already registered in `TypeNamesBySymbol` (and
+        // consequently the file name + import collector).
+        var tsName = nameOverride ?? IrToTsNamingPolicy.ToTypeName(ir.Name, ir.Attributes);
         var typeParams = ConvertTypeParameters(ir.TypeParameters);
 
         statements.Add(

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs
@@ -46,15 +46,38 @@ public static class IrToTsTypeMapper
             _ => new TsAnyType(),
         };
 
+    /// <summary>
+    /// Optional name rewriter consulted by <see cref="MapNamed"/>.
+    /// Set by <see cref="Metano.Transformation.TypeTransformer"/>
+    /// when <c>--strip-interface-prefix</c> is active so every
+    /// named-type reference picks up the stripped identifier at the
+    /// emit boundary. Uses <see cref="AsyncLocal{T}"/> so the flow
+    /// state stays scoped to the transformer's execution context —
+    /// parallel test runs (TUnit default) each see their own value
+    /// instead of racing on a process-wide static slot.
+    /// </summary>
+    private static readonly AsyncLocal<IReadOnlyDictionary<string, string>?> _namedTypeRenames =
+        new();
+
+    internal static IReadOnlyDictionary<string, string>? NamedTypeRenames
+    {
+        get => _namedTypeRenames.Value;
+        set => _namedTypeRenames.Value = value;
+    }
+
     private static TsType MapNamed(IrNamedTypeRef named, IrToTsTypeOverrides? overrides)
     {
-        TsTypeOrigin? origin = named.Origin is { } o ? BuildTsOrigin(o, named.Name) : null;
+        var name = named.Name;
+        if (NamedTypeRenames is { } renames && renames.TryGetValue(name, out var renamed))
+            name = renamed;
+
+        TsTypeOrigin? origin = named.Origin is { } o ? BuildTsOrigin(o, name) : null;
 
         IReadOnlyList<TsType>? args = named.TypeArguments is { Count: > 0 } ta
             ? ta.Select(t => Map(t, overrides)).ToList()
             : null;
 
-        return new TsNamedType(named.Name, args, origin);
+        return new TsNamedType(name, args, origin);
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -17,6 +17,7 @@ public class Commands
     /// <param name="srcRoot">TypeScript source root relative to packageRoot (default: inferred from first segment of output path). Used to compute the dist prefix when output targets a subdirectory (e.g., src/domain/).</param>
     /// <param name="skipPackageJson">Skip generating/updating package.json</param>
     /// <param name="namespaceBarrels">Emit an additional src/index.ts root barrel mirroring the C# namespace hierarchy via `export namespace` blocks (opt-in; see ADR-0006).</param>
+    /// <param name="stripInterfacePrefix">Drop the C# `I` prefix from generated interface names when it is followed by another uppercase letter (opt-in). Collisions with sibling types in the same namespace keep the prefix and emit MS0017.</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -27,10 +28,15 @@ public class Commands
         string dist = "./dist",
         string? srcRoot = null,
         bool skipPackageJson = false,
-        bool namespaceBarrels = false
+        bool namespaceBarrels = false,
+        bool stripInterfacePrefix = false
     )
     {
-        var target = new TypeScriptTarget { NamespaceBarrels = namespaceBarrels };
+        var target = new TypeScriptTarget
+        {
+            NamespaceBarrels = namespaceBarrels,
+            StripInterfacePrefix = stripInterfacePrefix,
+        };
 
         var options = new TranspileOptions(
             ProjectPath: project,

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -41,6 +41,18 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     public bool NamespaceBarrels { get; init; }
 
     /// <summary>
+    /// When <c>true</c>, <see cref="ApplyInterfacePrefixStrip"/>
+    /// rewrites every interface entry in
+    /// <see cref="IrCompilation.TypeNamesBySymbol"/> whose C# name
+    /// matches <c>^I[A-Z]</c>, dropping the leading <c>I</c>.
+    /// Collisions with sibling types in the same namespace keep the
+    /// prefix and raise <c>MS0017</c>. Explicit
+    /// <c>[Name(TypeScript, "…")]</c> overrides win over the strip.
+    /// Opt-in via <c>--strip-interface-prefix</c>.
+    /// </summary>
+    public bool StripInterfacePrefix { get; init; }
+
+    /// <summary>
     /// Diagnostics collected during transformation. Includes warnings about unsupported
     /// language features and other issues that the user should know about.
     /// </summary>
@@ -122,8 +134,12 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         // IR rather than redoing the same probe.
         _assemblyWideTranspile = ir.AssemblyWideTranspile;
 
-        var typeNamesBySymbol =
-            ir.TypeNamesBySymbol ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        // Copy the frontend-produced map so any in-transformer
+        // rewrites (e.g., StripInterfacePrefix) stay scoped to this
+        // run without mutating the shared IR.
+        var typeNamesBySymbol = ir.TypeNamesBySymbol is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(ir.TypeNamesBySymbol, StringComparer.Ordinal);
 
         // Frontend owns discovery now — read the ordered entry list off the
         // IR and project it back to raw symbols for the existing per-type
@@ -134,6 +150,13 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         var transpilableTypeEntries =
             ir.TranspilableTypeEntries ?? Array.Empty<IrTranspilableTypeEntry>();
         var transpilableTypes = transpilableTypeEntries.Select(e => e.Symbol).ToList();
+
+        // Opt-in `I`-prefix strip runs once per transform, mutating the
+        // shared name dictionary so every downstream consumer
+        // (ResolveTsName, file-name derivation, import collector) sees
+        // the same rewritten identifier.
+        if (StripInterfacePrefix)
+            ApplyInterfacePrefixStrip(transpilableTypes, typeNamesBySymbol, _diagnostics);
 
         // Build the explicit per-compilation context that replaces TypeMapper statics.
         var crossPackageMisses = new HashSet<string>();
@@ -284,7 +307,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         else if (type.TypeKind == TypeKind.Interface)
         {
             var ifaceIr = (IrInterfaceDeclaration)GetOrExtractIr(type, irCache)!;
-            IrToTsInterfaceBridge.Convert(ifaceIr, sink);
+            IrToTsInterfaceBridge.Convert(ifaceIr, sink, Context.ResolveTsName(type));
         }
         else if (IsExceptionType(type))
         {
@@ -495,6 +518,91 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         string FileName,
         List<INamedTypeSymbol> Types
     );
+
+    /// <summary>
+    /// Rewrites every interface entry in
+    /// <paramref name="typeNamesBySymbol"/> whose C# name matches
+    /// <c>^I[A-Z]</c>, dropping the leading <c>I</c>. An interface
+    /// whose stripped name would collide with another top-level type
+    /// in the same namespace keeps the prefix and surfaces
+    /// <c>MS0017</c> so the consumer notices and picks an explicit
+    /// rename. Interfaces that already carry a
+    /// <c>[Name(TypeScript, "…")]</c> override skip the pass — the
+    /// author-chosen name wins.
+    /// </summary>
+    private static void ApplyInterfacePrefixStrip(
+        IReadOnlyList<INamedTypeSymbol> transpilableTypes,
+        Dictionary<string, string> typeNamesBySymbol,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        // Index the sibling space once so collision checks stay O(1):
+        // namespace display string → set of top-level type names
+        // (current emitted, not original) living there.
+        var namespaceIndex = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var t in transpilableTypes)
+        {
+            var ns = t.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            var key = t.GetCrossAssemblyOriginKey();
+            if (!typeNamesBySymbol.TryGetValue(key, out var emitted))
+                emitted = t.Name;
+            if (!namespaceIndex.TryGetValue(ns, out var bucket))
+            {
+                bucket = new HashSet<string>(StringComparer.Ordinal);
+                namespaceIndex[ns] = bucket;
+            }
+            bucket.Add(emitted);
+        }
+
+        foreach (var type in transpilableTypes)
+        {
+            if (type.TypeKind != TypeKind.Interface)
+                continue;
+            var key = type.GetCrossAssemblyOriginKey();
+            if (!typeNamesBySymbol.TryGetValue(key, out var current))
+                continue;
+            // `[Name(TypeScript, "…")]` wins. If the frontend-stored
+            // name differs from the Roslyn name, an override is
+            // already in play — leave it alone.
+            if (!string.Equals(current, type.Name, StringComparison.Ordinal))
+                continue;
+            if (!LooksLikeInterfacePrefix(current))
+                continue;
+
+            var stripped = current[1..];
+            var ns = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            var siblings = namespaceIndex[ns];
+            if (siblings.Contains(stripped))
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Warning,
+                        DiagnosticCodes.InterfacePrefixCollision,
+                        $"Cannot strip the 'I' prefix from '{current}' in '{ns}' — "
+                            + $"another top-level type named '{stripped}' already lives in "
+                            + $"the same namespace. Keeping the prefixed name. Rename the "
+                            + $"conflicting type or set [Name(TypeScript, \"…\")] to resolve.",
+                        type.Locations.FirstOrDefault()
+                    )
+                );
+                continue;
+            }
+
+            typeNamesBySymbol[key] = stripped;
+            siblings.Remove(current);
+            siblings.Add(stripped);
+        }
+    }
+
+    /// <summary>
+    /// Matches <c>^I[A-Z]</c> — captures <c>IFoo</c> and
+    /// <c>ISO8601</c> alike. <c>[Name(TypeScript, "…")]</c> is the
+    /// documented escape hatch for names users explicitly want to
+    /// keep (<c>IOrder</c> that is not an interface, acronym-led
+    /// names).
+    /// </summary>
+    private static bool LooksLikeInterfacePrefix(string name) =>
+        name.Length >= 2 && name[0] == 'I' && char.IsUpper(name[1]);
 
     /// <summary>
     /// Lowers an <c>[ExportedAsModule]</c> static class (or any static class

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -151,12 +151,34 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             ir.TranspilableTypeEntries ?? Array.Empty<IrTranspilableTypeEntry>();
         var transpilableTypes = transpilableTypeEntries.Select(e => e.Symbol).ToList();
 
-        // Opt-in `I`-prefix strip runs once per transform, mutating the
-        // shared name dictionary so every downstream consumer
-        // (ResolveTsName, file-name derivation, import collector) sees
-        // the same rewritten identifier.
+        // Clone the frontend-produced TranspilableTypes map so the
+        // strip pass (and any future in-transformer renamer) can
+        // rewrite entries without mutating the shared IR.
+        var transpilableTypesDict = ir.TranspilableTypes is null
+            ? new Dictionary<string, IrTranspilableTypeRef>(StringComparer.Ordinal)
+            : new Dictionary<string, IrTranspilableTypeRef>(
+                ir.TranspilableTypes,
+                StringComparer.Ordinal
+            );
+
+        // Opt-in `I`-prefix strip runs once per transform, mutating
+        // both name dictionaries so every downstream consumer
+        // (ResolveTsName, file-name derivation, the import collector
+        // that walks IrTranspilableTypeRef) sees the same rewritten
+        // identifier. The rename dictionary also feeds
+        // IrToTsTypeMapper.NamedTypeRenames so emitted type
+        // references at usage sites (method parameters, property
+        // types, generic arguments) pick up the stripped identifier
+        // at the emit boundary.
+        var nameRenames = new Dictionary<string, string>(StringComparer.Ordinal);
         if (StripInterfacePrefix)
-            ApplyInterfacePrefixStrip(transpilableTypes, typeNamesBySymbol, _diagnostics);
+            ApplyInterfacePrefixStrip(
+                transpilableTypes,
+                typeNamesBySymbol,
+                transpilableTypesDict,
+                nameRenames,
+                _diagnostics
+            );
 
         // Build the explicit per-compilation context that replaces TypeMapper statics.
         var crossPackageMisses = new HashSet<string>();
@@ -179,8 +201,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             compilation,
             _currentAssembly,
             _assemblyWideTranspile,
-            ir.TranspilableTypes
-                ?? new Dictionary<string, IrTranspilableTypeRef>(StringComparer.Ordinal),
+            transpilableTypesDict,
             ir.ExternalImports,
             ir.BclExports,
             typeNamesBySymbol,
@@ -196,16 +217,31 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         var files = new List<TsSourceFile>();
 
-        // Group types by output file. Types decorated with [EmitInFile("name")] share
-        // the same file; everything else gets its own file (legacy 1:1 default). The
-        // grouping is keyed by (namespace, fileName) so types with the same EmitInFile
-        // value but different namespaces don't accidentally collide — that case is
-        // rejected later as MS0008.
-        foreach (var group in GroupTypesByFile(transpilableTypes))
+        // Publish the interface-prefix rename dict for the duration
+        // of this transform so `IrToTsTypeMapper.MapNamed` rewrites
+        // every TsNamedType identifier emitted below. The try/finally
+        // guarantees the static slot is cleared even when a bridge
+        // throws, keeping subsequent TransformAll runs clean.
+        var previousRenames = IrToTsTypeMapper.NamedTypeRenames;
+        IrToTsTypeMapper.NamedTypeRenames = nameRenames.Count > 0 ? nameRenames : null;
+        try
         {
-            var file = TransformGroup(group);
-            if (file is not null)
-                files.Add(file);
+            // Group types by output file. Types decorated with
+            // [EmitInFile("name")] share the same file; everything else gets
+            // its own file (legacy 1:1 default). The grouping is keyed by
+            // (namespace, fileName) so types with the same EmitInFile value
+            // but different namespaces don't accidentally collide — that case
+            // is rejected later as MS0008.
+            foreach (var group in GroupTypesByFile(transpilableTypes))
+            {
+                var file = TransformGroup(group);
+                if (file is not null)
+                    files.Add(file);
+            }
+        }
+        finally
+        {
+            IrToTsTypeMapper.NamedTypeRenames = previousRenames;
         }
 
         // Generate index.ts barrel files per namespace folder
@@ -520,36 +556,50 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     );
 
     /// <summary>
-    /// Rewrites every interface entry in
-    /// <paramref name="typeNamesBySymbol"/> whose C# name matches
-    /// <c>^I[A-Z]</c>, dropping the leading <c>I</c>. An interface
+    /// Rewrites every top-level transpilable interface whose C# name
+    /// matches <c>^I[A-Z]</c> in both
+    /// <paramref name="typeNamesBySymbol"/> (read by
+    /// <see cref="TypeScriptTransformContext.ResolveTsName"/> and the
+    /// interface-bridge <c>nameOverride</c> plumbing) and
+    /// <paramref name="transpilableTypesDict"/> (read by
+    /// <see cref="ImportCollector"/> + guard builder). An interface
     /// whose stripped name would collide with another top-level type
-    /// in the same namespace keeps the prefix and surfaces
-    /// <c>MS0017</c> so the consumer notices and picks an explicit
-    /// rename. Interfaces that already carry a
+    /// in the same enclosing scope (namespace for top-level types,
+    /// containing-type for nested ones) keeps the prefix and
+    /// surfaces <c>MS0017</c> so the consumer notices and picks an
+    /// explicit rename. Interfaces that already carry a
     /// <c>[Name(TypeScript, "…")]</c> override skip the pass — the
-    /// author-chosen name wins.
+    /// author-chosen name wins. Nested interfaces are deliberately
+    /// out of scope for this first slice; they retain their original
+    /// names because the downstream lowering has not yet been
+    /// audited for a rename there.
     /// </summary>
     private static void ApplyInterfacePrefixStrip(
         IReadOnlyList<INamedTypeSymbol> transpilableTypes,
         Dictionary<string, string> typeNamesBySymbol,
+        Dictionary<string, IrTranspilableTypeRef> transpilableTypesDict,
+        Dictionary<string, string> nameRenames,
         List<MetanoDiagnostic> diagnostics
     )
     {
-        // Index the sibling space once so collision checks stay O(1):
-        // namespace display string → set of top-level type names
-        // (current emitted, not original) living there.
-        var namespaceIndex = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        // Index the sibling space once so collision checks stay O(1).
+        // The scope key is the type's *enclosing container*: the
+        // containing type (`…+Outer`) when the interface is nested,
+        // or the namespace display string for top-level types. Using
+        // `ToDisplayString()` on the namespace would falsely collide
+        // nested interfaces across different outer types that happen
+        // to share a namespace.
+        var scopeIndex = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         foreach (var t in transpilableTypes)
         {
-            var ns = t.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            var scope = GetEnclosingScopeKey(t);
             var key = t.GetCrossAssemblyOriginKey();
             if (!typeNamesBySymbol.TryGetValue(key, out var emitted))
                 emitted = t.Name;
-            if (!namespaceIndex.TryGetValue(ns, out var bucket))
+            if (!scopeIndex.TryGetValue(scope, out var bucket))
             {
                 bucket = new HashSet<string>(StringComparer.Ordinal);
-                namespaceIndex[ns] = bucket;
+                scopeIndex[scope] = bucket;
             }
             bucket.Add(emitted);
         }
@@ -557,6 +607,13 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         foreach (var type in transpilableTypes)
         {
             if (type.TypeKind != TypeKind.Interface)
+                continue;
+            // Nested interfaces skip the rewrite in this slice — the
+            // bridge + file-naming paths for nested types have not
+            // been audited for the renamed identifier, and a mixed
+            // shape (stripped top-level but prefixed nested) would
+            // surprise consumers. Follow-up work can lift this.
+            if (type.ContainingType is not null)
                 continue;
             var key = type.GetCrossAssemblyOriginKey();
             if (!typeNamesBySymbol.TryGetValue(key, out var current))
@@ -570,17 +627,21 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                 continue;
 
             var stripped = current[1..];
-            var ns = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
-            var siblings = namespaceIndex[ns];
+            var scope = GetEnclosingScopeKey(type);
+            var siblings = scopeIndex[scope];
             if (siblings.Contains(stripped))
             {
+                var ns = type.ContainingNamespace is { IsGlobalNamespace: false } nsSymbol
+                    ? nsSymbol.ToDisplayString()
+                    : null;
+                var location = ns is null ? "the global namespace" : $"namespace '{ns}'";
                 diagnostics.Add(
                     new MetanoDiagnostic(
                         MetanoDiagnosticSeverity.Warning,
                         DiagnosticCodes.InterfacePrefixCollision,
-                        $"Cannot strip the 'I' prefix from '{current}' in '{ns}' — "
+                        $"Cannot strip the 'I' prefix from '{current}' in {location} — "
                             + $"another top-level type named '{stripped}' already lives in "
-                            + $"the same namespace. Keeping the prefixed name. Rename the "
+                            + $"the same scope. Keeping the prefixed name. Rename the "
                             + $"conflicting type or set [Name(TypeScript, \"…\")] to resolve.",
                         type.Locations.FirstOrDefault()
                     )
@@ -591,8 +652,46 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             typeNamesBySymbol[key] = stripped;
             siblings.Remove(current);
             siblings.Add(stripped);
+            RewriteTranspilableTypeEntry(transpilableTypesDict, current, stripped);
+            nameRenames[current] = stripped;
         }
     }
+
+    /// <summary>
+    /// Propagates the rewritten name into
+    /// <see cref="TypeScriptTransformContext.TranspilableTypes"/>.
+    /// The frontend registers each entry under its source name (and
+    /// its TS alias when they diverge). Under the strip, the source
+    /// name (<c>IIssueRepository</c>) goes away from the dict and
+    /// the stripped form (<c>IssueRepository</c>) becomes the
+    /// consumer-visible key, with <c>TsName</c> + <c>FileName</c>
+    /// updated so the import collector emits the rewritten file
+    /// path and identifier.
+    /// </summary>
+    private static void RewriteTranspilableTypeEntry(
+        Dictionary<string, IrTranspilableTypeRef> dict,
+        string sourceName,
+        string stripped
+    )
+    {
+        if (!dict.TryGetValue(sourceName, out var entry))
+            return;
+        var rewrittenFileName = string.Equals(entry.FileName, SymbolHelper.ToKebabCase(sourceName))
+            ? SymbolHelper.ToKebabCase(stripped)
+            : entry.FileName;
+        var updated = entry with { TsName = stripped, FileName = rewrittenFileName };
+        dict.Remove(sourceName);
+        dict[stripped] = updated;
+    }
+
+    private static string GetEnclosingScopeKey(INamedTypeSymbol type) =>
+        type.ContainingType is { } outer
+            ? outer.ToDisplayString()
+            : (
+                type.ContainingNamespace is { IsGlobalNamespace: false } ns
+                    ? ns.ToDisplayString()
+                    : string.Empty
+            );
 
     /// <summary>
     /// Matches <c>^I[A-Z]</c> — captures <c>IFoo</c> and

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -63,6 +63,19 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     public bool NamespaceBarrels { get; init; }
 
+    /// <summary>
+    /// When <c>true</c>, the transformer rewrites every interface
+    /// whose C# name matches <c>^I[A-Z]</c> to drop the leading
+    /// <c>I</c> (so <c>IIssueRepository</c> emits as
+    /// <c>IssueRepository</c>). Interfaces whose stripped name would
+    /// collide with another top-level type in the same namespace
+    /// keep the prefix and raise <c>MS0017</c>. Explicit
+    /// <c>[Name(TypeScript, "…")]</c> overrides win over the strip.
+    /// Opt-in via <c>--strip-interface-prefix</c>; the default stays
+    /// off so existing consumer imports keep working on upgrade.
+    /// </summary>
+    public bool StripInterfacePrefix { get; init; }
+
     public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
     {
         if (compilation is null)
@@ -75,6 +88,7 @@ public sealed class TypeScriptTarget : ITranspilerTarget
         var transformer = new TypeTransformer(ir, compilation)
         {
             NamespaceBarrels = NamespaceBarrels,
+            StripInterfacePrefix = StripInterfacePrefix,
         };
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -128,6 +128,16 @@ public static class DiagnosticCodes
     /// literal form without a separate analyzer pass.</summary>
     public const string InvalidConstant = "MS0014";
 
+    /// <summary>MS0017 — Stripping the <c>I</c> prefix from an
+    /// interface name would collide with another top-level type in
+    /// the same namespace. Emitted only when
+    /// <c>--strip-interface-prefix</c> / <c>MetanoStripInterfacePrefix</c>
+    /// is enabled. The generator falls back to keeping the original
+    /// prefixed name so the consumer surface stays compilable;
+    /// authors wanting the strip must rename the conflicting type or
+    /// override one side with <c>[Name(TypeScript, "…")]</c>.</summary>
+    public const string InterfacePrefixCollision = "MS0017";
+
     /// <summary>MS0016 — <c>[Inline]</c> (from
     /// <c>Metano.Annotations</c>) was applied to an unsupported
     /// shape or its expansion would cycle. Valid targets are

--- a/tests/Metano.Tests/StripInterfacePrefixTests.cs
+++ b/tests/Metano.Tests/StripInterfacePrefixTests.cs
@@ -1,0 +1,143 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for the opt-in <c>--strip-interface-prefix</c> flag (issue
+/// #92). When enabled, the transformer rewrites every interface
+/// whose C# name matches <c>^I[A-Z]</c> to drop the leading <c>I</c>
+/// so generated TypeScript matches community conventions
+/// (<c>IIssueRepository</c> → <c>IssueRepository</c>). Collisions
+/// with sibling types in the same namespace keep the prefix and
+/// raise <c>MS0017</c>. Explicit
+/// <c>[Name(TypeScript, "…")]</c> overrides win over the strip.
+/// </summary>
+public class StripInterfacePrefixTests
+{
+    [Test]
+    public async Task StripInterfacePrefix_NoCollision_DropsPrefix()
+    {
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [assembly: TranspileAssembly]
+
+            public interface IIssueRepository
+            {
+                string Name { get; }
+            }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("issue-repository.ts");
+        await Assert.That(files).DoesNotContainKey("i-issue-repository.ts");
+        var output = files["issue-repository.ts"];
+        await Assert.That(output).Contains("export interface IssueRepository");
+        await Assert.That(output).DoesNotContain("IIssueRepository");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_OffByDefault_PreservesPrefix()
+    {
+        // Regression guard: without the flag the historical shape is
+        // preserved byte-for-byte so consumer imports do not break
+        // on upgrade.
+        var files = TranspileHelper.Transpile(
+            """
+            [assembly: TranspileAssembly]
+
+            public interface IIssueRepository
+            {
+                string Name { get; }
+            }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("i-issue-repository.ts");
+        await Assert.That(files["i-issue-repository.ts"]).Contains("IIssueRepository");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_CollidesWithSiblingClass_KeepsPrefixAndEmitsMs0017()
+    {
+        var (files, diagnostics) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [assembly: TranspileAssembly]
+
+            public interface IIssueRepository { string Name { get; } }
+
+            public class IssueRepository
+            {
+                public string Name => "fixed";
+            }
+            """
+        );
+
+        // Conflict → prefix preserved so neither consumer import
+        // collapses into the other.
+        await Assert.That(files).ContainsKey("i-issue-repository.ts");
+        await Assert.That(files).ContainsKey("issue-repository.ts");
+
+        var ms0017 = diagnostics.FirstOrDefault(d =>
+            d.Code == DiagnosticCodes.InterfacePrefixCollision
+        );
+        await Assert.That(ms0017).IsNotNull();
+        await Assert.That(ms0017!.Message).Contains("IIssueRepository");
+        await Assert.That(ms0017!.Message).Contains("IssueRepository");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_NameOverride_WinsOverStrip()
+    {
+        // `[Name(TypeScript, "…")]` already requested a specific
+        // emitted name; the strip pass must leave it alone.
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            [Name(TargetLanguage.TypeScript, "IRepo")]
+            public interface IIssueRepository { string Name { get; } }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("i-repo.ts");
+        await Assert.That(files["i-repo.ts"]).Contains("export interface IRepo");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_IdentityShape_DoesNotMatch()
+    {
+        // `Identity` lacks the `I[A-Z]` shape (second char is lowercase);
+        // the regex rejects it so the strip does not over-reach.
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [assembly: TranspileAssembly]
+
+            public interface Identity { string Name { get; } }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("identity.ts");
+        await Assert.That(files["identity.ts"]).Contains("export interface Identity");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_DoesNotTouchClasses()
+    {
+        // `IpAddress` is a class, not an interface — its name must
+        // not be rewritten even though it would match the regex.
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [assembly: TranspileAssembly]
+
+            public class IPAddress
+            {
+                public string Value => "127.0.0.1";
+            }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("ip-address.ts");
+        await Assert.That(files["ip-address.ts"]).Contains("export class IPAddress");
+    }
+}

--- a/tests/Metano.Tests/StripInterfacePrefixTests.cs
+++ b/tests/Metano.Tests/StripInterfacePrefixTests.cs
@@ -122,6 +122,41 @@ public class StripInterfacePrefixTests
     }
 
     [Test]
+    public async Task StripInterfacePrefix_ConsumerImportsUseStrippedName()
+    {
+        // Integration: a separate transpilable class references the
+        // interface. The consumer must import the stripped name from
+        // the stripped file path; without mirroring the rewrite into
+        // TranspilableTypes, the import collector would emit the
+        // original `IIssueRepository` / `i-issue-repository` pair and
+        // the generated TS would break.
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [assembly: TranspileAssembly]
+
+            public interface IIssueRepository
+            {
+                string Name { get; }
+            }
+
+            public class Service
+            {
+                private readonly IIssueRepository _repo;
+                public Service(IIssueRepository repo) { _repo = repo; }
+                public string Name => _repo.Name;
+            }
+            """
+        );
+
+        await Assert.That(files).ContainsKey("service.ts");
+        var output = files["service.ts"];
+        await Assert.That(output).Contains("IssueRepository");
+        await Assert.That(output).Contains("./issue-repository");
+        await Assert.That(output).DoesNotContain("IIssueRepository");
+        await Assert.That(output).DoesNotContain("i-issue-repository");
+    }
+
+    [Test]
     public async Task StripInterfacePrefix_DoesNotTouchClasses()
     {
         // `IpAddress` is a class, not an interface — its name must

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -131,7 +131,8 @@ public static class TranspileHelper
     ) TranspileCore(
         CSharpCompilation compilation,
         bool useIrBodies = true,
-        bool namespaceBarrels = false
+        bool namespaceBarrels = false,
+        bool stripInterfacePrefix = false
     )
     {
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
@@ -139,6 +140,7 @@ public static class TranspileHelper
         {
             UseIrBodiesWhenCovered = useIrBodies,
             NamespaceBarrels = namespaceBarrels,
+            StripInterfacePrefix = stripInterfacePrefix,
         };
         var files = transformer.TransformAll();
         var printer = new Printer();
@@ -190,6 +192,25 @@ public static class TranspileHelper
             OutputKind.DynamicallyLinkedLibrary
         );
         return TranspileCore(compilation, namespaceBarrels: true).Files;
+    }
+
+    /// <summary>
+    /// Variant of <see cref="Transpile"/> that enables the opt-in
+    /// <c>--strip-interface-prefix</c> flag. Returns both the emitted
+    /// files and the merged diagnostics so collision tests can
+    /// assert <c>MS0017</c> when the strip cannot apply.
+    /// </summary>
+    public static (
+        Dictionary<string, string> Files,
+        IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic> Diagnostics
+    ) TranspileWithStripInterfacePrefix(string csharpSource)
+    {
+        var compilation = CompileAssembly(
+            csharpSource,
+            "TestAssembly",
+            OutputKind.DynamicallyLinkedLibrary
+        );
+        return TranspileCore(compilation, stripInterfacePrefix: true);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #92 (mechanics). Opt-in `--strip-interface-prefix` CLI flag (also surfaced as `MetanoStripInterfacePrefix` MSBuild property) rewrites every transpilable interface whose C# name matches `^I[A-Z]` to drop the leading `I` when emitted to TypeScript:

```
public interface IIssueRepository { ... }
// default:  file i-issue-repository.ts, `export interface IIssueRepository`
// opt-in:   file issue-repository.ts,   `export interface IssueRepository`
```

Default stays off — same compatibility story as `--namespace-barrels` (#22). Flipping by default waits for a major version bump.

## Pipeline

- `Commands.Transpile` accepts the new `stripInterfacePrefix` flag and forwards it to `TypeScriptTarget`.
- `TypeScriptTarget.StripInterfacePrefix` forwards into `TypeTransformer`.
- `TypeTransformer.TransformAll` clones `ir.TypeNamesBySymbol` into a local mutable dictionary and runs `ApplyInterfacePrefixStrip` once. The pass indexes transpilable types by namespace, detects collisions with sibling types, and rewrites the entry in place.
- `ResolveTsName`, file-name derivation (`GroupTypesByFile`), and `ImportCollector` all consume the rewritten map transparently — no per-consumer plumbing.
- `IrToTsInterfaceBridge.Convert` accepts an optional `nameOverride` so the emitted `export interface <Name>` matches the rewritten dictionary entry.
- `Metano.Build.targets` wires the MSBuild property into `_MetanoArgs`.

## Collision handling (MS0017)

When the stripped name would clash with another top-level type in the same namespace, the transformer keeps the prefixed name and emits `MS0017 InterfacePrefixCollision` as a warning. Resolution: rename the conflicting type, or set `[Name(TypeScript, "…")]` on one side.

## `[Name]` override precedence

Author-provided `[Name(TypeScript, "…")]` wins over the strip. The pass skips entries whose current (frontend-registered) name diverges from the Roslyn type name, so the author-chosen TS name passes through unchanged.

## Out of scope

- Sample migration (`SampleIssueTracker.csproj` flipping to the opt-in) — follow-up.
- ADR update covering the opt-in default rationale — follow-up.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **696/696 green** (689 → 696), 6 new tests in `StripInterfacePrefixTests`:
  - `NoCollision_DropsPrefix` — canonical rewrite
  - `OffByDefault_PreservesPrefix` — compat guard
  - `CollidesWithSiblingClass_KeepsPrefixAndEmitsMs0017` — diagnostic + fallback
  - `NameOverride_WinsOverStrip` — author override precedence
  - `IdentityShape_DoesNotMatch` — `/^I[A-Z]/` heuristic guard
  - `DoesNotTouchClasses` — interface-only scope
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the mutable-copy of `TypeNamesBySymbol` in `TypeTransformer.TransformAll` does not regress any cross-assembly lookup path — the transformer-local copy is what every downstream site reads
- [ ] Reviewer: sanity-check the heuristic scope (`/^I[A-Z]/` captures `IFoo` and `ISO8601` alike; users opt out per-type via `[Name(TypeScript, "…")]`)

Closes #92.