### PR TITLE
feat(ts): introduce [This] attribute — Slice A (delegate type signature)

### DIFF
--- a/spec/09-attribute-catalog.md
+++ b/spec/09-attribute-catalog.md
@@ -1,7 +1,7 @@
 # Attribute Catalog
 
 This appendix lists the currently available Metano annotations relevant to the
-transpilation model. The current codebase exposes **25 attribute types** in
+transpilation model. The current codebase exposes **26 attribute types** in
 `Metano.Annotations`, plus the supporting `EmitTarget` enum used by some
 annotations.
 
@@ -45,6 +45,7 @@ annotations.
 | `ExternalAttribute` (TypeScript) | Marks a `static class` as a stub for runtime-available JS globals — the class emits no file and static member access flattens to a bare identifier. Attribute usage now accepts method/property/field targets so the family can grow; the per-member declaration-suppression lowering and the split from class-level flatten ship in a follow-up slice. |
 | `ConstantAttribute` | Applied to a parameter or field; the value must be a compile-time constant literal. Violations surface as MS0014 `InvalidConstant`. Enables literal-type narrowing in `[Emit]` templates and safe `[Inline]` expansion. |
 | `InlineAttribute` | Applied to a `static readonly` field or a `static` property with an expression-bodied getter; every reference substitutes the member's initializer (or getter expression) at the call site. Method / extension inlining and static-class propagation ship in a follow-up slice. Violations surface as MS0016 `InvalidInline`. |
+| `ThisAttribute` | Applied to the first parameter of a delegate or inlinable method; promotes the slot to the synthetic JavaScript `this` receiver. The parameter is dropped from the emitted TS positional list and re-introduced as the function type's `this` annotation (`(this: T, …) => R`). Lambda / method-group / body-rewrite emission lands in a follow-up slice. Violations surface as MS0018 `InvalidThis`. |
 
 ## Packaging and Interop
 

--- a/spec/10-diagnostic-catalog.md
+++ b/spec/10-diagnostic-catalog.md
@@ -12,7 +12,7 @@ Each diagnostic carries:
 - message;
 - optional source location.
 
-The current stable code range is **`MS0001` through `MS0017`**, with
+The current stable code range is **`MS0001` through `MS0018`**, with
 `MS0013` reserved for the upcoming `[NoEmit]` redefinition slice
 (see ADR-0015).
 
@@ -36,6 +36,7 @@ The current stable code range is **`MS0001` through `MS0017`**, with
 | `MS0015` | `InvalidErasable` | `[Erasable]` was applied to a non-static class, or combined with `[Transpile]`. |
 | `MS0016` | `InvalidInline` | `[Inline]` was applied to an unsupported shape (instance or mutable field, field without initializer, block-bodied property, non-static property, or any other target). |
 | `MS0017` | `InterfacePrefixCollision` | Stripping the `I` prefix from an interface name (under `--strip-interface-prefix`) would collide with another top-level type in the same namespace. Keeps the prefix so the consumer surface stays compilable. |
+| `MS0018` | `InvalidThis` | `[This]` (from `Metano.Annotations`) was applied outside the first positional parameter, or combined with `ref` / `out` / `params`. |
 
 ## Reserved Codes
 

--- a/src/Metano.Compiler.Dart/Bridge/IrToDartTypeMapper.cs
+++ b/src/Metano.Compiler.Dart/Bridge/IrToDartTypeMapper.cs
@@ -32,7 +32,7 @@ public static class IrToDartTypeMapper
                 [Map(kv.KeyType), Map(kv.ValueType)]
             ),
             IrFunctionTypeRef f => new DartFunctionType(
-                f.Parameters.Select(p => new DartParameter(p.Name, Map(p.Type))).ToList(),
+                BuildDartFunctionParameters(f),
                 Map(f.ReturnType)
             ),
             IrPromiseTypeRef pr => new DartNamedType("Future", [Map(pr.ResultType)]),
@@ -59,6 +59,24 @@ public static class IrToDartTypeMapper
             : null;
 
         return new DartNamedType(named.Name, args, origin);
+    }
+
+    /// <summary>
+    /// Materializes the Dart parameter list for a function type. Dart
+    /// has no JS-style <c>this</c> rebind, so when the IR carries a
+    /// <see cref="IrFunctionTypeRef.ThisType"/> (promoted by the TS
+    /// backend contract for <c>[This]</c>), the Dart bridge
+    /// re-introduces it as a regular positional parameter at
+    /// index 0 — the attribute degrades to a no-op on this backend
+    /// rather than silently dropping the receiver from the signature.
+    /// </summary>
+    private static IReadOnlyList<DartParameter> BuildDartFunctionParameters(IrFunctionTypeRef f)
+    {
+        var parameters = new List<DartParameter>(f.Parameters.Count + (f.ThisType is null ? 0 : 1));
+        if (f.ThisType is { } thisType)
+            parameters.Add(new DartParameter("self", Map(thisType)));
+        parameters.AddRange(f.Parameters.Select(p => new DartParameter(p.Name, Map(p.Type))));
+        return parameters;
     }
 
     private static DartType MapPrimitive(IrPrimitive primitive) =>

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
@@ -461,6 +461,8 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
                 break;
             case IrFunctionTypeRef fn:
                 CollectTypeParamRefs(fn.ReturnType, acc);
+                if (fn.ThisType is { } thisType)
+                    CollectTypeParamRefs(thisType, acc);
                 foreach (var p in fn.Parameters)
                     CollectTypeParamRefs(p.Type, acc);
                 break;

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeMapper.cs
@@ -27,7 +27,8 @@ public static class IrToTsTypeMapper
             IrTupleTypeRef t => new TsTupleType(t.Elements.Select(e => Map(e, overrides)).ToList()),
             IrFunctionTypeRef f => new TsFunctionType(
                 f.Parameters.Select(p => MapParameter(p, overrides)).ToList(),
-                Map(f.ReturnType, overrides)
+                Map(f.ReturnType, overrides),
+                f.ThisType is null ? null : Map(f.ThisType, overrides)
             ),
             IrPromiseTypeRef pr => new TsPromiseType(Map(pr.ResultType, overrides)),
             IrGeneratorTypeRef g => new TsNamedType("Generator", [Map(g.YieldType, overrides)]),

--- a/src/Metano.Compiler.TypeScript/Bridge/IrTypeRefSignatures.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrTypeRefSignatures.cs
@@ -19,8 +19,7 @@ internal static class IrTypeRefSignatures
             IrMapTypeRef m => $"map<{Describe(m.KeyType)},{Describe(m.ValueType)}>",
             IrSetTypeRef s => $"set<{Describe(s.ElementType)}>",
             IrTupleTypeRef t => $"tuple<{string.Join(",", t.Elements.Select(Describe))}>",
-            IrFunctionTypeRef f =>
-                $"fn<{string.Join(",", f.Parameters.Select(p => Describe(p.Type)))}->{Describe(f.ReturnType)}>",
+            IrFunctionTypeRef f => BuildFunctionSignature(f),
             IrPromiseTypeRef pr => $"promise<{Describe(pr.ResultType)}>",
             IrGeneratorTypeRef g => $"gen<{Describe(g.YieldType)}>",
             IrIterableTypeRef i => $"iter<{Describe(i.ElementType)}>",
@@ -33,4 +32,23 @@ internal static class IrTypeRefSignatures
             IrUnknownTypeRef => "unknown",
             _ => "?",
         };
+
+    /// <summary>
+    /// Describes an <see cref="IrFunctionTypeRef"/>. Keeps the
+    /// historical <c>fn&lt;p1,p2-&gt;R&gt;</c> shape when the ref has
+    /// no synthetic <c>this</c> receiver; prefixes with
+    /// <c>this:T,</c> when <see cref="IrFunctionTypeRef.ThisType"/> is
+    /// populated so the signature key distinguishes delegates that
+    /// rebind <c>this</c> from shape-compatible siblings that don't.
+    /// </summary>
+    private static string BuildFunctionSignature(IrFunctionTypeRef f)
+    {
+        var positional = string.Join(",", f.Parameters.Select(p => Describe(p.Type)));
+        var args = f.ThisType is { } thisType
+            ? positional.Length == 0
+                ? $"this:{Describe(thisType)}"
+                : $"this:{Describe(thisType)},{positional}"
+            : positional;
+        return $"fn<{args}->{Describe(f.ReturnType)}>";
+    }
 }

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsFunctionType.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsFunctionType.cs
@@ -1,9 +1,16 @@
 namespace Metano.TypeScript.AST;
 
 /// <summary>
-/// A TypeScript function type: <c>(param: T) => R</c>.
-/// Used for delegate type mappings (<c>Action&lt;T&gt;</c>, <c>Func&lt;T,R&gt;</c>,
+/// A TypeScript function type: <c>(param: T) =&gt; R</c>. When
+/// <paramref name="ThisType"/> is set, the printer emits the TS
+/// synthetic <c>this</c> annotation as the first parameter
+/// (<c>(this: T, …) =&gt; R</c>) — used for delegates whose first
+/// parameter carried <c>[This]</c>. Used for delegate type
+/// mappings (<c>Action&lt;T&gt;</c>, <c>Func&lt;T,R&gt;</c>,
 /// <c>EventHandler&lt;T&gt;</c>, and custom delegate types).
 /// </summary>
-public sealed record TsFunctionType(IReadOnlyList<TsParameter> Parameters, TsType ReturnType)
-    : TsType;
+public sealed record TsFunctionType(
+    IReadOnlyList<TsParameter> Parameters,
+    TsType ReturnType,
+    TsType? ThisType = null
+) : TsType;

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -761,6 +761,13 @@ public sealed class Printer(string indent = "  ")
 
             case TsFunctionType funcType:
                 _sb.Write("(");
+                if (funcType.ThisType is { } thisType)
+                {
+                    _sb.Write("this: ");
+                    PrintType(thisType);
+                    if (funcType.Parameters.Count > 0)
+                        _sb.Write(", ");
+                }
                 PrintParameters(funcType.Parameters);
                 _sb.Write(") => ");
                 PrintType(funcType.ReturnType);

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -142,6 +142,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             ValidateExternalAttribute(compilation, diagnostics);
             ValidateConstantAttribute(compilation, assemblyWideTranspile, diagnostics);
             ValidateInlineAttribute(compilation, diagnostics);
+            ValidateThisAttribute(compilation, diagnostics);
         }
 
         return new IrCompilation(
@@ -1133,6 +1134,88 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
             }
         }
         return false;
+    }
+
+    /// <summary>
+    /// Validates <c>[This]</c> from <c>Metano.Annotations</c>. The
+    /// attribute may decorate only the first parameter of a
+    /// delegate or method, and never a <c>ref</c> / <c>out</c> /
+    /// <c>params</c> slot — any other shape surfaces
+    /// <c>MS0018 InvalidThis</c>. The pass walks every type in the
+    /// current assembly: custom delegate types (the invoke
+    /// method's parameters) and ordinary methods alike.
+    /// </summary>
+    private static void ValidateThisAttribute(
+        Compilation compilation,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        var currentAssembly = compilation.Assembly;
+        CollectTopLevelTypes(
+            currentAssembly.GlobalNamespace,
+            type => VisitTypeForThis(type, diagnostics)
+        );
+    }
+
+    private static void VisitTypeForThis(INamedTypeSymbol type, List<MetanoDiagnostic> diagnostics)
+    {
+        // Delegate types expose their parameter list via the synthesized
+        // Invoke method — a plain `.GetMembers()` walk over
+        // IMethodSymbol covers both ordinary methods and delegate
+        // invokes in one pass.
+        foreach (var member in type.GetMembers())
+        {
+            if (member is IMethodSymbol method)
+                ValidateMethodParametersForThis(method, diagnostics);
+        }
+        foreach (var nested in type.GetTypeMembers())
+            VisitTypeForThis(nested, diagnostics);
+    }
+
+    private static void ValidateMethodParametersForThis(
+        IMethodSymbol method,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            var parameter = method.Parameters[i];
+            if (!parameter.HasThis())
+                continue;
+            if (i != 0)
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidThis,
+                        $"[This] on parameter '{parameter.Name}' of "
+                            + $"{FormatMemberPath(method)} is only valid on the first "
+                            + $"positional parameter. The attribute promotes the first "
+                            + $"slot to the synthetic JavaScript 'this' receiver; later "
+                            + $"parameters cannot take that role.",
+                        parameter.Locations.FirstOrDefault()
+                    )
+                );
+                continue;
+            }
+            if (
+                parameter.RefKind is RefKind.Ref or RefKind.Out or RefKind.RefReadOnly
+                || parameter.IsParams
+            )
+            {
+                diagnostics.Add(
+                    new MetanoDiagnostic(
+                        MetanoDiagnosticSeverity.Error,
+                        DiagnosticCodes.InvalidThis,
+                        $"[This] on parameter '{parameter.Name}' of "
+                            + $"{FormatMemberPath(method)} cannot be combined with "
+                            + $"'ref' / 'out' / 'params'. The receiver is passed by "
+                            + $"value at the JavaScript boundary.",
+                        parameter.Locations.FirstOrDefault()
+                    )
+                );
+            }
+        }
     }
 
     /// <summary>

--- a/src/Metano.Compiler/CSharpSourceFrontend.cs
+++ b/src/Metano.Compiler/CSharpSourceFrontend.cs
@@ -1199,7 +1199,7 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                 continue;
             }
             if (
-                parameter.RefKind is RefKind.Ref or RefKind.Out or RefKind.RefReadOnly
+                parameter.RefKind is RefKind.Ref or RefKind.Out or RefKind.In or RefKind.RefReadOnly
                 || parameter.IsParams
             )
             {
@@ -1209,8 +1209,8 @@ public sealed class CSharpSourceFrontend : ISourceFrontend
                         DiagnosticCodes.InvalidThis,
                         $"[This] on parameter '{parameter.Name}' of "
                             + $"{FormatMemberPath(method)} cannot be combined with "
-                            + $"'ref' / 'out' / 'params'. The receiver is passed by "
-                            + $"value at the JavaScript boundary.",
+                            + $"'ref' / 'out' / 'in' / 'params'. The receiver is passed "
+                            + $"by value at the JavaScript boundary.",
                         parameter.Locations.FirstOrDefault()
                     )
                 );

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -128,6 +128,18 @@ public static class DiagnosticCodes
     /// literal form without a separate analyzer pass.</summary>
     public const string InvalidConstant = "MS0014";
 
+    /// <summary>MS0018 — <c>[This]</c> (from
+    /// <c>Metano.Annotations</c>) was applied to a parameter that
+    /// cannot act as the JavaScript <c>this</c> receiver. Valid
+    /// placement is strictly the first positional parameter of a
+    /// delegate or inlinable method, without <c>ref</c> /
+    /// <c>out</c> / <c>params</c> modifiers. The diagnostic surfaces
+    /// misuses such as applying the attribute to a later parameter,
+    /// to a <c>ref</c> / <c>out</c> / <c>params</c> slot, or to a
+    /// parameter list whose emitted shape would leave the function
+    /// without a receiver to bind to.</summary>
+    public const string InvalidThis = "MS0018";
+
     /// <summary>MS0017 — Stripping the <c>I</c> prefix from an
     /// interface name would collide with another top-level type in
     /// the same namespace. Emitted only when

--- a/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
+++ b/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
@@ -238,6 +238,8 @@ public static class IrRuntimeRequirementScanner
                     ScanTypeRef(e, acc);
                 break;
             case IrFunctionTypeRef f:
+                if (f.ThisType is { } thisType)
+                    ScanTypeRef(thisType, acc);
                 foreach (var p in f.Parameters)
                     ScanTypeRef(p.Type, acc);
                 ScanTypeRef(f.ReturnType, acc);

--- a/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
+++ b/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
@@ -441,15 +441,29 @@ public static class IrTypeRefMapper
         if (invoke is null)
             return new IrFunctionTypeRef([], new IrPrimitiveTypeRef(IrPrimitive.Void));
 
-        var parameters = invoke
-            .Parameters.Select(p => new IrParameter(p.Name, Map(p.Type, originResolver)))
+        // `[This]` on the first parameter promotes it to the
+        // synthetic `this` receiver slot. The parameter itself is
+        // dropped from the positional list so each backend picks
+        // the emission shape it prefers — TypeScript prepends a
+        // `(this: T, …)` annotation, Dart re-introduces the
+        // parameter as a regular positional arg in its bridge.
+        IrTypeRef? thisType = null;
+        var sourceParameters = invoke.Parameters;
+        if (sourceParameters.Length > 0 && SymbolHelper.HasThis(sourceParameters[0]))
+        {
+            thisType = Map(sourceParameters[0].Type, originResolver);
+            sourceParameters = sourceParameters.RemoveAt(0);
+        }
+
+        var parameters = sourceParameters
+            .Select(p => new IrParameter(p.Name, Map(p.Type, originResolver)))
             .ToList();
 
         var returnType = invoke.ReturnsVoid
             ? new IrPrimitiveTypeRef(IrPrimitive.Void)
             : Map(invoke.ReturnType, originResolver);
 
-        return new IrFunctionTypeRef(parameters, returnType);
+        return new IrFunctionTypeRef(parameters, returnType, thisType);
     }
 
     /// <summary>

--- a/src/Metano.Compiler/IR/IrTypeRef.cs
+++ b/src/Metano.Compiler/IR/IrTypeRef.cs
@@ -129,10 +129,18 @@ public sealed record IrTupleTypeRef(IReadOnlyList<IrTypeRef> Elements) : IrTypeR
 
 /// <summary>
 /// A function/delegate type (C# <c>Action&lt;T&gt;</c>, <c>Func&lt;T,R&gt;</c>,
-/// or any custom delegate).
+/// or any custom delegate). <paramref name="ThisType"/> holds the
+/// synthetic JavaScript <c>this</c> receiver when the delegate's
+/// first parameter carried <c>[This]</c>; the parameter itself is
+/// dropped from <paramref name="Parameters"/> so each backend emits
+/// the shape it prefers (TypeScript inserts a <c>(this: T, …)</c>
+/// annotation; Dart re-introduces the parameter positionally).
 /// </summary>
-public sealed record IrFunctionTypeRef(IReadOnlyList<IrParameter> Parameters, IrTypeRef ReturnType)
-    : IrTypeRef;
+public sealed record IrFunctionTypeRef(
+    IReadOnlyList<IrParameter> Parameters,
+    IrTypeRef ReturnType,
+    IrTypeRef? ThisType = null
+) : IrTypeRef;
 
 /// <summary>
 /// An asynchronous result (C# <c>Task&lt;T&gt;</c>, <c>ValueTask&lt;T&gt;</c>).

--- a/src/Metano.Compiler/SymbolHelper.cs
+++ b/src/Metano.Compiler/SymbolHelper.cs
@@ -248,6 +248,24 @@ public static class SymbolHelper
             );
 
     /// <summary>
+    /// Reads <c>[This]</c> from <c>Metano.Annotations</c>. Marks
+    /// the first parameter of a delegate (or inlinable method) as
+    /// the JavaScript <c>this</c> receiver so backends that support
+    /// the rebind can drop the parameter from the positional list
+    /// and emit it as the function type's synthetic <c>this</c>
+    /// annotation. Namespace-qualified match so unrelated
+    /// <c>[This]</c> attributes from other libraries are not
+    /// mistaken for the Metano variant.
+    /// </summary>
+    public static bool HasThis(this ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(a =>
+                a.AttributeClass?.Name is ("ThisAttribute" or "This")
+                && a.AttributeClass?.ContainingNamespace?.ToDisplayString() == "Metano.Annotations"
+            );
+
+    /// <summary>
     /// Reads <c>[Inline]</c> from <c>Metano.Annotations</c>. Marks
     /// a <c>static readonly</c> field or a <c>static</c> property
     /// for use-site substitution — every reference to the member is

--- a/src/Metano/Annotations/ThisAttribute.cs
+++ b/src/Metano/Annotations/ThisAttribute.cs
@@ -1,0 +1,40 @@
+namespace Metano.Annotations;
+
+/// <summary>
+/// Marks the first parameter of a <c>delegate</c> declaration (or an
+/// inlinable method) as the JavaScript <c>this</c> receiver. The
+/// decorated parameter is dropped from the emitted TypeScript
+/// parameter list and re-introduced as the function type's
+/// synthetic <c>this</c> annotation:
+/// <code>
+/// public delegate void MouseEventListener([This] Element self, MouseEvent @event);
+/// </code>
+/// lowers to
+/// <code>
+/// export type MouseEventListener = (this: Element, event: MouseEvent) =&gt; void;
+/// </code>
+/// Lambdas, anonymous methods, and named methods bound to a
+/// <c>[This]</c>-bearing delegate must emit with the <c>function</c>
+/// keyword so the runtime can rebind <c>this</c> at dispatch time
+/// (arrow functions inherit <c>this</c> from the enclosing scope,
+/// which would defeat the pattern).
+/// <para>
+/// Applies only to the first parameter. <c>ref</c> / <c>out</c> /
+/// <c>params</c> modifiers are rejected with <c>MS0018</c>, as is
+/// any attempt to attach the attribute to a parameter past index 0.
+/// </para>
+/// <para>
+/// Backends that have no JS-style <c>this</c> rebinding (Dart,
+/// Kotlin today) treat the attribute as a no-op and keep the
+/// parameter as a regular positional argument in the emitted
+/// signature.
+/// </para>
+/// <para>
+/// <c>[This]</c> lives in <see cref="Metano.Annotations"/> because
+/// the intent (first parameter acts as the call-site receiver) is
+/// meaningful for every backend, even when only the TypeScript
+/// target realizes it today.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+public sealed class ThisAttribute : Attribute;

--- a/tests/Metano.Tests/DartBackendTests.cs
+++ b/tests/Metano.Tests/DartBackendTests.cs
@@ -474,6 +474,36 @@ public class DartBackendTests
     }
 
     [Test]
+    public async Task ThisAttribute_DartBridge_ReintroducesReceiverAsFirstParameter()
+    {
+        // Dart has no JS-style `this` rebind, so the `[This]`
+        // attribute degrades to a no-op: the receiver promoted into
+        // IrFunctionTypeRef.ThisType is re-introduced as a regular
+        // positional parameter at index 0. Guards that the TS-
+        // specific rewrite does not silently drop the receiver from
+        // the Dart signature.
+        var (files, _) = TranspileDart(
+            """
+            [Transpile]
+            public abstract class Element {}
+
+            public delegate void MouseEventListener([This] Element self, string arg);
+
+            [Transpile]
+            public class Widget
+            {
+                public MouseEventListener? OnClick { get; set; }
+            }
+            """
+        );
+
+        var dart = files["widget.dart"];
+        // The receiver type still appears as the first positional
+        // parameter in the emitted function-typed field.
+        await Assert.That(dart).Contains("Element");
+    }
+
+    [Test]
     public async Task TemporalRelationalLowering_DoesNotLeakIntoDartTarget()
     {
         // The TypeScript-specific `Temporal.*.compare(...) op 0`

--- a/tests/Metano.Tests/ThisAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ThisAttributeTranspileTests.cs
@@ -1,0 +1,127 @@
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for Slice A of <c>[This]</c> (issue #113): the attribute
+/// promotes the first parameter of a delegate to the synthetic
+/// JavaScript <c>this</c> receiver. In this slice the TS delegate
+/// type emits with a <c>(this: T, …)</c> signature and the validator
+/// rejects misuse (non-first position, <c>ref</c>/<c>out</c>/<c>params</c>).
+/// Body rewriting, lambda <c>function</c>-keyword emission, and
+/// method-group assignment land in later slices.
+/// </summary>
+public class ThisAttributeTranspileTests
+{
+    [Test]
+    public async Task This_OnDelegateFirstParameter_EmitsThisAnnotationInFunctionType()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void MouseEventListener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public MouseEventListener? OnClick { get; set; }
+            }
+            """
+        );
+
+        // The delegate-typed property on `Widget` lowers to the
+        // TypeScript function type; the emitted signature carries the
+        // synthetic `this: Element` slot and the remaining
+        // parameters after the one dropped by the attribute.
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("(this: Element, arg: string) => void");
+    }
+
+    [Test]
+    public async Task This_OnNonFirstParameter_EmitsMs0018()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element {}
+
+            public delegate void BadListener(Element self, [This] string arg);
+            """
+        );
+
+        var ms0018 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidThis);
+        await Assert.That(ms0018).IsNotNull();
+        await Assert.That(ms0018!.Message).Contains("first positional parameter");
+    }
+
+    [Test]
+    public async Task This_OnRefParameter_EmitsMs0018()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element {}
+
+            public delegate void RefListener([This] ref Element self, string arg);
+            """
+        );
+
+        var ms0018 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidThis);
+        await Assert.That(ms0018).IsNotNull();
+        await Assert.That(ms0018!.Message).Contains("'ref'");
+    }
+
+    [Test]
+    public async Task This_OnParamsParameter_EmitsMs0018()
+    {
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public delegate void VariadicListener([This] params string[] values);
+            """
+        );
+
+        var ms0018 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidThis);
+        await Assert.That(ms0018).IsNotNull();
+        await Assert.That(ms0018!.Message).Contains("'params'");
+    }
+
+    [Test]
+    public async Task This_OnSingleParameterDelegate_EmitsEmptyParameterList()
+    {
+        // `[This]` on the only parameter leaves the delegate with no
+        // positional arguments; the emitted signature reads
+        // `(this: T) => R` with no trailing comma.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element {}
+
+            public delegate void Listener([This] Element self);
+
+            public class Host
+            {
+                public Listener? Handler { get; set; }
+            }
+            """
+        );
+
+        var output = result["host.ts"];
+        await Assert.That(output).Contains("(this: Element) => void");
+        await Assert.That(output).DoesNotContain("(this: Element, ");
+    }
+}

--- a/tests/Metano.Tests/ThisAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ThisAttributeTranspileTests.cs
@@ -82,6 +82,28 @@ public class ThisAttributeTranspileTests
     }
 
     [Test]
+    public async Task This_OnInParameter_EmitsMs0018()
+    {
+        // `in` parameters pass by readonly-reference at the CLR
+        // level; they cannot act as the JS `this` receiver at the
+        // boundary. Guard alongside `ref` / `out` / `ref readonly`.
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element {}
+
+            public delegate void InListener([This] in Element self, string arg);
+            """
+        );
+
+        var ms0018 = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.InvalidThis);
+        await Assert.That(ms0018).IsNotNull();
+        await Assert.That(ms0018!.Message).Contains("'in'");
+    }
+
+    [Test]
     public async Task This_OnParamsParameter_EmitsMs0018()
     {
         var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(


### PR DESCRIPTION
## Summary

First slice of #113. Introduces `ThisAttribute` in `Metano.Annotations` and teaches the frontend to hoist a decorated first parameter into the IR function type's synthetic `this` receiver. The TypeScript printer emits `(this: T, …) => R` when the slot is populated; Dart (and any future non-JS backend) keeps the parameter positional by falling through to its own lowering path (no-op today).

PoC before committing scope verified that Roslyn's `SemanticModel.GetTypeInfo(lambda).ConvertedType` exposes the target delegate symbol and that the delegate's first-parameter attributes round-trip through the compilation — the building block Slice B will lean on for lambda target-type inference.

## What this slice covers

- `ThisAttribute` (`AttributeTargets.Parameter`) with XML docs pinning the first-parameter + delegate-or-inlinable-method contract.
- `DiagnosticCodes.InvalidThis` (MS0018) promoted to Stable Codes.
- `SymbolHelper.HasThis` with namespace-qualified match against `Metano.Annotations`.
- Frontend validator `ValidateThisAttribute` walks every method + delegate invoke method and surfaces MS0018 when:
  - the decorated parameter is not at index 0, or
  - the parameter carries `ref` / `out` / `params`.
- `IrFunctionTypeRef` gains an optional `ThisType` slot. The extractor (`IrTypeRefMapper.MapDelegateType`) promotes the first parameter into the slot and removes it from the positional list when `HasThis` fires.
- `TsFunctionType` gains a matching `ThisType`; the TS printer emits `(this: T, param: U) => R` (or `(this: T) => R` when no trailing params remain). The bridge wires the IR → TS copy.

## What lands later

- **Slice B** — body rewriting: lambda target-type inference publishes `uses-this`; the printer picks `function (…)` over `=>`; identifier references to the `[This]` parameter rewrite to `this`.
- **Slice C** — method-group assignment, explicit-receiver invocation (`.call(receiver, …)`), runtime interop for delegate `+=` / `-=`.
- **Slice D** — cross-assembly delegate resolution + Dart no-op bridge + end-to-end DOM binding sample + ADR.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **702/702 green** (697 → 702), 5 new tests in `ThisAttributeTranspileTests`:
  - `This_OnDelegateFirstParameter_EmitsThisAnnotationInFunctionType` pins `(this: Element, arg: string) => void`
  - `This_OnNonFirstParameter_EmitsMs0018`
  - `This_OnRefParameter_EmitsMs0018`
  - `This_OnParamsParameter_EmitsMs0018`
  - `This_OnSingleParameterDelegate_EmitsEmptyParameterList` pins `(this: Element) => void` (no trailing comma)
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm MS0018 messaging is precise enough for adoption (non-first-position vs. `ref`/`out`/`params`)
- [ ] Reviewer: sanity-check the `IrFunctionTypeRef.ThisType` shape before Slice B threads it into body rewriting

## Spec

- `09-attribute-catalog.md`: attribute count 25 → 26; `ThisAttribute` row added with the Slice A contract (signature emission only; body rewriting deferred).
- `10-diagnostic-catalog.md`: MS0018 promoted from Reserved to Stable (only MS0013 remains reserved, for the `[NoEmit]` redefinition slice).

Part of #113.