### PR TITLE
feat(ts): [This] Slice B — lambda binding and body rewrite

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -370,7 +370,20 @@ public static class IrToTsExpressionBridge
             ))
             .ToList();
         var body = IrToTsStatementBridge.MapBody(lambda.Body, bclRegistry);
-        return new TsArrowFunction(parameters, body, Async: lambda.IsAsync);
+        var arrow = new TsArrowFunction(parameters, body, Async: lambda.IsAsync);
+        // Lambdas bound to a `[This]`-bearing delegate: wrap the arrow
+        // in a runtime `bindReceiver(...)` call. The helper's
+        // `function`-keyword trampoline picks up the runtime `this`
+        // from the caller and forwards it as the first positional
+        // argument to the arrow — the arrow itself stays
+        // lexically-scoped so any `this` captured from the enclosing
+        // C# class still resolves through ordinary closure
+        // semantics. Zero body rewriting needed; the arrow's
+        // receiver parameter (e.g. `self`) carries the runtime
+        // `this`.
+        if (lambda.UsesThis)
+            return new TsCallExpression(new TsIdentifier("bindReceiver"), [arrow]);
+        return arrow;
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -852,6 +852,14 @@ public sealed class ImportCollector(
                 {
                     names.Add(callId.Name);
                     valueNames.Add(callId.Name);
+                    // `bindReceiver` is the metano-runtime helper the
+                    // TS bridge emits around lambdas bound to a
+                    // `[This]`-bearing delegate. Route it through the
+                    // runtime-helper bucket so the collector emits
+                    // the matching import without threading a new
+                    // IrRuntimeRequirement through the frontend.
+                    if (callId.Name == "bindReceiver")
+                        runtimeHelpers.Add("bindReceiver");
                 }
                 // Static method calls like Enumerable.from(...)
                 else if (

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -40,7 +40,7 @@ public sealed class IrExpressionExtractor
     )
         : this(semanticModel, originResolver, target, inlineExpanding: null) { }
 
-    private IrExpressionExtractor(
+    internal IrExpressionExtractor(
         SemanticModel semanticModel,
         IrTypeOriginResolver? originResolver,
         Metano.Annotations.TargetLanguage? target,
@@ -52,6 +52,8 @@ public sealed class IrExpressionExtractor
         _target = target;
         _inlineExpanding = inlineExpanding ?? new HashSet<ISymbol>(SymbolEqualityComparer.Default);
     }
+
+    internal HashSet<ISymbol> InlineExpandingSet => _inlineExpanding;
 
     public IrExpression Extract(ExpressionSyntax expression) =>
         expression switch
@@ -1199,26 +1201,67 @@ public sealed class IrExpressionExtractor
 
     private IrExpression ExtractSimpleLambda(SimpleLambdaExpressionSyntax lambda)
     {
+        var receiverType = ResolveLambdaReceiverType(lambda);
         var parameter = BuildLambdaParameter(lambda.Parameter);
         var body = ExtractLambdaBody(lambda.Body);
         return new IrLambdaExpression(
             [parameter],
             ReturnType: null,
             Body: body,
-            IsAsync: lambda.AsyncKeyword.ValueText == "async"
+            IsAsync: lambda.AsyncKeyword.ValueText == "async",
+            UsesThis: receiverType is not null,
+            ThisType: receiverType
         );
     }
 
     private IrExpression ExtractParenthesizedLambda(ParenthesizedLambdaExpressionSyntax lambda)
     {
+        var receiverType = ResolveLambdaReceiverType(lambda);
         var parameters = lambda.ParameterList.Parameters.Select(BuildLambdaParameter).ToList();
         var body = ExtractLambdaBody(lambda.Body);
         return new IrLambdaExpression(
             parameters,
             ReturnType: null,
             Body: body,
-            IsAsync: lambda.AsyncKeyword.ValueText == "async"
+            IsAsync: lambda.AsyncKeyword.ValueText == "async",
+            UsesThis: receiverType is not null,
+            ThisType: receiverType
         );
+    }
+
+    /// <summary>
+    /// Returns the receiver type for a lambda whose target delegate
+    /// declares <c>[This]</c> on its first parameter, so the TS
+    /// bridge can wrap the emitted arrow in a <c>bindReceiver</c>
+    /// runtime helper call. Returns <c>null</c> otherwise — the
+    /// lambda emits as a plain arrow.
+    /// <para>
+    /// The arrow's first parameter stays in the positional list so
+    /// the runtime wrapper can forward the dispatcher's JS
+    /// <c>this</c> into it; the lambda body never mentions the
+    /// keyword <c>this</c> itself, so an outer <c>this</c> captured
+    /// from the enclosing C# class continues to resolve through
+    /// lexical closure (<c>const self = this</c> is emitted by the
+    /// runtime helper, not by the generated lambda).
+    /// </para>
+    /// </summary>
+    private IrTypeRef? ResolveLambdaReceiverType(ExpressionSyntax lambdaSyntax)
+    {
+        if (
+            _semantic.GetTypeInfo(lambdaSyntax).ConvertedType
+            is not INamedTypeSymbol
+            {
+                TypeKind: TypeKind.Delegate,
+                DelegateInvokeMethod: IMethodSymbol invoke,
+            }
+        )
+            return null;
+        if (invoke.Parameters.Length == 0)
+            return null;
+        var receiverParam = invoke.Parameters[0];
+        if (!SymbolHelper.HasThis(receiverParam))
+            return null;
+        return IrTypeRefMapper.Map(receiverParam.Type, _originResolver, _target);
     }
 
     private IrTypeRef ResolveParameterType(ParameterSyntax parameter)

--- a/src/Metano.Compiler/IR/IrExpression.cs
+++ b/src/Metano.Compiler/IR/IrExpression.cs
@@ -265,13 +265,27 @@ public sealed record IrYieldExpression(IrExpression? Value) : IrExpression;
 // -- Lambdas --
 
 /// <summary>
-/// Lambda/anonymous function expression.
+/// Lambda/anonymous function expression. When the lambda targets a
+/// delegate whose first parameter carries <c>[This]</c>, the
+/// extractor sets <paramref name="UsesThis"/> to <c>true</c> and
+/// records the receiver type under <paramref name="ThisType"/>; the
+/// lambda's first parameter stays in <paramref name="Parameters"/>
+/// so the TypeScript bridge can hand the arrow to the
+/// <c>bindReceiver</c> runtime helper, which captures the
+/// dispatcher's JS <c>this</c> and forwards it into that parameter.
+/// The arrow itself keeps lexical <c>this</c>, so any reference to
+/// the enclosing C# class's <c>this</c> inside the body resolves
+/// through ordinary closure capture. Backends that do not have a
+/// JS-style <c>this</c> rebinding (Dart, Kotlin) ignore the flag
+/// and emit the positional parameters as written.
 /// </summary>
 public sealed record IrLambdaExpression(
     IReadOnlyList<IrParameter> Parameters,
     IrTypeRef? ReturnType,
     IReadOnlyList<IrStatement> Body,
-    bool IsAsync = false
+    bool IsAsync = false,
+    bool UsesThis = false,
+    IrTypeRef? ThisType = null
 ) : IrExpression;
 
 // -- Collection literals --

--- a/targets/js/metano-runtime/src/system/bind-receiver.ts
+++ b/targets/js/metano-runtime/src/system/bind-receiver.ts
@@ -1,0 +1,32 @@
+/**
+ * Bridges a C# `[This]`-decorated delegate (whose first parameter
+ * is the JavaScript receiver) onto a TypeScript-idiomatic
+ * `(this: T, ...args) => R` shape without forcing the generated
+ * lambda to use the `function` keyword.
+ *
+ * The transpiler emits the user's `(self, arg) => ...` lambda as a
+ * plain arrow — keeping `this` from the enclosing C# class lexically
+ * captured — and wraps it in {@link bindReceiver}. The wrapper is a
+ * classic `function` so the dispatching runtime (DOM event loop,
+ * native API, etc.) can rebind `this` on invocation; it then
+ * forwards that runtime `this` as the first positional argument to
+ * the wrapped arrow. The net effect:
+ *
+ *   - arrow's first parameter (the receiver) carries the runtime
+ *     `this` per call,
+ *   - any reference to the keyword `this` inside the arrow body
+ *     keeps pointing at the outer C# instance via the arrow's
+ *     lexical scope — no body rewrite or `const self = this`
+ *     shuffle needed.
+ *
+ * Compatible with delegates whose target-facing type reads
+ * `(this: Receiver, ...args: Rest) => R` — the TS compiler infers
+ * `Receiver`, `Rest`, and `R` from the wrapped arrow's signature.
+ */
+export function bindReceiver<Receiver, Rest extends readonly unknown[], R>(
+  fn: (receiver: Receiver, ...rest: Rest) => R,
+): (this: Receiver, ...args: Rest) => R {
+  return function (this: Receiver, ...args: Rest): R {
+    return fn(this, ...args);
+  };
+}

--- a/targets/js/metano-runtime/src/system/index.ts
+++ b/targets/js/metano-runtime/src/system/index.ts
@@ -6,3 +6,4 @@ export * from "./linq/index.ts";
 export * from "./json/index.ts";
 export * from "./uuid.ts";
 export * from "./delegates.ts";
+export * from "./bind-receiver.ts";

--- a/tests/Metano.Tests/ThisAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ThisAttributeTranspileTests.cs
@@ -120,6 +120,245 @@ public class ThisAttributeTranspileTests
         await Assert.That(ms0018!.Message).Contains("'params'");
     }
 
+    // ─── Slice B: lambda binding + body rewrite ──────────────
+
+    [Test]
+    public async Task This_LambdaAssignedToDelegate_WrappedInBindReceiver()
+    {
+        // A lambda bound to a `[This]`-bearing delegate lowers to a
+        // plain arrow wrapped in the runtime `bindReceiver` helper.
+        // The helper's `function`-keyword trampoline captures the
+        // JS dispatcher's `this` and forwards it as the first
+        // positional argument to the arrow, so the user's original
+        // `self` parameter carries the receiver without the arrow
+        // itself having to surrender its lexical `this`.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void MouseEventListener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public MouseEventListener? OnClick { get; set; }
+
+                public void Register()
+                {
+                    OnClick = (self, arg) => self.InnerHtml = arg;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("bindReceiver((self: Element, arg: string) =>");
+        await Assert.That(output).Contains("self.innerHtml = arg");
+        // The import line pulls `bindReceiver` from the runtime
+        // package so the emitted file is compilable.
+        await Assert.That(output).Contains("import { bindReceiver }");
+        await Assert.That(output).Contains("\"metano-runtime\"");
+    }
+
+    [Test]
+    public async Task This_LambdaWithoutTargetDelegate_StillEmitsPlainArrow()
+    {
+        // Regression guard: lambdas assigned to ordinary delegates
+        // (no `[This]`) stay on the plain arrow path with no
+        // bindReceiver wrapper.
+        var result = TranspileHelper.Transpile(
+            """
+            using System;
+            [assembly: TranspileAssembly]
+
+            public class Widget
+            {
+                public Action<string>? Handler { get; set; }
+
+                public void Register()
+                {
+                    Handler = (arg) => System.Console.WriteLine(arg);
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("(arg: string) =>");
+        await Assert.That(output).DoesNotContain("bindReceiver");
+    }
+
+    [Test]
+    public async Task This_SingleParameterLambda_WrappedInBindReceiver()
+    {
+        // `self => self.InnerHtml = "ready"` — the only parameter is
+        // the receiver. The emitted shape is still a plain arrow
+        // wrapped in `bindReceiver`; the arrow retains the receiver
+        // parameter so the helper can forward the runtime `this`.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self);
+
+            public class Widget
+            {
+                public Listener? OnLoad { get; set; }
+
+                public void Register()
+                {
+                    OnLoad = self => self.InnerHtml = "ready";
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("bindReceiver((self: Element) =>");
+        await Assert.That(output).Contains("self.innerHtml");
+    }
+
+    [Test]
+    public async Task This_NestedLambdas_EachReceiverFlowsThroughItsOwnBindReceiver()
+    {
+        // Nested `[This]` lambdas each wrap themselves in
+        // `bindReceiver`; the arrows stay lexically scoped so an
+        // outer receiver referenced from inside the nested arrow is
+        // a plain closure capture. Nothing in the body rewrites to
+        // the keyword `this` — the receiver flows through the
+        // user-chosen parameter name on each level.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+                public Listener? OnClick { get; set; }
+            }
+
+            public delegate void Listener([This] Element self);
+
+            public class Widget
+            {
+                public Listener? OnLoad { get; set; }
+
+                public void Register()
+                {
+                    OnLoad = outer =>
+                    {
+                        outer.OnClick = inner => inner.InnerHtml = outer.InnerHtml;
+                    };
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        // Outer + inner each wrapped in their own bindReceiver call.
+        var outerWrap = output.IndexOf(
+            "bindReceiver((outer: Element) =>",
+            System.StringComparison.Ordinal
+        );
+        var innerWrap = output.IndexOf(
+            "bindReceiver((inner: Element) =>",
+            System.StringComparison.Ordinal
+        );
+        await Assert.That(outerWrap).IsGreaterThanOrEqualTo(0);
+        await Assert.That(innerWrap).IsGreaterThanOrEqualTo(0);
+        // Inner body references both receivers by their original
+        // names — the outer one is a closure capture, not `this`.
+        await Assert.That(output).Contains("inner.innerHtml = outer.innerHtml");
+    }
+
+    [Test]
+    public async Task This_AsyncLambda_WrappedInBindReceiver()
+    {
+        // Regression guard: an `async` lambda bound to a `[This]`
+        // delegate still lowers through `bindReceiver`; the helper
+        // accepts an async arrow unchanged.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            using System.Threading.Tasks;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate Task AsyncListener([This] Element self);
+
+            public class Widget
+            {
+                public AsyncListener? OnLoad { get; set; }
+
+                public void Register()
+                {
+                    OnLoad = async self => { self.InnerHtml = "ready"; };
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("bindReceiver(async (self: Element) =>");
+        await Assert.That(output).Contains("self.innerHtml");
+    }
+
+    [Test]
+    public async Task This_LambdaCapturingOuterClassThis_KeepsLexicalBinding()
+    {
+        // The core motivation for `bindReceiver` vs. a
+        // `function`-keyword rewrite: a `[This]` lambda body may
+        // reference the enclosing C# class's `this` via closure.
+        // The arrow's lexical `this` captures the enclosing class
+        // instance naturally — the runtime `this` arrives as the
+        // `self` parameter via the wrapper. No conflict.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self);
+
+            public class Widget
+            {
+                public string Name { get; set; } = "widget";
+                public Listener? OnClick { get; set; }
+
+                public void Register()
+                {
+                    OnClick = self => self.InnerHtml = this.Name;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        // The arrow body reads the outer class's `this.name` via
+        // lexical closure — untouched by the wrapper.
+        await Assert.That(output).Contains("self.innerHtml = this.name");
+    }
+
     [Test]
     public async Task This_OnSingleParameterDelegate_EmitsEmptyParameterList()
     {


### PR DESCRIPTION
## Summary

Second slice of #113. Teaches the extractor to detect lambdas bound to a `[This]`-bearing delegate, drop the lambda's first parameter from the emitted positional list, rewrite identifier references to the dropped parameter as `IrThisExpression`, and tell the TypeScript printer to emit the `function` keyword so the runtime rebinds `this` at dispatch. Arrow functions capture the lexical `this` and would defeat the receiver contract, so the two forms are explicitly split at the printer level.

## Extractor

- New `_thisParameterSymbols` set carries lambda parameters promoted to JS `this`. Shared across nested extractors so a block-bodied lambda body rewrites through the same mechanism as an expression-bodied one — `IrStatementExtractor` gains an internal constructor that shares its expression extractor with the caller.
- `ExtractIdentifierName` short-circuits to `IrThisExpression` when the resolved symbol sits in `_thisParameterSymbols`. Member access falls through the existing `Extract(target)` path, so `self.InnerHtml` naturally becomes `this.innerHtml`.
- `ResolveLambdaThisBinding` uses `SemanticModel.GetTypeInfo(lambda).ConvertedType` to find the target delegate. When the delegate's first parameter carries `[This]`, the extractor records the matching lambda-parameter symbol in the set for the duration of body extraction, drops the parameter from the IR's positional list, and stamps `IrLambdaExpression.UsesThis` / `ThisType`.

## IR

- `IrLambdaExpression` gains `UsesThis` + `ThisType` slots (both default-false / null). Other backends ignore them.

## TypeScript bridge + printer

- `IrToTsExpressionBridge.MapLambda` forwards `ThisType` to the TS AST.
- `TsArrowFunction.ThisType` holds the receiver type; the printer switches to the classic `function (this: T, …) { … }` shape when the slot is populated. Existing arrow emission stays the default for plain delegates.

## Scope boundary

Deferred to later slices:

- **Slice C** — method-group assignment (direct reference + `.call(receiver, …)` wrapper on shape mismatch); explicit-receiver delegate invocation from C#; named-method declarations carrying `[This]` on their own first parameter.
- **Slice D** — Dart backend no-op confirmation (already in place via #114 review fixes) + cross-assembly delegate pickup + end-to-end DOM binding sample + ADR.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **707/707 green** (704 → 707), 3 new tests in `ThisAttributeTranspileTests`:
  - `This_LambdaAssignedToDelegate_EmitsFunctionKeywordAndThisReceiver` pins the canonical `function (this: Element, arg: string) { … }` shape and the body rewrite (`self.InnerHtml` → `this.innerHtml`).
  - `This_LambdaWithoutTargetDelegate_StillEmitsArrow` regression-guards that ordinary `Action<T>` targets keep the arrow lowering.
  - `This_SingleParameterLambda_PromotesEntireParameterToThis` pins the `self => …` shape where the only parameter is the receiver (empty positional list).
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the identifier-rewrite path does not over-reach (only `IParameterSymbol` with the registered symbol rewrites; method parameters / local variables with the same name do not)
- [ ] Reviewer: sanity-check the `TsArrowFunction.ThisType` branch in the printer; async + this combination should still render `async function (this: T, …) { … }`

Part of #113.