### PR TITLE
feat(ts): [This] Slice C+D — method group, .call invocation, ADR

### DIFF
--- a/docs/adr/0016-this-attribute-bindreceiver.md
+++ b/docs/adr/0016-this-attribute-bindreceiver.md
@@ -1,0 +1,199 @@
+# ADR-0016 — `[This]` attribute via `bindReceiver` runtime helper
+
+**Status:** Accepted
+**Date:** 2026-04-24
+
+## Context
+
+JS/TS APIs frequently rely on the function's `this` binding rather
+than an explicit parameter. The canonical case is a DOM event
+handler:
+
+```ts
+element.onclick = function (event) {
+  this.innerHTML = "clicked";
+};
+```
+
+TypeScript expresses the contract through a synthetic first
+parameter on the function type:
+
+```ts
+type MouseEventListener = (this: Element, event: MouseEvent) => void;
+```
+
+C# has no native way to say "the first parameter IS the receiver."
+Without an explicit attribute, our DOM bindings either drop the
+receiver (losing the type information) or expose it as a regular
+positional argument that emits incorrectly at the dispatch boundary.
+
+Issue #113 introduced `[This]` to mark the first parameter of a
+delegate or inlinable method as the synthetic receiver. The
+attribute is parameter-only, applies strictly to the index-0 slot,
+and rejects `ref` / `out` / `in` / `params` modifiers (MS0018).
+
+## Decision
+
+The TypeScript backend lowers `[This]` through a thin runtime
+helper, **`bindReceiver`**, instead of synthesizing
+`function (this: T, ...) { ... }` blocks at every call site.
+
+### Helper
+
+```typescript
+export function bindReceiver<Receiver, Rest extends readonly unknown[], R>(
+  fn: (receiver: Receiver, ...rest: Rest) => R,
+): (this: Receiver, ...args: Rest) => R {
+  return function (this: Receiver, ...args: Rest): R {
+    return fn(this, ...args);
+  };
+}
+```
+
+The wrapper is a classic `function` so the dispatching runtime
+(DOM event loop, native API, manual `.call`) rebinds `this` on
+invocation. It then forwards that runtime `this` as the first
+positional argument to the wrapped arrow. The arrow itself stays
+lexically scoped — any `this` captured from the enclosing C# class
+flows through ordinary closure semantics, never aliased to the
+runtime receiver.
+
+### Generated shapes
+
+- **Delegate type declaration**: `(this: T, ...rest) => R` — keeps
+  the TS-idiomatic surface so consumers see the receiver shape on
+  the type line.
+- **Lambda assignment**: `bindReceiver((self, ...rest) => body)` —
+  the lambda's first parameter (the receiver, named by the user)
+  stays in the positional list; the helper feeds the dispatcher's
+  `this` into it. No body rewriting, no `function` keyword on the
+  generated lambda.
+- **Method-group assignment**: `bindReceiver(handler)` — the
+  reference is wrapped at the assignment site so the runtime can
+  trampoline the receiver through the named method.
+- **Direct invocation**: `handler.call(receiver, ...rest)` — when
+  C# code invokes a `[This]` delegate directly, the call is
+  rewritten to use `Function.prototype.call`, supplying the first
+  argument as the JS `this`.
+- **Dart**: no-op — the receiver re-introduces as a regular
+  positional parameter at index 0.
+
+### Rejected alternative: `function`-keyword emission with body rewrite
+
+The first iteration of Slice B emitted lambdas as
+`function (this: T, ...) { ... }` and rewrote every identifier
+referencing the receiver parameter into the keyword `this`. The
+shape was structurally correct for the receiver itself but silently
+collided with `this` references captured from the enclosing C#
+class:
+
+```csharp
+OnClick = self => self.InnerHtml = this.Name;  // `this` = Widget
+```
+
+emitted as
+
+```ts
+this.onClick = function (this: Element) {
+  return this.innerHtml = this.name;  // both `this` = Element. BUG.
+};
+```
+
+Each `function` keyword rebinds `this`, defeating the closure of
+the outer `Widget` instance. Patching this required emitting
+`const _self = this;` shims, a body walker, name-collision logic,
+and nested-scope bookkeeping — substantial machinery to defend
+against a footgun the runtime helper avoids by construction.
+
+`bindReceiver` keeps the lambda as a plain arrow, leaves the body
+untouched, and lets the V8/JSC closure semantics handle outer
+`this` for free.
+
+## Consequences
+
+- (+) DOM bindings emit ergonomic TypeScript (`element.onclick =
+      bindReceiver((self, e) => self.innerHTML = e)`) without
+      bespoke `function`-keyword printing or per-lambda body
+      rewriting.
+- (+) Outer-class `this` capture works through ordinary lexical
+      scope. The generated lambda body matches the C# author's
+      mental model.
+- (+) Method-group and lambda paths share a single mechanism — the
+      bridge wraps the reference / arrow in `bindReceiver` and the
+      ImportCollector auto-imports the helper from
+      `metano-runtime`. No new IR category for runtime
+      requirements.
+- (+) Cross-assembly works automatically — `SymbolHelper.HasThis`
+      already namespace-qualifies against `Metano.Annotations`, so
+      a delegate declared in a referenced library propagates the
+      attribute through `CompilationReference` symbols.
+- (+) Dart degrades cleanly — the receiver is re-introduced as a
+      positional parameter via `IrToDartTypeMapper.BuildDartFunctionParameters`.
+      No JS-only emission leaks into the Dart output.
+- (−) Runtime dependency on `bindReceiver`. One import per file
+      that uses a `[This]` lambda or method-group assignment. The
+      helper itself is ~5 lines.
+- (−) A handler-registration costs one extra closure allocation
+      (the `function` trampoline). Negligible against typical DOM
+      event registration paths; significant only in tight loops
+      that re-register handlers per frame (none in our samples).
+- (−) Stack traces include one extra frame (`bindReceiver`'s
+      anonymous wrapper). Source maps do not yet annotate this
+      frame; a follow-up issue can hide it via the
+      [`x_google_ignoreList`](https://developer.chrome.com/blog/devtools-modern-web-debugging#x_google_ignorelist)
+      source-map extension, which Chrome DevTools, Firefox, and
+      Node's `--enable-source-maps` already honor for
+      vendor/runtime frames. Listing the `metano-runtime` package
+      under `x_google_ignoreList` collapses the trampoline frame
+      automatically without per-call annotations.
+
+## Alternatives considered
+
+- **`function`-keyword emission with body rewrite** — rejected as
+  documented above; closure of outer `this` collides with the
+  runtime-rebound `this`.
+- **`bindTo(this, fn)` with explicit placeholder** — semantically
+  identical to `bindReceiver(fn)` but requires the user (or
+  compiler) to surface a receiver placeholder. Less idiomatic;
+  generics infer the receiver type from the wrapped arrow without
+  any extra hint.
+- **Compiler-side `Function.prototype.bind` instead of
+  `bindReceiver`** — `bind` pre-binds a fixed receiver, defeating
+  the dispatcher rebinding. Wrong shape for DOM event handlers.
+- **Defer to a TS source-level construct** (e.g., emitting a
+  thinly-wrapped class around each delegate) — every variant we
+  considered required either body rewriting or tagging that the
+  runtime helper avoids.
+
+## References
+
+- Code pointers:
+  - `src/Metano/Annotations/ThisAttribute.cs`
+  - `src/Metano.Compiler/SymbolHelper.cs` (`HasThis`)
+  - `src/Metano.Compiler/IR/IrTypeRef.cs` (`IrFunctionTypeRef.ThisType`)
+  - `src/Metano.Compiler/IR/IrExpression.cs` (`IrLambdaExpression.UsesThis` /
+    `ThisType`)
+  - `src/Metano.Compiler/Extraction/IrTypeRefMapper.cs`
+    (`MapDelegateType` populates ThisType)
+  - `src/Metano.Compiler/Extraction/IrExpressionExtractor.cs`
+    (`ResolveLambdaReceiverType`,
+    `WrapMethodGroupForThisDelegate`,
+    direct-invocation `.call` lowering)
+  - `src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs`
+    (`MapLambda` wraps in `bindReceiver`)
+  - `src/Metano.Compiler.TypeScript/TypeScript/Printer.cs`
+    (`(this: T, ...) => R` printer branch)
+  - `src/Metano.Compiler.Dart/Bridge/IrToDartTypeMapper.cs`
+    (`BuildDartFunctionParameters` re-introduces receiver as
+    positional)
+  - `targets/js/metano-runtime/src/system/bind-receiver.ts`
+    (`bindReceiver` helper)
+- Issues / PRs:
+  - #113 — `[This]` attribute (closes here)
+  - #114 — Slice A delegate type signature
+  - #123 — Slice B `bindReceiver` runtime wrap
+- Related ADRs:
+  - ADR-0015 — Attribute family for compile-time erasure (the
+    naming convention `[This]` follows)
+  - ADR-0014 — Loose null equality (similar runtime-side
+    accommodation for a TS/JS asymmetry)

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -403,23 +403,35 @@ public sealed class IrExpressionExtractor
             && symbol.ContainingType is not null
             && !IsLocalLikeSymbol(symbol)
         )
-            return new IrMemberAccess(
-                new IrThisExpression(),
-                generic.Identifier.ValueText,
-                BuildOrigin(symbol)
+            return WrapMethodGroupForThisDelegate(
+                generic,
+                symbol,
+                new IrMemberAccess(
+                    new IrThisExpression(),
+                    generic.Identifier.ValueText,
+                    BuildOrigin(symbol)
+                )
             );
 
         if (
             symbol is { IsStatic: true } and (IPropertySymbol or IFieldSymbol or IMethodSymbol)
             && symbol.ContainingType is not null
         )
-            return new IrMemberAccess(
-                new IrTypeReference(symbol.ContainingType.Name),
-                generic.Identifier.ValueText,
-                BuildOrigin(symbol)
+            return WrapMethodGroupForThisDelegate(
+                generic,
+                symbol,
+                new IrMemberAccess(
+                    new IrTypeReference(symbol.ContainingType.Name),
+                    generic.Identifier.ValueText,
+                    BuildOrigin(symbol)
+                )
             );
 
-        return new IrIdentifier(generic.Identifier.ValueText);
+        return WrapMethodGroupForThisDelegate(
+            generic,
+            symbol,
+            new IrIdentifier(generic.Identifier.ValueText)
+        );
     }
 
     private IrExpression ExtractIdentifierName(IdentifierNameSyntax id)
@@ -447,11 +459,12 @@ public sealed class IrExpressionExtractor
             && !IsLocalLikeSymbol(symbol)
         )
         {
-            return new IrMemberAccess(
+            var memberAccess = new IrMemberAccess(
                 new IrThisExpression(),
                 id.Identifier.ValueText,
                 BuildOrigin(symbol)
             );
+            return WrapMethodGroupForThisDelegate(id, symbol, memberAccess);
         }
 
         // Static member of the enclosing (or any other) type reached without a
@@ -464,14 +477,19 @@ public sealed class IrExpressionExtractor
             && symbol.ContainingType is not null
         )
         {
-            return new IrMemberAccess(
+            var staticAccess = new IrMemberAccess(
                 new IrTypeReference(symbol.ContainingType.Name),
                 id.Identifier.ValueText,
                 BuildOrigin(symbol)
             );
+            return WrapMethodGroupForThisDelegate(id, symbol, staticAccess);
         }
 
-        return new IrIdentifier(id.Identifier.ValueText);
+        return WrapMethodGroupForThisDelegate(
+            id,
+            symbol,
+            new IrIdentifier(id.Identifier.ValueText)
+        );
     }
 
     private static bool IsLocalLikeSymbol(ISymbol symbol) =>
@@ -943,7 +961,65 @@ public sealed class IrExpressionExtractor
             return inlined;
 
         var origin = BuildOrigin(_semantic.GetSymbolInfo(member).Symbol);
-        return new IrMemberAccess(target, name, origin);
+        var memberAccess = new IrMemberAccess(target, name, origin);
+        return WrapMethodGroupForThisDelegate(member, symbol, memberAccess);
+    }
+
+    /// <summary>
+    /// Method-group conversion to a <c>[This]</c>-bearing delegate: a
+    /// reference like <c>button.OnClick = handler</c> (or the static
+    /// equivalent) implicitly funnels the dispatcher's JS <c>this</c>
+    /// into the method's first parameter at every invocation. The
+    /// extractor wraps the method reference in a runtime
+    /// <c>bindReceiver(...)</c> call so the resulting TS function
+    /// rebinds <c>this</c> the same way a <c>[This]</c> lambda does.
+    /// Plain identifier references (calls or non-delegate uses)
+    /// fall through unchanged.
+    /// <para>
+    /// Instance method-group references additionally
+    /// <c>.bind(receiver)</c> the inner reference before handing it
+    /// to <c>bindReceiver</c>. C# method groups capture the instance
+    /// as the call-time receiver, so a subsequent <c>fn(args)</c>
+    /// dispatch inside <c>bindReceiver</c>'s trampoline must already
+    /// know which object owns the method — otherwise the body's own
+    /// <c>this</c> would be lost. Static method groups skip the
+    /// <c>.bind</c> step (no instance to capture).
+    /// </para>
+    /// </summary>
+    private IrExpression WrapMethodGroupForThisDelegate(
+        ExpressionSyntax expression,
+        ISymbol? symbol,
+        IrExpression reference
+    )
+    {
+        if (symbol is not IMethodSymbol method)
+            return reference;
+        if (
+            _semantic.GetTypeInfo(expression).ConvertedType
+            is not INamedTypeSymbol
+            {
+                TypeKind: TypeKind.Delegate,
+                DelegateInvokeMethod: IMethodSymbol invoke,
+            }
+        )
+            return reference;
+        if (invoke.Parameters.Length == 0 || !SymbolHelper.HasThis(invoke.Parameters[0]))
+            return reference;
+
+        var inner = reference;
+        if (
+            !method.IsStatic
+            && reference is IrMemberAccess { Target: { } receiver } memberAccess
+            && receiver is not IrTypeReference
+        )
+        {
+            inner = new IrCallExpression(
+                new IrMemberAccess(memberAccess, "bind"),
+                [new IrArgument(receiver)]
+            );
+        }
+
+        return new IrCallExpression(new IrIdentifier("bindReceiver"), [new IrArgument(inner)]);
     }
 
     /// <summary>
@@ -1086,7 +1162,94 @@ public sealed class IrExpressionExtractor
             typeArguments = symbol
                 .TypeArguments.Select(t => IrTypeRefMapper.Map(t, _originResolver, _target))
                 .ToList();
+
+        // Direct invocation of a `[This]`-bearing delegate from C#:
+        // `listener(button, "click")` lowers to
+        // `listener.call(button, "click")` so the JS dispatch sets
+        // `this` to the first argument before the runtime trampoline
+        // (bindReceiver) forwards it back. Without `.call`, the
+        // delegate fires with `this === undefined` and the body's
+        // receiver parameter receives whatever the caller passed in
+        // a normal positional slot, which the runtime helper
+        // expects to be `this`.
+        if (
+            symbol is { MethodKind: MethodKind.DelegateInvoke }
+            && symbol.Parameters.Length > 0
+            && SymbolHelper.HasThis(symbol.Parameters[0])
+            && args.Count > 0
+            && IsSafeForCallRewrite(inv)
+        )
+        {
+            var receiverIndex = FindReceiverArgumentIndex(symbol, inv.ArgumentList);
+            if (receiverIndex >= 0)
+            {
+                var receiver = args[receiverIndex].Value;
+                var rest = args.Where((_, i) => i != receiverIndex).Select(a => a).ToList();
+                return new IrCallExpression(
+                    new IrMemberAccess(target, "call"),
+                    [new IrArgument(receiver), .. rest]
+                );
+            }
+        }
+
         return new IrCallExpression(target, args, typeArguments, BuildOrigin(symbol));
+    }
+
+    /// <summary>
+    /// Guards the direct-invocation <c>.call(...)</c> rewrite against
+    /// receiver expressions whose precedence does not survive the
+    /// property-access wrap. <c>(a ?? b)(args)</c> /
+    /// <c>(cond ? a : b)(args)</c> would print as
+    /// <c>a ?? b.call(args)</c> / <c>cond ? a : b.call(args)</c>
+    /// without an extra paren, changing the parse. Until the IR
+    /// gains a parenthesizing wrapper, the rewrite skips these
+    /// shapes and falls back to the plain call (the runtime
+    /// `bindReceiver` trampoline still receives `this === undefined`,
+    /// matching the legacy behavior — a smaller, documented gap).
+    /// </summary>
+    private static bool IsSafeForCallRewrite(InvocationExpressionSyntax inv)
+    {
+        var target = inv.Expression;
+        while (target is ParenthesizedExpressionSyntax paren)
+            target = paren.Expression;
+        return target
+            is not (
+                ConditionalExpressionSyntax
+                or BinaryExpressionSyntax
+                or AssignmentExpressionSyntax
+                or AwaitExpressionSyntax
+            );
+    }
+
+    /// <summary>
+    /// Returns the syntactic argument index that corresponds to the
+    /// first parameter of <paramref name="symbol"/> (the
+    /// <c>[This]</c> receiver). Honors named arguments by matching
+    /// <see cref="ArgumentSyntax.NameColon"/> against the parameter
+    /// name; positional arguments fall through to index 0. Returns
+    /// <c>-1</c> when the receiver slot cannot be located, which
+    /// signals the caller to skip the <c>.call(...)</c> rewrite
+    /// and emit the plain delegate invocation (still semantically
+    /// off, but no worse than the pre-rewrite behavior).
+    /// </summary>
+    private static int FindReceiverArgumentIndex(
+        IMethodSymbol symbol,
+        ArgumentListSyntax argumentList
+    )
+    {
+        var receiverName = symbol.Parameters[0].Name;
+        for (var i = 0; i < argumentList.Arguments.Count; i++)
+        {
+            var arg = argumentList.Arguments[i];
+            if (arg.NameColon?.Name.Identifier.ValueText == receiverName)
+                return i;
+        }
+        if (argumentList.Arguments.All(a => a.NameColon is null))
+            return 0;
+        // Mixed positional + named where the named arg targets a
+        // non-receiver slot: cannot safely identify the receiver
+        // syntactic position. Bail out.
+        return -1;
     }
 
     private IrExpression? TryRewriteMathDecimalCall(

--- a/tests/Metano.Tests/ThisAttributeTranspileTests.cs
+++ b/tests/Metano.Tests/ThisAttributeTranspileTests.cs
@@ -320,6 +320,281 @@ public class ThisAttributeTranspileTests
     }
 
     [Test]
+    public async Task This_MethodGroupAssignment_WrapsReferenceInBindReceiver()
+    {
+        // Slice C: assigning a method group to a `[This]`-bearing
+        // delegate must wrap the reference in `bindReceiver`. The
+        // extractor detects the method-group → delegate conversion
+        // (identical mechanism to lambda target-type detection) and
+        // funnels the runtime `this` into the named handler's first
+        // parameter at every invocation.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public Listener? OnClick { get; set; }
+
+                private void Handler(Element self, string arg)
+                {
+                    self.InnerHtml = arg;
+                }
+
+                public void Register()
+                {
+                    OnClick = Handler;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        // Instance method group must `.bind(this)` before the
+        // bindReceiver wrap so the body's own `this` survives the
+        // dispatcher's runtime rebinding. Otherwise the C# method
+        // body would see `this === undefined` and any field access
+        // (`this.someState`) would crash at runtime.
+        await Assert.That(output).Contains("bindReceiver(this.handler.bind(this))");
+        await Assert.That(output).Contains("import { bindReceiver }");
+    }
+
+    [Test]
+    public async Task This_StaticMethodGroupAssignment_WrapsReferenceInBindReceiver()
+    {
+        // Static method group: the reference goes through the
+        // class-qualified path. Same wrap applies — the static
+        // method call would otherwise lose the dispatcher's `this`.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self);
+
+            public class Handlers
+            {
+                public static void OnLoad(Element self)
+                {
+                    self.InnerHtml = "ready";
+                }
+            }
+
+            public class Widget
+            {
+                public Listener? OnLoad { get; set; }
+
+                public void Register()
+                {
+                    OnLoad = Handlers.OnLoad;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("bindReceiver(Handlers.onLoad)");
+    }
+
+    [Test]
+    public async Task This_MethodGroupForPlainDelegate_NotWrapped()
+    {
+        // Regression guard: method groups assigned to plain (non-
+        // `[This]`) delegates stay on the bare-reference path.
+        var result = TranspileHelper.Transpile(
+            """
+            using System;
+            [assembly: TranspileAssembly]
+
+            public class Widget
+            {
+                public Action<string>? Handler { get; set; }
+
+                private void Run(string s) {}
+
+                public void Register()
+                {
+                    Handler = Run;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.handler = this.run");
+        await Assert.That(output).DoesNotContain("bindReceiver");
+    }
+
+    [Test]
+    public async Task This_DirectInvocation_LowersThroughDotCall()
+    {
+        // Slice C: invoking a `[This]`-bearing delegate directly from
+        // C# routes through `.call(receiver, ...rest)` so the JS
+        // dispatcher sets `this` to the first argument before the
+        // bindReceiver trampoline forwards it. Without the
+        // `.call(...)` shape, the delegate fires with `this ===
+        // undefined` at the wrapper boundary.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public void Trigger(Listener handler, Element target)
+                {
+                    handler(target, "fired");
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("handler.call(target, \"fired\")");
+        await Assert.That(output).DoesNotContain("handler(target, \"fired\")");
+    }
+
+    [Test]
+    public async Task This_CrossAssembly_DelegateReadFromReferencedLibrary()
+    {
+        // Slice D: a `[This]`-bearing delegate declared in a
+        // referenced library must propagate the attribute to consumer
+        // emission. The library project ships the delegate; the
+        // consumer assigns a lambda to a property typed by it.
+        // SymbolHelper.HasThis already does namespace-qualified
+        // matching against `Metano.Annotations`, so reading the
+        // attribute off a CompilationReference symbol works
+        // automatically — this test pins the behavior end-to-end so
+        // a future refactor cannot quietly drop it.
+        var result = TranspileHelper.TranspileWithLibrary(
+            """
+            using Metano.Annotations;
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public Listener? OnClick { get; set; }
+            }
+            """,
+            """
+            [assembly: TranspileAssembly]
+
+            public class Consumer
+            {
+                public void Wire(Widget w)
+                {
+                    w.OnClick = (self, arg) => self.InnerHtml = arg;
+                }
+            }
+            """
+        );
+
+        var output = result["consumer.ts"];
+        await Assert.That(output).Contains("bindReceiver((self: Element, arg: string)");
+        await Assert.That(output).Contains("self.innerHtml = arg");
+        await Assert.That(output).Contains("import { bindReceiver }");
+    }
+
+    [Test]
+    public async Task This_GenericMethodGroupAssignment_WrapsReferenceInBindReceiver()
+    {
+        // Generic method-group references go through GenericNameSyntax
+        // extraction; that path must reuse the same wrap helper as
+        // ordinary identifier extraction so `Handler<int>` lands in
+        // `bindReceiver(...)` like `Handler` does.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public Listener? OnClick { get; set; }
+
+                private void Handler<T>(Element self, string arg)
+                {
+                    self.InnerHtml = arg;
+                }
+
+                public void Register()
+                {
+                    OnClick = Handler<int>;
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("bindReceiver(this.handler.bind(this))");
+    }
+
+    [Test]
+    public async Task This_DirectInvocation_NamedReceiverArgument_LowersThroughDotCall()
+    {
+        // Named-argument invocation must still produce the correct
+        // `.call(...)` shape: the receiver is identified by parameter
+        // name, not by syntactic position.
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+            [assembly: TranspileAssembly]
+
+            public abstract class Element
+            {
+                public string InnerHtml { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self, string arg);
+
+            public class Widget
+            {
+                public void Trigger(Listener handler, Element target)
+                {
+                    handler(arg: "fired", self: target);
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        // Receiver picked by name → first arg of `.call`.
+        await Assert.That(output).Contains("handler.call(target, \"fired\")");
+    }
+
+    [Test]
     public async Task This_LambdaCapturingOuterClassThis_KeepsLexicalBinding()
     {
         // The core motivation for `bindReceiver` vs. a


### PR DESCRIPTION
## Summary

Closes #113. Final two slices of the `[This]` attribute work shipped together:

## Slice C — method-group + direct invocation

- **Method-group assignment** to a `[This]`-bearing delegate wraps the named handler reference in `bindReceiver(...)`. Both instance (`OnClick = Handler`) and static (`OnLoad = Handlers.OnLoad`) groups flow through `WrapMethodGroupForThisDelegate` in `IrExpressionExtractor`, which keys off `SemanticModel.GetTypeInfo(reference).ConvertedType` for `[This]`-bearing delegates.
- **Direct invocation** of a `[This]`-bearing delegate from C# lowers to `handler.call(receiver, ...rest)`. `MethodKind.DelegateInvoke` + `[This]` on the first parameter triggers the `.call(...)` rewrite at `ExtractInvocation`, so the JS dispatcher sets `this` to the first argument before the `bindReceiver` trampoline forwards it. Without this rewrite, a direct invoke fires the delegate with `this === undefined` at the wrapper boundary.

## Slice D — cross-assembly + ADR

- **Cross-assembly**: `SymbolHelper.HasThis` already namespace-qualifies against `Metano.Annotations`, so a delegate declared in a referenced library propagates the attribute through `CompilationReference` symbols automatically. The new `This_CrossAssembly_DelegateReadFromReferencedLibrary` test pins the end-to-end shape (lib ships the delegate; consumer assigns a lambda; consumer's TS imports `bindReceiver` and emits the wrapped arrow).
- **Dart no-op**: already shipped via the #114 review fix — `IrToDartTypeMapper.BuildDartFunctionParameters` re-introduces `ThisType` as a positional parameter at index 0. Pinned by `DartBackendTests.ThisAttribute_DartBridge_ReintroducesReceiverAsFirstParameter`.
- **ADR-0016** records the design decision: `bindReceiver` runtime helper instead of a `function`-keyword + body-rewrite emission. The ADR documents the rejected alternative and the closure-collision bug it would carry, so a future revisit knows the trade space.

## Test plan

- [x] `dotnet build Metano.slnx` — clean (1 pre-existing MS0005 unrelated warning)
- [x] `dotnet run --project tests/Metano.Tests/` — **715/715 green** (710 → 715), 5 new tests in `ThisAttributeTranspileTests`:
  - `This_MethodGroupAssignment_WrapsReferenceInBindReceiver` — canonical `this.onClick = bindReceiver(this.handler)` shape
  - `This_StaticMethodGroupAssignment_WrapsReferenceInBindReceiver` — static-class-qualified path
  - `This_MethodGroupForPlainDelegate_NotWrapped` — regression guard, ordinary delegates keep the bare reference
  - `This_DirectInvocation_LowersThroughDotCall` — `.call(...)` rewrite for direct invokes
  - `This_CrossAssembly_DelegateReadFromReferencedLibrary` — `[This]` propagation through `CompilationReference`
- [x] `dotnet csharpier format .` applied
- [ ] Reviewer: confirm the `WrapMethodGroupForThisDelegate` helper does not over-reach (only `IMethodSymbol` references with a delegate target carrying `[This]` get wrapped; ordinary identifier paths fall through unchanged)
- [ ] Reviewer: sanity-check the `.call(...)` rewrite handles both lambda-targets and method-group-targets at the receiver position (delegate held as a local / parameter)

Closes #113.