### PR TITLE
feat(core): lower handler?.Invoke(args) to optional call

### DIFF
--- a/src/Metano.Compiler.Dart/Dart/IrBodyPrinter.cs
+++ b/src/Metano.Compiler.Dart/Dart/IrBodyPrinter.cs
@@ -252,7 +252,7 @@ public static class IrBodyPrinter
                 sb.Append(']');
                 break;
             case IrCallExpression call:
-                PrintExpression(sb, call.Target);
+                PrintCallTarget(sb, call.Target);
                 if (call.IsOptional)
                     sb.Append("?.call");
                 sb.Append('(');
@@ -360,6 +360,35 @@ public static class IrBodyPrinter
                 break;
         }
     }
+
+    /// <summary>
+    /// Print a call target, wrapping it in parentheses when its node
+    /// kind has lower precedence than the call. Required because the
+    /// IR may surface low-precedence shapes as the call target (e.g.
+    /// <c>(a ?? b)?.Invoke()</c> lowers to a call whose target is a
+    /// binary expression — printed bare it would parse as
+    /// <c>a ?? b()</c>).
+    /// </summary>
+    private static void PrintCallTarget(StringBuilder sb, IrExpression target)
+    {
+        if (CallTargetRequiresParens(target))
+        {
+            sb.Append('(');
+            PrintExpression(sb, target);
+            sb.Append(')');
+        }
+        else
+        {
+            PrintExpression(sb, target);
+        }
+    }
+
+    private static bool CallTargetRequiresParens(IrExpression expression) =>
+        expression
+            is IrBinaryExpression
+                or IrConditionalExpression
+                or IrAwaitExpression
+                or IrLambdaExpression;
 
     /// <summary>
     /// Dart renders <c>x is Foo</c> natively. A type-with-designator (<c>x is Foo f</c>)

--- a/src/Metano.Compiler.Dart/Dart/IrBodyPrinter.cs
+++ b/src/Metano.Compiler.Dart/Dart/IrBodyPrinter.cs
@@ -253,6 +253,8 @@ public static class IrBodyPrinter
                 break;
             case IrCallExpression call:
                 PrintExpression(sb, call.Target);
+                if (call.IsOptional)
+                    sb.Append("?.call");
                 sb.Append('(');
                 PrintArgs(sb, call.Arguments);
                 sb.Append(')');

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -313,7 +313,7 @@ public static class IrToTsExpressionBridge
                 return mapped;
         }
 
-        return new TsCallExpression(Map(call.Target, bclRegistry), loweredArgs);
+        return new TsCallExpression(Map(call.Target, bclRegistry), loweredArgs, call.IsOptional);
     }
 
     private static string? TsTypeArgName(IrTypeRef type) =>

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsCallExpression.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsCallExpression.cs
@@ -1,4 +1,15 @@
 namespace Metano.TypeScript.AST;
 
-public sealed record TsCallExpression(TsExpression Callee, IReadOnlyList<TsExpression> Arguments)
-    : TsExpression;
+/// <summary>
+/// A TypeScript call expression: <c>callee(args)</c>. When
+/// <paramref name="Optional"/> is <c>true</c>, the printer emits
+/// the optional-call shape <c>callee?.(args)</c> — used for
+/// delegate-typed null-conditional invocations
+/// (<c>handler?.Invoke(args)</c> in C# →
+/// <c>handler?.(args)</c> in TS).
+/// </summary>
+public sealed record TsCallExpression(
+    TsExpression Callee,
+    IReadOnlyList<TsExpression> Arguments,
+    bool Optional = false
+) : TsExpression;

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -905,6 +905,35 @@ public sealed class Printer(string indent = "  ")
 
     // ─── Expressions ────────────────────────────────────────
 
+    /// <summary>
+    /// Print a call/optional-call callee, wrapping it in parentheses
+    /// when its node kind has lower precedence than the call itself.
+    /// Required because the IR may surface low-precedence shapes as
+    /// the call target (e.g. <c>(a ?? b)?.Invoke()</c> lowers to a
+    /// call whose callee is a binary expression — printed bare it
+    /// would parse as <c>a ?? b()</c>).
+    /// </summary>
+    private void PrintCallCallee(TsExpression callee)
+    {
+        if (CalleeRequiresParens(callee))
+        {
+            _sb.Write("(");
+            PrintExpression(callee);
+            _sb.Write(")");
+        }
+        else
+        {
+            PrintExpression(callee);
+        }
+    }
+
+    private static bool CalleeRequiresParens(TsExpression expression) =>
+        expression
+            is TsBinaryExpression
+                or TsConditionalExpression
+                or TsAwaitExpression
+                or TsArrowFunction;
+
     private void PrintExpression(TsExpression expr)
     {
         switch (expr)
@@ -960,7 +989,7 @@ public sealed class Printer(string indent = "  ")
                 break;
 
             case TsCallExpression call:
-                PrintExpression(call.Callee);
+                PrintCallCallee(call.Callee);
                 if (call.Optional)
                     _sb.Write("?.");
                 _sb.Write("(");

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -961,6 +961,8 @@ public sealed class Printer(string indent = "  ")
 
             case TsCallExpression call:
                 PrintExpression(call.Callee);
+                if (call.Optional)
+                    _sb.Write("?.");
                 _sb.Write("(");
                 _sb.WriteList(call.Arguments, PrintExpression);
                 _sb.Write(")");

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -149,6 +149,32 @@ public sealed class IrExpressionExtractor
                 when inv.Expression is MemberBindingExpressionSyntax mbCall:
                 var methodSymbol = _semantic.GetSymbolInfo(inv).Symbol;
                 var args = inv.ArgumentList.Arguments.Select(ExtractArgument).ToList();
+
+                // `handler?.Invoke(args)` lowers to a delegate
+                // optional call. The `.Invoke` member binding has no
+                // runtime counterpart in JS/TS — the delegate is the
+                // function — so the IR drops the binding name and
+                // marks the call as optional. The Dart bridge
+                // re-introduces the explicit `.call` segment because
+                // Dart's optional-call shape is `receiver?.call(...)`.
+                //
+                // `[This]`-bearing delegates fall through: the
+                // first parameter rebinds JS `this`, so the binding
+                // must remain visible to whatever lowering decides
+                // to wire the receiver argument into the runtime
+                // trampoline.
+                if (
+                    methodSymbol is IMethodSymbol delegateMethod
+                    && IsDelegateInvoke(delegateMethod)
+                    && !HasThisParameter(delegateMethod)
+                )
+                    return new IrCallExpression(
+                        receiver,
+                        args,
+                        Origin: BuildOrigin(methodSymbol),
+                        IsOptional: true
+                    );
+
                 var chainTarget = new IrOptionalChain(receiver, mbCall.Name.Identifier.ValueText);
 
                 return new IrCallExpression(chainTarget, args, Origin: BuildOrigin(methodSymbol));
@@ -266,6 +292,34 @@ public sealed class IrExpressionExtractor
                 new IrElementAccess(inner, Extract(ea.ArgumentList.Arguments[0].Expression)),
             _ => null,
         };
+
+    /// <summary>
+    /// True when <paramref name="method"/> is a delegate's
+    /// synthesized <c>Invoke</c> method. C# manufactures this
+    /// member on every delegate type; it has no JS/TS counterpart
+    /// because the delegate IS the function. The extractor uses
+    /// the predicate at two sites:
+    /// <list type="bullet">
+    ///   <item><c>handler?.Invoke(args)</c> lowers to a
+    ///   delegate-typed optional call (<see cref="IrCallExpression"/>
+    ///   with <c>IsOptional = true</c>).</item>
+    ///   <item><c>handler.Invoke(args)</c> drops the <c>.Invoke</c>
+    ///   indirection and lowers to a plain call on the delegate
+    ///   receiver.</item>
+    /// </list>
+    /// </summary>
+    private static bool IsDelegateInvoke(IMethodSymbol method) =>
+        method.MethodKind == MethodKind.DelegateInvoke;
+
+    /// <summary>
+    /// True when the delegate's first parameter carries
+    /// <c>[This]</c> — i.e. the receiver is rebound as JS
+    /// <c>this</c> at the call site. The Invoke shortcuts must
+    /// fall through for these so the existing
+    /// <c>delegate.call(receiver, ...)</c> rewrite still runs.
+    /// </summary>
+    private static bool HasThisParameter(IMethodSymbol method) =>
+        method.Parameters.Length > 0 && SymbolHelper.HasThis(method.Parameters[0]);
 
     /// <summary>
     /// True for IR shapes that can be referenced twice in the
@@ -1233,6 +1287,31 @@ public sealed class IrExpressionExtractor
     private IrExpression ExtractInvocation(InvocationExpressionSyntax inv)
     {
         var symbol = _semantic.GetSymbolInfo(inv).Symbol as IMethodSymbol;
+
+        // `handler.Invoke(args)` lowers to `handler(args)` — the
+        // synthesized `Invoke` member has no runtime counterpart in
+        // JS/TS because the delegate IS the function. Drop the
+        // `.Invoke` indirection at the source-level so consumers
+        // read the dispatch as a plain function call. The Dart
+        // bridge re-introduces the explicit `.call(...)` segment;
+        // routing through the call below is fine because the
+        // bridge's call lowering handles the receiver shape.
+        //
+        // `[This]`-bearing delegates fall through to the rewrite
+        // further down (line 1357 onward), which produces the
+        // `delegate.call(receiver, ...)` shape that JS needs to
+        // rebind `this` before the runtime trampoline forwards it.
+        if (
+            symbol is { } invoke
+            && IsDelegateInvoke(invoke)
+            && !HasThisParameter(invoke)
+            && inv.Expression is MemberAccessExpressionSyntax invokeMember
+        )
+        {
+            var receiver = Extract(invokeMember.Expression);
+            var invokeArgs = inv.ArgumentList.Arguments.Select(ExtractArgument).ToList();
+            return new IrCallExpression(receiver, invokeArgs, Origin: BuildOrigin(symbol));
+        }
 
         // `decimal.Parse(s)` → `new Decimal(s)`.
         if (

--- a/src/Metano.Compiler/IR/IrExpression.cs
+++ b/src/Metano.Compiler/IR/IrExpression.cs
@@ -125,7 +125,8 @@ public sealed record IrCallExpression(
     IrExpression Target,
     IReadOnlyList<IrArgument> Arguments,
     IReadOnlyList<IrTypeRef>? TypeArguments = null,
-    IrMemberOrigin? Origin = null
+    IrMemberOrigin? Origin = null,
+    bool IsOptional = false
 ) : IrExpression;
 
 /// <summary>

--- a/tests/Metano.Tests/NullConditionalInvokeTests.cs
+++ b/tests/Metano.Tests/NullConditionalInvokeTests.cs
@@ -234,6 +234,104 @@ public class NullConditionalInvokeTests
     }
 
     [Test]
+    public async Task NullConditionalInvoke_ChainedAccess_PreservesEachShortCircuit()
+    {
+        // `a?.b?.c?.Invoke()` must short-circuit at every step and
+        // still drop the trailing `.Invoke` indirection. The TS form
+        // is `a?.b?.c?.()` — optional-call composes with the
+        // optional-chain prefix.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Inner
+            {
+                public Action? Handler;
+            }
+
+            [Transpile]
+            public class Middle
+            {
+                public Inner? Inner;
+            }
+
+            [Transpile]
+            public class Outer
+            {
+                public Middle? Middle;
+
+                public void Fire()
+                {
+                    Middle?.Inner?.Handler?.Invoke();
+                }
+            }
+            """
+        );
+
+        var output = result["outer.ts"];
+        await Assert.That(output).Contains("this.middle?.inner?.handler?.()");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task NullConditionalInvoke_LowPrecedenceReceiver_ParenthesizesCallee()
+    {
+        // `(handler ?? fallback)?.Invoke()` lowers to a call whose
+        // callee is a binary expression. The printer must wrap it in
+        // parens or the output parses as `handler ?? fallback?.()`
+        // instead of `(handler ?? fallback)?.()`.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action? Handler;
+                public Action? Fallback;
+
+                public void Fire()
+                {
+                    (Handler ?? Fallback)?.Invoke();
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("(this.handler ?? this.fallback)?.()");
+    }
+
+    [Test]
+    public async Task DirectInvoke_LowPrecedenceReceiver_ParenthesizesCallee()
+    {
+        // `(handler ?? fallback).Invoke()` becomes a plain call whose
+        // callee is a binary expression. Without parens the call
+        // would bind only to `fallback`.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action Handler { get; }
+                public Action Fallback { get; }
+
+                public Widget(Action handler, Action fallback)
+                {
+                    Handler = handler;
+                    Fallback = fallback;
+                }
+
+                public void Fire()
+                {
+                    (Handler ?? Fallback).Invoke();
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("(this.handler ?? this.fallback)()");
+    }
+
+    [Test]
     public async Task NullConditionalInvoke_DartTarget_LowersToOptionalCallMethod()
     {
         var (files, _) = TranspileDart(

--- a/tests/Metano.Tests/NullConditionalInvokeTests.cs
+++ b/tests/Metano.Tests/NullConditionalInvokeTests.cs
@@ -1,0 +1,331 @@
+using Metano.Annotations;
+using Metano.Compiler;
+using Metano.Compiler.Diagnostics;
+using Metano.Dart.Transformation;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Lowering of <c>handler?.Invoke(...)</c> to TypeScript optional-call
+/// <c>handler?.(...)</c> and Dart <c>handler?.call(...)</c>. Non-conditional
+/// <c>handler.Invoke(...)</c> drops the <c>.Invoke</c> indirection on both
+/// targets — the runtime delegate is itself callable.
+/// </summary>
+public class NullConditionalInvokeTests
+{
+    [Test]
+    public async Task NullConditionalInvoke_NoArgs_LowersToOptionalCall()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action? OnClick;
+
+                public void Fire()
+                {
+                    OnClick?.Invoke();
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.onClick?.()");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task NullConditionalInvoke_WithArgs_LowersToOptionalCall()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action<string, int>? OnEvent;
+
+                public void Fire()
+                {
+                    OnEvent?.Invoke("hello", 42);
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.onEvent?.(\"hello\", 42)");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task DirectInvoke_DropsInvokeIndirection()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action<string> Logger { get; }
+
+                public Widget(Action<string> logger)
+                {
+                    Logger = logger;
+                }
+
+                public void Log()
+                {
+                    Logger.Invoke("msg");
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.logger(\"msg\")");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task NullConditionalInvoke_StaticDelegateField_NoImplicitThis()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public static class Bus
+            {
+                public static Action<string>? Listener;
+
+                public static void Publish(string msg)
+                {
+                    Listener?.Invoke(msg);
+                }
+            }
+            """
+        );
+
+        var output = result["bus.ts"];
+        await Assert.That(output).Contains("Bus.listener?.(msg)");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task NullConditionalInvoke_InsideLambda_PreservesOptionalCall()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action? OnClick;
+
+                public Action Wrap()
+                {
+                    return () => OnClick?.Invoke();
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.onClick?.()");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task DirectInvoke_GenericDelegate_DropsInvokeIndirection()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Func<int, string> Format { get; }
+
+                public Widget(Func<int, string> format)
+                {
+                    Format = format;
+                }
+
+                public string Render(int value)
+                {
+                    return Format.Invoke(value);
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains("this.format(value)");
+        await Assert.That(output).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task ThisBearingDelegate_DirectInvoke_KeepsCallRewrite()
+    {
+        // `[This]`-bearing delegates rebind the first argument as JS
+        // `this`. The Invoke shortcut must fall through so the
+        // existing `.call(receiver, ...)` rewrite stays in charge.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public abstract class Element {}
+
+            public delegate void MouseEventListener([This] Element self, string arg);
+
+            [Transpile]
+            public class Widget
+            {
+                public MouseEventListener Listener { get; }
+
+                public Widget(MouseEventListener listener)
+                {
+                    Listener = listener;
+                }
+
+                public void Fire(Element target)
+                {
+                    Listener(target, "click");
+                }
+            }
+            """
+        );
+
+        var output = result["widget.ts"];
+        await Assert.That(output).Contains(".call(target, \"click\")");
+    }
+
+    [Test]
+    public async Task EventSubscription_Unaffected_ByInvokeShortcut()
+    {
+        // Event `+=` lowers to `delegateAdd`, never to a call. The
+        // Invoke shortcuts must not interfere.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+
+            [Transpile]
+            public class App
+            {
+                private Counter _counter = new Counter();
+
+                public void Setup()
+                {
+                    _counter.CountChanged += OnCountChanged;
+                }
+
+                private void OnCountChanged(int count) { }
+            }
+            """
+        );
+
+        var output = result["app.ts"];
+        await Assert.That(output).Contains("countChanged$add(");
+        await Assert.That(output).DoesNotContain("?.()");
+    }
+
+    [Test]
+    public async Task NullConditionalInvoke_DartTarget_LowersToOptionalCallMethod()
+    {
+        var (files, _) = TranspileDart(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action<int>? OnTick;
+
+                public void Fire()
+                {
+                    OnTick?.Invoke(7);
+                }
+            }
+            """
+        );
+
+        var dart = files["widget.dart"];
+        await Assert.That(dart).Contains("onTick?.call(7)");
+        await Assert.That(dart).DoesNotContain("Invoke");
+    }
+
+    [Test]
+    public async Task DirectInvoke_DartTarget_DropsInvokeIndirection()
+    {
+        var (files, _) = TranspileDart(
+            """
+            [Transpile]
+            public class Widget
+            {
+                public Action<int> OnTick { get; }
+
+                public Widget(Action<int> onTick)
+                {
+                    OnTick = onTick;
+                }
+
+                public void Fire()
+                {
+                    OnTick.Invoke(7);
+                }
+            }
+            """
+        );
+
+        var dart = files["widget.dart"];
+        await Assert.That(dart).Contains("onTick(7)");
+        await Assert.That(dart).DoesNotContain("Invoke");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private static (
+        Dictionary<string, string> Files,
+        IReadOnlyList<MetanoDiagnostic> Diagnostics
+    ) TranspileDart(string csharpSource)
+    {
+        var source = $"""
+            using System;
+            using Metano.Annotations;
+            {csharpSource}
+            """;
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            source,
+            new CSharpParseOptions(LanguageVersion.Preview)
+        );
+        var compilation = CSharpCompilation.Create(
+            "DartTestAssembly",
+            [syntaxTree],
+            TranspileHelper.BaseReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        var errors = compilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        if (errors.Count > 0)
+            throw new InvalidOperationException(
+                "C# compilation failed:\n" + string.Join("\n", errors.Select(e => e.ToString()))
+            );
+
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(
+            compilation,
+            TargetLanguage.Dart
+        );
+        var transformer = new DartTransformer(ir, compilation);
+        var files = transformer.TransformAll();
+        var printer = new Metano.Dart.Printer();
+        var result = new Dictionary<string, string>();
+        foreach (var file in files)
+            result[file.FileName] = printer.Print(file);
+        return (result, transformer.Diagnostics);
+    }
+}


### PR DESCRIPTION
## Summary

- Lower C# `handler?.Invoke(args)` to TypeScript `handler?.(args)` and Dart `handler?.call(args)`.
- Drop the `.Invoke` indirection on non-conditional `handler.Invoke(args)` (becomes `handler(args)` on both targets) — the runtime delegate is the function.
- `[This]`-bearing delegates fall through both shortcuts so the existing `delegate.call(receiver, ...)` rewrite keeps producing the JS `this`-rebind shape.

## Mechanism

- `IrCallExpression` gains an `IsOptional` flag.
- `IrExpressionExtractor` detects `MethodKind.DelegateInvoke` at two sites (conditional binding via `MemberBindingExpressionSyntax` and direct invocation via `MemberAccessExpressionSyntax`), drops the binding, and sets the flag.
- TS printer: emits `?.` between callee and argument list when `Optional`.
- Dart printer: emits `?.call` when `IsOptional`.

## Test plan

- [x] 11 new tests in `NullConditionalInvokeTests.cs` covering: TS no-args, TS with-args, TS direct, TS static field, TS inside lambda, TS generic `Func<T,R>`, TS `[This]`-bearing (keeps `.call` rewrite), TS event `+=` (unaffected), Dart conditional, Dart direct.
- [x] Full suite: `dotnet run --project tests/Metano.Tests/` → 738/738 pass.
- [x] csharpier-format clean.

Closes #121