### PR TITLE
feat(ts): emit extends clause for interface inheritance

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassBridge.cs
@@ -39,16 +39,32 @@ internal static class IrToTsClassBridge
     /// interface that doesn't get emitted alongside the class. Returns
     /// <c>null</c> when nothing remains so the printer elides the clause.
     /// </summary>
-    public static IReadOnlyList<TsType>? BuildImplements(IrClassDeclaration ir)
+    public static IReadOnlyList<TsType>? BuildImplements(IrClassDeclaration ir) =>
+        ConvertHeritageList(ir.Interfaces);
+
+    /// <summary>
+    /// Lowers a list of IR base / interface references into TS heritage
+    /// entries. Drops named refs flagged <c>IsTranspilable: false</c>
+    /// (e.g. <c>[NoEmit]</c> or unmapped BCL interfaces) and rewrites
+    /// the array shorthand <c>T[]</c> (produced when a base maps
+    /// through <see cref="IrArrayTypeRef"/> for collection-like BCL
+    /// types) into <c>Array&lt;T&gt;</c>: TypeScript rejects
+    /// <c>extends T[]</c> / <c>implements T[]</c> in heritage clauses,
+    /// but accepts the named <c>Array</c> form.
+    /// </summary>
+    public static IReadOnlyList<TsType>? ConvertHeritageList(IReadOnlyList<IrTypeRef>? references)
     {
-        if (ir.Interfaces is not { Count: > 0 } ifaces)
+        if (references is not { Count: > 0 } refs)
             return null;
         var result = new List<TsType>();
-        foreach (var iface in ifaces)
+        foreach (var reference in refs)
         {
-            if (iface is IrNamedTypeRef { Semantics.IsTranspilable: false })
+            if (reference is IrNamedTypeRef { Semantics.IsTranspilable: false })
                 continue;
-            result.Add(IrToTsTypeMapper.Map(iface));
+            var mapped = IrToTsTypeMapper.Map(reference);
+            result.Add(
+                mapped is TsArrayType array ? new TsNamedType("Array", [array.ElementType]) : mapped
+            );
         }
         return result.Count > 0 ? result : null;
     }

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
@@ -45,15 +45,39 @@ public static class IrToTsInterfaceBridge
         // consequently the file name + import collector).
         var tsName = nameOverride ?? IrToTsNamingPolicy.ToTypeName(ir.Name, ir.Attributes);
         var typeParams = ConvertTypeParameters(ir.TypeParameters);
+        var extends = BuildExtends(ir.BaseInterfaces);
 
         statements.Add(
             new TsInterface(
                 tsName,
                 properties,
                 TypeParameters: typeParams,
-                Methods: methods.Count > 0 ? methods : null
+                Methods: methods.Count > 0 ? methods : null,
+                Extends: extends
             )
         );
+    }
+
+    /// <summary>
+    /// Convert IR base-interface references into TS extends entries.
+    /// Mirrors <c>IrToTsClassBridge.BuildImplements</c>: drops named
+    /// references that are not transpilable (e.g. <c>[NoEmit]</c> or
+    /// BCL types without an <c>[ExportFromBcl]</c> mapping) so the
+    /// emitted clause only references types that exist at the target
+    /// layer.
+    /// </summary>
+    public static IReadOnlyList<TsType>? BuildExtends(IReadOnlyList<IrTypeRef>? baseInterfaces)
+    {
+        if (baseInterfaces is not { Count: > 0 } bases)
+            return null;
+        var result = new List<TsType>();
+        foreach (var iface in bases)
+        {
+            if (iface is IrNamedTypeRef { Semantics.IsTranspilable: false })
+                continue;
+            result.Add(IrToTsTypeMapper.Map(iface));
+        }
+        return result.Count > 0 ? result : null;
     }
 
     private static TsProperty ConvertProperty(IrPropertyDeclaration prop)

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsInterfaceBridge.cs
@@ -60,25 +60,13 @@ public static class IrToTsInterfaceBridge
 
     /// <summary>
     /// Convert IR base-interface references into TS extends entries.
-    /// Mirrors <c>IrToTsClassBridge.BuildImplements</c>: drops named
-    /// references that are not transpilable (e.g. <c>[NoEmit]</c> or
-    /// BCL types without an <c>[ExportFromBcl]</c> mapping) so the
-    /// emitted clause only references types that exist at the target
-    /// layer.
+    /// Delegates to <see cref="IrToTsClassBridge.ConvertHeritageList"/>
+    /// so the same filtering and array-shorthand normalization apply
+    /// to both <c>extends</c> (interface) and <c>implements</c>
+    /// (class) clauses.
     /// </summary>
-    public static IReadOnlyList<TsType>? BuildExtends(IReadOnlyList<IrTypeRef>? baseInterfaces)
-    {
-        if (baseInterfaces is not { Count: > 0 } bases)
-            return null;
-        var result = new List<TsType>();
-        foreach (var iface in bases)
-        {
-            if (iface is IrNamedTypeRef { Semantics.IsTranspilable: false })
-                continue;
-            result.Add(IrToTsTypeMapper.Map(iface));
-        }
-        return result.Count > 0 ? result : null;
-    }
+    public static IReadOnlyList<TsType>? BuildExtends(IReadOnlyList<IrTypeRef>? baseInterfaces) =>
+        IrToTsClassBridge.ConvertHeritageList(baseInterfaces);
 
     private static TsProperty ConvertProperty(IrPropertyDeclaration prop)
     {

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsPlainObjectBridge.cs
@@ -52,7 +52,9 @@ public static class IrToTsPlainObjectBridge
             }
         }
 
-        sink.Add(new TsInterface(tsName, properties));
+        sink.Add(
+            new TsInterface(tsName, properties, Extends: IrToTsClassBridge.BuildImplements(ir))
+        );
 
         if (ir.Members is { Count: > 0 } members)
         {

--- a/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/ImportCollector.cs
@@ -498,6 +498,9 @@ public sealed class ImportCollector(
         {
             case TsInterface iface:
                 CollectFromTypeParameters(iface.TypeParameters, names, crossPackageOrigins);
+                if (iface.Extends is not null)
+                    foreach (var baseRef in iface.Extends)
+                        CollectFromType(baseRef, names, crossPackageOrigins);
                 foreach (var prop in iface.Properties)
                     CollectFromType(prop.Type, names, crossPackageOrigins);
                 if (iface.Methods is not null)

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -986,7 +986,8 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             TypeKind.Enum => IrEnumExtractor.Extract(type),
             TypeKind.Interface => IrInterfaceExtractor.Extract(
                 type,
-                target: TargetLanguage.TypeScript
+                Context.OriginResolver,
+                TargetLanguage.TypeScript
             ),
             TypeKind.Class or TypeKind.Struct => IrClassExtractor.Extract(
                 type,

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsInterface.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsInterface.cs
@@ -5,5 +5,6 @@ public sealed record TsInterface(
     IReadOnlyList<TsProperty> Properties,
     bool Exported = true,
     IReadOnlyList<TsTypeParameter>? TypeParameters = null,
-    IReadOnlyList<TsInterfaceMethod>? Methods = null
+    IReadOnlyList<TsInterfaceMethod>? Methods = null,
+    IReadOnlyList<TsType>? Extends = null
 ) : TsTopLevel;

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -338,6 +338,16 @@ public sealed class Printer(string indent = "  ")
         _sb.Write("interface ");
         _sb.Write(iface.Name);
         PrintTypeParameters(iface.TypeParameters);
+        if (iface.Extends is { Count: > 0 } extends)
+        {
+            _sb.Write(" extends ");
+            for (var i = 0; i < extends.Count; i++)
+            {
+                if (i > 0)
+                    _sb.Write(", ");
+                PrintType(extends[i]);
+            }
+        }
         _sb.WriteBlock(() =>
         {
             foreach (var prop in iface.Properties)

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -341,12 +341,7 @@ public sealed class Printer(string indent = "  ")
         if (iface.Extends is { Count: > 0 } extends)
         {
             _sb.Write(" extends ");
-            for (var i = 0; i < extends.Count; i++)
-            {
-                if (i > 0)
-                    _sb.Write(", ");
-                PrintType(extends[i]);
-            }
+            _sb.WriteList(extends, PrintType);
         }
         _sb.WriteBlock(() =>
         {

--- a/tests/Metano.Tests/InterfaceInheritanceTests.cs
+++ b/tests/Metano.Tests/InterfaceInheritanceTests.cs
@@ -1,0 +1,274 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Lowering of C# interface inheritance (<c>interface IA : IB</c>) into
+/// TypeScript <c>extends</c> clauses. Covers single + multiple bases,
+/// generic bases (with BCL mapping), naming overrides, cross-package
+/// bases, and <c>[PlainObject]</c> records that emit as interfaces.
+/// </summary>
+public class InterfaceInheritanceTests
+{
+    [Test]
+    public async Task SingleBase_EmitsExtendsClause()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public interface ICloseable
+            {
+                void Close();
+            }
+
+            [Transpile]
+            public interface IStream : ICloseable
+            {
+                int Read();
+            }
+            """
+        );
+
+        var output = result["i-stream.ts"];
+        await Assert.That(output).Contains("export interface IStream extends ICloseable");
+    }
+
+    [Test]
+    public async Task MultipleBases_EmitsCommaSeparatedExtends()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public interface ICloseable
+            {
+                void Close();
+            }
+
+            [Transpile]
+            public interface IFlushable
+            {
+                void Flush();
+            }
+
+            [Transpile]
+            public interface IStream : ICloseable, IFlushable
+            {
+                int Read();
+            }
+            """
+        );
+
+        var output = result["i-stream.ts"];
+        await Assert.That(output).Contains("interface IStream extends ICloseable, IFlushable");
+    }
+
+    [Test]
+    public async Task GenericBase_PropagatesTypeArguments()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public interface IBox<T>
+            {
+                T Value { get; }
+            }
+
+            [Transpile]
+            public interface ITypedBox<T> : IBox<T>
+            {
+                string Label { get; }
+            }
+            """
+        );
+
+        var output = result["i-typed-box.ts"];
+        await Assert.That(output).Contains("interface ITypedBox<T> extends IBox<T>");
+    }
+
+    [Test]
+    public async Task BclGenericBase_MapsThroughBclLayer()
+    {
+        // `IReadOnlyCollection<T>` is a BCL type that maps to TS
+        // `Iterable<T>` via the existing IrToTsTypeMapper rules. The
+        // extends clause must use the mapped name, not the C# original.
+        var result = TranspileHelper.Transpile(
+            """
+            using System.Collections.Generic;
+
+            [Transpile]
+            public interface ITyped<T> : IReadOnlyCollection<T>
+            {
+                string Label { get; }
+            }
+            """
+        );
+
+        var output = result["i-typed.ts"];
+        await Assert.That(output).Contains("interface ITyped<T> extends Iterable<T>");
+        await Assert.That(output).DoesNotContain("IReadOnlyCollection");
+    }
+
+    [Test]
+    public async Task NameOverrideOnBase_AppliesToExtendsEntry()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            [Name("Closeable")]
+            public interface ICloseable
+            {
+                void Close();
+            }
+
+            [Transpile]
+            public interface IStream : ICloseable
+            {
+                int Read();
+            }
+            """
+        );
+
+        var output = result["i-stream.ts"];
+        await Assert.That(output).Contains("interface IStream extends Closeable");
+        await Assert.That(output).DoesNotContain("ICloseable");
+    }
+
+    [Test]
+    public async Task StripInterfacePrefix_RewritesBothDeclarationAndExtends()
+    {
+        var (files, _) = TranspileHelper.TranspileWithStripInterfacePrefix(
+            """
+            [Transpile]
+            public interface ICloseable
+            {
+                void Close();
+            }
+
+            [Transpile]
+            public interface IStream : ICloseable
+            {
+                int Read();
+            }
+            """
+        );
+
+        var output = files["stream.ts"];
+        await Assert.That(output).Contains("export interface Stream extends Closeable");
+    }
+
+    [Test]
+    public async Task CrossPackageBase_AddsImportTypeEntry()
+    {
+        var library = """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("@scope/lib")]
+
+            namespace MyLib.Streams
+            {
+                public interface ICloseable
+                {
+                    void Close();
+                }
+            }
+            """;
+
+        var consumer = """
+            [assembly: TranspileAssembly]
+
+            namespace App;
+
+            public interface IStream : MyLib.Streams.ICloseable
+            {
+                int Read();
+            }
+            """;
+
+        var result = TranspileHelper.TranspileWithLibrary(library, consumer);
+        var output = result["i-stream.ts"];
+
+        await Assert.That(output).Contains("import");
+        await Assert.That(output).Contains("ICloseable");
+        await Assert.That(output).Contains("@scope/lib");
+        await Assert.That(output).Contains("interface IStream extends ICloseable");
+    }
+
+    [Test]
+    public async Task NonTranspilableBase_FilteredFromExtends()
+    {
+        // A base interface that isn't transpiled (no [Transpile], no
+        // declarative mapping) must not leak into the extends clause.
+        // Mirrors the class implements filter to keep both shapes
+        // consistent.
+        var result = TranspileHelper.Transpile(
+            """
+            using System;
+
+            [Transpile]
+            public interface ICustom : IDisposable
+            {
+                void DoWork();
+            }
+            """
+        );
+
+        var output = result["i-custom.ts"];
+        await Assert.That(output).Contains("interface ICustom");
+        await Assert.That(output).DoesNotContain("extends IDisposable");
+    }
+
+    [Test]
+    public async Task CrossPackageMemberType_OnInterface_AddsImport()
+    {
+        // Locks in the side-effect of wiring OriginResolver into the
+        // interface extractor: cross-package types referenced by a
+        // member (not just by a base) now resolve their origin and
+        // surface as imports.
+        var library = """
+            [assembly: TranspileAssembly]
+            [assembly: EmitPackage("@scope/lib")]
+
+            namespace MyLib.Domain
+            {
+                public record Money(decimal Amount, string Currency);
+            }
+            """;
+
+        var consumer = """
+            [assembly: TranspileAssembly]
+
+            namespace App;
+
+            public interface IWallet
+            {
+                MyLib.Domain.Money Balance { get; }
+            }
+            """;
+
+        var result = TranspileHelper.TranspileWithLibrary(library, consumer);
+        var output = result["i-wallet.ts"];
+
+        await Assert.That(output).Contains("import");
+        await Assert.That(output).Contains("Money");
+        await Assert.That(output).Contains("@scope/lib");
+        await Assert.That(output).Contains("balance: Money");
+    }
+
+    [Test]
+    public async Task PlainObjectRecord_HonorsBaseInterfaceChain()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public interface IPet
+            {
+                string Name { get; }
+            }
+
+            [PlainObject]
+            [Transpile]
+            public record Cat(string Name) : IPet;
+            """
+        );
+
+        var output = result["cat.ts"];
+        await Assert.That(output).Contains("export interface Cat extends IPet");
+    }
+}

--- a/tests/Metano.Tests/InterfaceInheritanceTests.cs
+++ b/tests/Metano.Tests/InterfaceInheritanceTests.cs
@@ -109,17 +109,17 @@ public class InterfaceInheritanceTests
     [Test]
     public async Task CollectionLikeBase_NormalizesArrayShorthandToNamedArray()
     {
-        // `IEnumerable<T>` / `IList<T>` / `ICollection<T>` map to
-        // `IrArrayTypeRef` (T[]). The TS printer's array shorthand
-        // is illegal in a heritage clause (`extends T[]` doesn't
-        // parse). The bridge rewrites it to the named `Array<T>`
-        // form, which TS accepts.
+        // `IList<T>` / `ICollection<T>` map to `IrArrayTypeRef`
+        // (T[]) via the existing collection-like rule. The TS
+        // printer's array shorthand is illegal in a heritage clause
+        // (`extends T[]` doesn't parse); the bridge rewrites it to
+        // the named `Array<T>` form, which TS accepts.
         var result = TranspileHelper.Transpile(
             """
             using System.Collections.Generic;
 
             [Transpile]
-            public interface IRows<T> : IEnumerable<T>
+            public interface IRows<T> : IList<T>
             {
                 int Count { get; }
             }

--- a/tests/Metano.Tests/InterfaceInheritanceTests.cs
+++ b/tests/Metano.Tests/InterfaceInheritanceTests.cs
@@ -107,6 +107,31 @@ public class InterfaceInheritanceTests
     }
 
     [Test]
+    public async Task CollectionLikeBase_NormalizesArrayShorthandToNamedArray()
+    {
+        // `IEnumerable<T>` / `IList<T>` / `ICollection<T>` map to
+        // `IrArrayTypeRef` (T[]). The TS printer's array shorthand
+        // is illegal in a heritage clause (`extends T[]` doesn't
+        // parse). The bridge rewrites it to the named `Array<T>`
+        // form, which TS accepts.
+        var result = TranspileHelper.Transpile(
+            """
+            using System.Collections.Generic;
+
+            [Transpile]
+            public interface IRows<T> : IEnumerable<T>
+            {
+                int Count { get; }
+            }
+            """
+        );
+
+        var output = result["i-rows.ts"];
+        await Assert.That(output).Contains("interface IRows<T> extends Array<T>");
+        await Assert.That(output).DoesNotContain("extends T[]");
+    }
+
+    [Test]
     public async Task NameOverrideOnBase_AppliesToExtendsEntry()
     {
         var result = TranspileHelper.Transpile(


### PR DESCRIPTION
## Summary

C# `interface IA : IB, IC` now lowers to TypeScript `interface IA extends IB, IC`. The IR already captured the base chain (`IrInterfaceDeclaration.BaseInterfaces`); this PR threads it through the TS bridge, AST, printer, and import collector.

## Mechanism

- `TsInterface` AST: new `Extends: IReadOnlyList<TsType>?` field.
- `IrToTsInterfaceBridge.BuildExtends`: mirrors `IrToTsClassBridge.BuildImplements` — maps each base via `IrToTsTypeMapper`, filters out `IrNamedTypeRef { IsTranspilable: false }` (BCL bases without `[ExportFromBcl]`).
- `IrToTsPlainObjectBridge`: passes `BuildImplements(ir)` to `TsInterface.Extends` so `[PlainObject]` records that implement interfaces emit with the chain.
- `Printer.PrintInterface`: emits ` extends A, B` after type params, before the block.
- `ImportCollector.CollectFromTopLevel` (`TsInterface` arm): walks `iface.Extends` so cross-package bases generate the right `import type { IBase } from "pkg/path"` entry and `package.json` dependency.

## Side effect: cross-package member types on interfaces

`TypeTransformer` now wires `Context.OriginResolver` into `IrInterfaceExtractor.Extract`. The extractor previously got `null`, which silently dropped origin metadata for cross-package types referenced by interface members (not just bases). They were emitted as bare names with no import. The test `CrossPackageMemberType_OnInterface_AddsImport` locks this in. Same-package output is byte-identical because origin resolution returns null for local types.

## Test plan

- [x] 10 new tests in `InterfaceInheritanceTests.cs`: single base, multiple bases, generic base, BCL generic base (`IReadOnlyCollection<T>` → `Iterable<T>`), `[Name]` override on base, `--strip-interface-prefix`, cross-package base import, non-transpilable filter (`IDisposable`), `[PlainObject]` record extends interface, cross-package member type.
- [x] Full suite: 750/750 pass.
- [x] csharpier-format clean.

## Out of scope

- Dart target — issue is TS-only. The Dart bridge already emits `implements` from `IrInterfaceDeclaration.BaseInterfaces` directly; no changes needed.

Closes #117