### PR TITLE
fix(core): map IEnumerable<T> to Iterable<T> instead of Array

### DIFF
--- a/src/Metano.Compiler.TypeScript/Transformation/JsonSerializerContextTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/JsonSerializerContextTransformer.cs
@@ -426,8 +426,22 @@ public sealed class JsonSerializerContextTransformer(TypeScriptTransformContext 
             if (named.IsSetLike() && named.TypeArguments.Length > 0)
                 return "hashSet";
 
-            // Collection-like → array
-            if (named.IsCollectionLike() && named.TypeArguments.Length > 0)
+            // Collection-like / IEnumerable / IReadOnlyCollection → array.
+            // Since #129 these no longer share the `IsCollectionLike`
+            // predicate (they lower to TS `Iterable<T>` at the type
+            // level), but JSON-wise they still serialize as arrays —
+            // `JSON.stringify([...iter])` works the same as a plain
+            // array. Keep the descriptor as "array" so the generated
+            // serializer context knows to iterate and emit the element
+            // descriptor.
+            if (
+                (
+                    named.IsCollectionLike()
+                    || fullName.StartsWith("System.Collections.Generic.IEnumerable")
+                    || fullName.StartsWith("System.Collections.Generic.IReadOnlyCollection")
+                )
+                && named.TypeArguments.Length > 0
+            )
                 return "array";
 
             // Enum with [StringEnum] → enum, otherwise numericEnum

--- a/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
+++ b/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
@@ -165,9 +165,17 @@ public static class IrTypeRefMapper
                     Map(named.TypeArguments[1], originResolver)
                 );
 
-            // IReadOnlyCollection<T> → Iterable
+            // IEnumerable<T> / IReadOnlyCollection<T> → Iterable.
+            // C# `IEnumerable<T>` is a lazy, read-only, forward-only
+            // sequence — the closest TS surface is `Iterable<T>`,
+            // not `Array<T>`. Iterator return types (yield) take a
+            // separate path through `MapForGeneratorReturn` and
+            // lower to `Generator<T>` instead.
             if (
-                fullName.StartsWith("System.Collections.Generic.IReadOnlyCollection")
+                (
+                    fullName.StartsWith("System.Collections.Generic.IEnumerable")
+                    || fullName.StartsWith("System.Collections.Generic.IReadOnlyCollection")
+                )
                 && named.TypeArguments.Length > 0
             )
                 return new IrIterableTypeRef(Map(named.TypeArguments[0], originResolver));

--- a/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
+++ b/src/Metano.Compiler/Extraction/IrTypeRefMapper.cs
@@ -178,11 +178,11 @@ public static class IrTypeRefMapper
                 )
                 && named.TypeArguments.Length > 0
             )
-                return new IrIterableTypeRef(Map(named.TypeArguments[0], originResolver));
+                return new IrIterableTypeRef(Map(named.TypeArguments[0], originResolver, target));
 
             // Collection-like → Array
             if (named.IsCollectionLike() && named.TypeArguments.Length > 0)
-                return new IrArrayTypeRef(Map(named.TypeArguments[0], originResolver));
+                return new IrArrayTypeRef(Map(named.TypeArguments[0], originResolver, target));
 
             // Delegate types → function type
             if (named.TypeKind == TypeKind.Delegate)

--- a/src/Metano.Compiler/RoslynTypeQueries.cs
+++ b/src/Metano.Compiler/RoslynTypeQueries.cs
@@ -44,13 +44,19 @@ public static class RoslynTypeQueries
             || fullName.StartsWith("System.Collections.Immutable.ImmutableHashSet");
     }
 
+    /// <summary>
+    /// True for BCL types that map to a TypeScript <c>Array</c> at the
+    /// IR level. <c>IEnumerable&lt;T&gt;</c> is intentionally excluded
+    /// — it represents a lazy sequence and lowers to
+    /// <c>IrIterableTypeRef</c> (TS <c>Iterable&lt;T&gt;</c>) instead;
+    /// see the dedicated branch in <see cref="Metano.Compiler.Extraction.IrTypeRefMapper"/>.
+    /// </summary>
     public static bool IsCollectionLike(this INamedTypeSymbol type)
     {
         var fullName = type.ToDisplayString();
         return fullName.StartsWith("System.Collections.Generic.List")
             || fullName.StartsWith("System.Collections.Generic.IList")
             || fullName.StartsWith("System.Collections.Generic.IReadOnlyList")
-            || fullName.StartsWith("System.Collections.Generic.IEnumerable")
             || fullName.StartsWith("System.Collections.Generic.ICollection")
             || fullName.StartsWith("System.Collections.Immutable.ImmutableList")
             || fullName.StartsWith("System.Collections.Immutable.ImmutableArray")

--- a/tests/Metano.Tests/ExtensionTranspileTests.cs
+++ b/tests/Metano.Tests/ExtensionTranspileTests.cs
@@ -75,7 +75,7 @@ public class ExtensionTranspileTests
         );
 
         var output = result["enumerable-ext.ts"];
-        await Assert.That(output).Contains("function isEmpty<T>(source: T[]): boolean");
+        await Assert.That(output).Contains("function isEmpty<T>(source: Iterable<T>): boolean");
     }
 
     // ─── C# 14 extension blocks ─────────────────────────────

--- a/tests/Metano.Tests/JsonSerializerContextTests.cs
+++ b/tests/Metano.Tests/JsonSerializerContextTests.cs
@@ -346,4 +346,41 @@ public class JsonSerializerContextTests
         // And UUID should be imported from metano-runtime
         await Assert.That(ts).Contains("import { UUID } from \"metano-runtime\"");
     }
+
+    [Test]
+    public async Task IEnumerableProperty_ClassifiesAsArrayDescriptor()
+    {
+        // After #129, `IEnumerable<T>` lowers to `Iterable<T>` at the
+        // type level, but JSON-wise it still serializes as an array.
+        // The serializer context must classify the property as
+        // `kind: "array"` so the runtime knows to iterate and emit
+        // each element through the inner descriptor — falling
+        // through to `kind: "ref"` would break serialization.
+        var result = TranspileHelper.Transpile(
+            """
+            using System.Collections.Generic;
+            using System.Text.Json.Serialization;
+
+            namespace TestApp;
+
+            [Transpile]
+            public record Tag(string Value);
+
+            [Transpile]
+            public record Article(string Title, IEnumerable<Tag> Tags);
+
+            [Transpile]
+            [JsonSerializable(typeof(Article))]
+            public partial class JsonContext : JsonSerializerContext
+            {
+                public JsonContext() : base(new System.Text.Json.JsonSerializerOptions()) { }
+                protected override System.Text.Json.JsonSerializerOptions? GeneratedSerializerOptions => null;
+                public override System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(Type type) => null;
+            }
+            """
+        );
+
+        var ts = result["json-context.ts"];
+        await Assert.That(ts).Contains("kind: \"array\"");
+    }
 }

--- a/tests/Metano.Tests/YieldTranspileTests.cs
+++ b/tests/Metano.Tests/YieldTranspileTests.cs
@@ -51,8 +51,12 @@ public class YieldTranspileTests
     }
 
     [Test]
-    public async Task IEnumerableWithoutYield_RemainsArrayMapping()
+    public async Task IEnumerableWithoutYield_MapsToIterable()
     {
+        // Non-iterator methods returning `IEnumerable<T>` lower to
+        // `Iterable<T>` — the lazy-sequence semantics match. Only
+        // iterator (yield-bearing) methods route through
+        // `MapForGeneratorReturn` and emit `Generator<T>`.
         var result = TranspileHelper.Transpile(
             """
             [Transpile]
@@ -64,7 +68,7 @@ public class YieldTranspileTests
         );
 
         var output = result["snapshot-provider.ts"];
-        await Assert.That(output).Contains("snapshot(): number[]");
+        await Assert.That(output).Contains("snapshot(): Iterable<number>");
         await Assert.That(output).DoesNotContain("*snapshot(");
     }
 }


### PR DESCRIPTION
## Summary

C# `IEnumerable<T>` is a lazy, read-only, forward-only sequence. The closest TypeScript surface is `Iterable<T>` — what `for...of` consumes — **not** `Array<T>` (which adds random access, mutation, and the full prototype). The mapping was incorrect because `RoslynTypeQueries.IsCollectionLike` lumped `IEnumerable` together with `IList`, `ICollection`, etc., and the IR mapper lowered all of them through `IrArrayTypeRef` (TS `T[]`).

## Mechanism

- Drop `System.Collections.Generic.IEnumerable` from `IsCollectionLike`.
- Add a dedicated branch in `IrTypeRefMapper.MapNamed` that handles both `IEnumerable<T>` and the existing `IReadOnlyCollection<T>` mapping → `IrIterableTypeRef` (printer emits `Iterable<T>`).
- Iterator (yield-bearing) methods unchanged: they route through `MapForGeneratorReturn` and emit `Generator<T>`.

## Symptom (now fixed)

```csharp
public IEnumerable<int> Snapshot() => [1, 2, 3];
```

Before: `snapshot(): number[]` (wrong — implies random access + mutation)
After:  `snapshot(): Iterable<number>` (matches the C# semantics)

The bug was visible in PR #128 reviews, where using `IEnumerable<T>` as a base interface produced `extends T[]` (illegal heritage shorthand). #128 worked around the symptom by rewriting `T[]` to `Array<T>` in heritage clauses; this PR fixes the root cause for all positions (parameters, return types, properties, fields, base interfaces).

## Test plan

- [x] Updated existing tests that asserted the old (wrong) behavior:
  - `YieldTranspileTests.IEnumerableWithoutYield_RemainsArrayMapping` → `IEnumerableWithoutYield_MapsToIterable`.
  - `ExtensionTranspileTests.ClassicExtension_GenericReceiver` — expects `Iterable<T>` instead of `T[]`.
- [x] Full .NET suite: 752/752 pass.
- [x] Sample regeneration produced byte-identical output (no sample uses `IEnumerable<T>` directly today, only `IList`/`IReadOnlyList`).
- [x] Bun test suites:
  - `metano-runtime`: 275 pass
  - `sample-todo`: 18 pass
  - `sample-issue-tracker`: 142 pass
  - `sample-todo-service`: 33 pass

Closes #129