### PR TITLE
fix(ts): bind 'this' on method group conversion to delegate

### DIFF
--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -581,7 +581,7 @@ public sealed class IrExpressionExtractor
             && symbol.ContainingType is not null
             && !IsLocalLikeSymbol(symbol)
         )
-            return WrapMethodGroupForThisDelegate(
+            return WrapMethodGroupForDelegate(
                 generic,
                 symbol,
                 new IrMemberAccess(
@@ -595,7 +595,7 @@ public sealed class IrExpressionExtractor
             symbol is { IsStatic: true } and (IPropertySymbol or IFieldSymbol or IMethodSymbol)
             && symbol.ContainingType is not null
         )
-            return WrapMethodGroupForThisDelegate(
+            return WrapMethodGroupForDelegate(
                 generic,
                 symbol,
                 new IrMemberAccess(
@@ -605,7 +605,7 @@ public sealed class IrExpressionExtractor
                 )
             );
 
-        return WrapMethodGroupForThisDelegate(
+        return WrapMethodGroupForDelegate(
             generic,
             symbol,
             new IrIdentifier(generic.Identifier.ValueText)
@@ -642,7 +642,7 @@ public sealed class IrExpressionExtractor
                 id.Identifier.ValueText,
                 BuildOrigin(symbol)
             );
-            return WrapMethodGroupForThisDelegate(id, symbol, memberAccess);
+            return WrapMethodGroupForDelegate(id, symbol, memberAccess);
         }
 
         // Static member of the enclosing (or any other) type reached without a
@@ -660,14 +660,10 @@ public sealed class IrExpressionExtractor
                 id.Identifier.ValueText,
                 BuildOrigin(symbol)
             );
-            return WrapMethodGroupForThisDelegate(id, symbol, staticAccess);
+            return WrapMethodGroupForDelegate(id, symbol, staticAccess);
         }
 
-        return WrapMethodGroupForThisDelegate(
-            id,
-            symbol,
-            new IrIdentifier(id.Identifier.ValueText)
-        );
+        return WrapMethodGroupForDelegate(id, symbol, new IrIdentifier(id.Identifier.ValueText));
     }
 
     private static bool IsLocalLikeSymbol(ISymbol symbol) =>
@@ -1142,31 +1138,33 @@ public sealed class IrExpressionExtractor
 
         var origin = BuildOrigin(_semantic.GetSymbolInfo(member).Symbol);
         var memberAccess = new IrMemberAccess(target, name, origin);
-        return WrapMethodGroupForThisDelegate(member, symbol, memberAccess);
+        return WrapMethodGroupForDelegate(member, symbol, memberAccess);
     }
 
     /// <summary>
-    /// Method-group conversion to a <c>[This]</c>-bearing delegate: a
-    /// reference like <c>button.OnClick = handler</c> (or the static
-    /// equivalent) implicitly funnels the dispatcher's JS <c>this</c>
-    /// into the method's first parameter at every invocation. The
-    /// extractor wraps the method reference in a runtime
-    /// <c>bindReceiver(...)</c> call so the resulting TS function
-    /// rebinds <c>this</c> the same way a <c>[This]</c> lambda does.
+    /// Method-group conversion to a delegate type. C# captures the
+    /// instance receiver implicitly so any later invocation runs the
+    /// body with the original <c>this</c>; JS does not — a bare
+    /// <c>obj.method</c> reference loses its receiver as soon as it
+    /// leaves the access expression. This wrapper normalizes the IR
+    /// so the emitted TS preserves the C# semantics in two layers:
+    /// <list type="bullet">
+    ///   <item><c>.bind(receiver)</c> on every instance method group
+    ///   assigned to a delegate slot. Static methods skip the bind
+    ///   (no instance to capture). Type-qualified references
+    ///   (<c>Class.StaticMember</c>) skip too.</item>
+    ///   <item><c>bindReceiver(...)</c> trampoline added on top when
+    ///   the delegate's first parameter carries <c>[This]</c>: the
+    ///   trampoline rebinds JS <c>this</c> from the call-site
+    ///   dispatcher into the method's first parameter, matching the
+    ///   <c>[This]</c> lambda lowering.</item>
+    /// </list>
     /// Plain identifier references (calls or non-delegate uses)
-    /// fall through unchanged.
-    /// <para>
-    /// Instance method-group references additionally
-    /// <c>.bind(receiver)</c> the inner reference before handing it
-    /// to <c>bindReceiver</c>. C# method groups capture the instance
-    /// as the call-time receiver, so a subsequent <c>fn(args)</c>
-    /// dispatch inside <c>bindReceiver</c>'s trampoline must already
-    /// know which object owns the method — otherwise the body's own
-    /// <c>this</c> would be lost. Static method groups skip the
-    /// <c>.bind</c> step (no instance to capture).
-    /// </para>
+    /// fall through unchanged. The Dart target is opted out — Dart
+    /// tear-offs auto-bind, so the runtime helpers and the JS-only
+    /// <c>.bind</c> idiom would only get in the way.
     /// </summary>
-    private IrExpression WrapMethodGroupForThisDelegate(
+    private IrExpression WrapMethodGroupForDelegate(
         ExpressionSyntax expression,
         ISymbol? symbol,
         IrExpression reference
@@ -1174,6 +1172,7 @@ public sealed class IrExpressionExtractor
     {
         if (symbol is not IMethodSymbol method)
             return reference;
+
         if (
             _semantic.GetTypeInfo(expression).ConvertedType
             is not INamedTypeSymbol
@@ -1183,23 +1182,57 @@ public sealed class IrExpressionExtractor
             }
         )
             return reference;
-        if (invoke.Parameters.Length == 0 || !SymbolHelper.HasThis(invoke.Parameters[0]))
+
+        if (IsDartTarget)
             return reference;
 
-        var inner = reference;
-        if (
-            !method.IsStatic
-            && reference is IrMemberAccess { Target: { } receiver } memberAccess
-            && receiver is not IrTypeReference
-        )
-        {
-            inner = new IrCallExpression(
-                new IrMemberAccess(memberAccess, "bind"),
-                [new IrArgument(receiver)]
-            );
-        }
+        var hasThisDelegate =
+            invoke.Parameters.Length > 0 && SymbolHelper.HasThis(invoke.Parameters[0]);
 
-        return new IrCallExpression(new IrIdentifier("bindReceiver"), [new IrArgument(inner)]);
+        var boundReference = ShouldBindInstanceReceiver(method, reference, out var instanceAccess)
+            ? new IrCallExpression(
+                new IrMemberAccess(instanceAccess, "bind"),
+                [new IrArgument(instanceAccess.Target)]
+            )
+            : reference;
+
+        return hasThisDelegate
+            ? new IrCallExpression(
+                new IrIdentifier("bindReceiver"),
+                [new IrArgument(boundReference)]
+            )
+            : boundReference;
+    }
+
+    private bool IsDartTarget => _target == Metano.Annotations.TargetLanguage.Dart;
+
+    /// <summary>
+    /// True when an instance method-group reference must
+    /// <c>.bind(receiver)</c> the underlying member access. Static
+    /// methods and type-qualified references skip the bind because
+    /// there is no instance to capture; non-member-access shapes
+    /// (bare identifiers from local functions, locals, parameters)
+    /// also skip — there is nothing to bind onto.
+    /// </summary>
+    private static bool ShouldBindInstanceReceiver(
+        IMethodSymbol method,
+        IrExpression reference,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IrMemberAccess? memberAccess
+    )
+    {
+        memberAccess = null;
+
+        if (method.IsStatic)
+            return false;
+
+        if (reference is not IrMemberAccess { Target: { } receiver } access)
+            return false;
+
+        if (receiver is IrTypeReference)
+            return false;
+
+        memberAccess = access;
+        return true;
     }
 
     /// <summary>

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -1186,13 +1186,12 @@ public sealed class IrExpressionExtractor
         if (IsDartTarget)
             return reference;
 
-        var hasThisDelegate =
-            invoke.Parameters.Length > 0 && SymbolHelper.HasThis(invoke.Parameters[0]);
+        var hasThisDelegate = HasThisParameter(invoke);
 
         var boundReference = ShouldBindInstanceReceiver(method, reference, out var instanceAccess)
             ? new IrCallExpression(
                 new IrMemberAccess(instanceAccess, "bind"),
-                [new IrArgument(instanceAccess.Target)]
+                [new IrArgument(BindArgumentFor(instanceAccess.Target))]
             )
             : reference;
 
@@ -1205,6 +1204,20 @@ public sealed class IrExpressionExtractor
     }
 
     private bool IsDartTarget => _target == Metano.Annotations.TargetLanguage.Dart;
+
+    /// <summary>
+    /// Returns the expression that should be passed to
+    /// <c>.bind(...)</c> as the receiver. <c>base.Method</c> lowers
+    /// to <c>super.method</c> in TypeScript, but <c>super</c> is not
+    /// a value expression in JS/TS and cannot be a <c>.bind</c>
+    /// argument. Substitute <c>this</c> in that position — the base
+    /// method's body still runs against the current instance, which
+    /// matches the C# semantics of <c>base</c>-qualified method
+    /// groups (the dispatch is non-virtual but the receiver is
+    /// still <c>this</c>).
+    /// </summary>
+    private static IrExpression BindArgumentFor(IrExpression receiver) =>
+        receiver is IrBaseExpression ? new IrThisExpression() : receiver;
 
     /// <summary>
     /// True when an instance method-group reference must

--- a/tests/Metano.Tests/DelegateEventTests.cs
+++ b/tests/Metano.Tests/DelegateEventTests.cs
@@ -126,4 +126,347 @@ public class DelegateEventTests
         var output = result["app.ts"];
         await Assert.That(output).Contains("countChanged$remove(");
     }
+
+    // ── Method group → delegate binding ──────────────────────────
+
+    [Test]
+    public async Task MethodGroupAssignment_InstanceMethod_BindsThis()
+    {
+        // C# method group conversion captures the receiver
+        // implicitly. JS doesn't auto-bind, so the IR must wrap the
+        // member access in `.bind(this)` before assigning to the
+        // delegate field — otherwise invoking the delegate via
+        // another object loses `this` and the body's member access
+        // crashes at runtime.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class View
+            {
+                public Action? OnClick { get; set; }
+            }
+
+            [Transpile]
+            public class Presenter
+            {
+                private readonly View _view = new();
+
+                public void Setup()
+                {
+                    _view.OnClick = OnButtonClicked;
+                }
+
+                private void OnButtonClicked() { }
+            }
+            """
+        );
+
+        var output = result["presenter.ts"];
+        await Assert.That(output).Contains("this._view.onClick = this.onButtonClicked.bind(this)");
+        await Assert.That(output).DoesNotContain("bindReceiver");
+    }
+
+    [Test]
+    public async Task MethodGroupAssignment_StaticMethod_SkipsBind()
+    {
+        // Static method groups have no instance to capture; the
+        // emitted reference stays bare. Wrapping in `.bind(...)`
+        // would be wasted allocation.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class View
+            {
+                public Action? OnClick { get; set; }
+            }
+
+            [Transpile]
+            public static class Handlers
+            {
+                public static void HandleClick() { }
+            }
+
+            [Transpile]
+            public class Presenter
+            {
+                public void Setup(View view)
+                {
+                    view.OnClick = Handlers.HandleClick;
+                }
+            }
+            """
+        );
+
+        var output = result["presenter.ts"];
+        await Assert.That(output).Contains("view.onClick = Handlers.handleClick");
+        await Assert.That(output).DoesNotContain("Handlers.handleClick.bind");
+    }
+
+    [Test]
+    public async Task MethodGroupAsArgument_InstanceMethod_BindsThis()
+    {
+        // Method group passed as a delegate-typed argument flows
+        // through the same path — bind preserves `this` inside the
+        // callee.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Scheduler
+            {
+                public void Run(Action callback) { }
+            }
+
+            [Transpile]
+            public class Worker
+            {
+                private readonly Scheduler _scheduler = new();
+
+                public void Start()
+                {
+                    _scheduler.Run(Tick);
+                }
+
+                private void Tick() { }
+            }
+            """
+        );
+
+        var output = result["worker.ts"];
+        await Assert.That(output).Contains("this._scheduler.run(this.tick.bind(this))");
+        await Assert.That(output).DoesNotContain("bindReceiver");
+    }
+
+    [Test]
+    public async Task MethodGroupReturn_InstanceMethod_BindsThis()
+    {
+        // Returning a method group as a delegate must bind too —
+        // the caller will invoke the result through whatever
+        // dispatcher it owns and lose `this` otherwise.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Box
+            {
+                private int _value;
+
+                public Func<int> GetReader()
+                {
+                    return Read;
+                }
+
+                private int Read() => _value;
+            }
+            """
+        );
+
+        var output = result["box.ts"];
+        await Assert.That(output).Contains("return this.read.bind(this)");
+        await Assert.That(output).DoesNotContain("bindReceiver");
+    }
+
+    [Test]
+    public async Task EventSubscription_InstanceHandler_BindsThis()
+    {
+        // `event += handler` lowers to `event$add(handler)`. The
+        // method group inside the assignment still flows through
+        // the wrapper, so the handler arrives at `event$add`
+        // already bound. No double-binding because the bind happens
+        // at the leaf reference.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Counter
+            {
+                public event Action<int>? CountChanged;
+            }
+
+            [Transpile]
+            public class Watcher
+            {
+                private readonly Counter _counter = new();
+
+                public void Listen()
+                {
+                    _counter.CountChanged += OnChanged;
+                }
+
+                private void OnChanged(int n) { }
+            }
+            """
+        );
+
+        var output = result["watcher.ts"];
+        await Assert.That(output).Contains("countChanged$add(this.onChanged.bind(this))");
+        await Assert.That(output).DoesNotContain("bind(this).bind");
+    }
+
+    [Test]
+    public async Task OrdinaryMethodCall_DoesNotBind()
+    {
+        // Plain method invocation must stay un-bound. The wrapper
+        // relies on Roslyn reporting no `ConvertedType` for method
+        // groups used as call targets — pin that invariant so a
+        // future Roslyn change does not silently double-bind every
+        // call site.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Calculator
+            {
+                public void Run()
+                {
+                    Tick();
+                }
+
+                private void Tick() { }
+            }
+            """
+        );
+
+        var output = result["calculator.ts"];
+        await Assert.That(output).Contains("this.tick()");
+        await Assert.That(output).DoesNotContain(".bind(this)");
+    }
+
+    [Test]
+    public async Task ThisDelegate_InstanceMethodGroup_StacksBindAndBindReceiver()
+    {
+        // `[This]`-bearing delegate assigned an instance method
+        // group must stack both wraps: `.bind(this)` on the inner
+        // reference (so the body's own `this` survives the
+        // dispatcher rebind) plus `bindReceiver(...)` on the
+        // outside (so the dispatcher rewrites JS `this` into the
+        // first parameter at call time).
+        var result = TranspileHelper.Transpile(
+            """
+            using Metano.Annotations;
+
+            namespace App;
+
+            [Transpile]
+            public abstract class Element
+            {
+                public string Tag { get; set; } = "";
+            }
+
+            public delegate void Listener([This] Element self);
+
+            [Transpile]
+            public class Widget
+            {
+                public Listener? OnClick { get; set; }
+            }
+
+            [Transpile]
+            public class Page
+            {
+                private readonly Widget _widget = new();
+
+                public void Setup()
+                {
+                    _widget.OnClick = OnButtonClicked;
+                }
+
+                private void OnButtonClicked(Element self) { }
+            }
+            """
+        );
+
+        var output = result["page.ts"];
+        await Assert.That(output).Contains("bindReceiver(this.onButtonClicked.bind(this))");
+    }
+
+    [Test]
+    public async Task DartTarget_DoesNotEmitBind()
+    {
+        // Dart tear-offs auto-bind, so the JS-only `.bind(this)`
+        // idiom must not appear in Dart output. The wrapper opts
+        // out via the `IsDartTarget` guard.
+        var (files, _) = TranspileDart(
+            """
+            [Transpile]
+            public class View
+            {
+                public Action? OnClick { get; set; }
+            }
+
+            [Transpile]
+            public class Presenter
+            {
+                private readonly View _view = new();
+
+                public void Setup()
+                {
+                    _view.OnClick = OnButtonClicked;
+                }
+
+                private void OnButtonClicked() { }
+            }
+            """
+        );
+
+        var dart = files["presenter.dart"];
+        await Assert.That(dart).Contains("onButtonClicked");
+        await Assert.That(dart).DoesNotContain(".bind(");
+        await Assert.That(dart).DoesNotContain("bindReceiver");
+    }
+
+    private static (
+        Dictionary<string, string> Files,
+        IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic> Diagnostics
+    ) TranspileDart(string csharpSource)
+    {
+        var source = $"""
+            using System;
+            using Metano.Annotations;
+            {csharpSource}
+            """;
+        var syntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+            source,
+            new Microsoft.CodeAnalysis.CSharp.CSharpParseOptions(
+                Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview
+            )
+        );
+        var compilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+            "DartTestAssembly",
+            [syntaxTree],
+            TranspileHelper.BaseReferences,
+            new Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+            )
+        );
+
+        var errors = compilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .ToList();
+        if (errors.Count > 0)
+            throw new InvalidOperationException(
+                "C# compilation failed:\n" + string.Join("\n", errors.Select(e => e.ToString()))
+            );
+
+        var ir = new Metano.Compiler.CSharpSourceFrontend().ExtractFromCompilation(
+            compilation,
+            Metano.Annotations.TargetLanguage.Dart
+        );
+        var transformer = new Metano.Dart.Transformation.DartTransformer(ir, compilation);
+        var files = transformer.TransformAll();
+        var printer = new Metano.Dart.Printer();
+        var result = new Dictionary<string, string>();
+        foreach (var file in files)
+            result[file.FileName] = printer.Print(file);
+        return (result, transformer.Diagnostics);
+    }
 }

--- a/tests/Metano.Tests/DelegateEventTests.cs
+++ b/tests/Metano.Tests/DelegateEventTests.cs
@@ -341,6 +341,42 @@ public class DelegateEventTests
     }
 
     [Test]
+    public async Task BaseMethodGroup_BindsThisInsteadOfSuper()
+    {
+        // `base.Method` lowers to `super.method` in TS, but `super`
+        // is not a value expression — it cannot be passed to
+        // `.bind(...)`. The wrapper substitutes `this` in the bind
+        // argument so the emitted JS stays valid; the base method
+        // body still runs against the current instance, matching
+        // the C# semantics of `base`-qualified method groups
+        // (non-virtual dispatch but receiver stays `this`).
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class BaseHandler
+            {
+                public virtual void Handle() { }
+            }
+
+            [Transpile]
+            public class DerivedHandler : BaseHandler
+            {
+                public Action GetBaseHandler()
+                {
+                    return base.Handle;
+                }
+            }
+            """
+        );
+
+        var output = result["derived-handler.ts"];
+        await Assert.That(output).Contains("super.handle.bind(this)");
+        await Assert.That(output).DoesNotContain("super.handle.bind(super)");
+    }
+
+    [Test]
     public async Task ThisDelegate_InstanceMethodGroup_StacksBindAndBindReceiver()
     {
         // `[This]`-bearing delegate assigned an instance method


### PR DESCRIPTION
## Summary

C# method groups assigned to a delegate slot capture the instance receiver at the conversion site so any later invocation runs the body with the original \`this\`. JS doesn't — a bare \`obj.method\` reference loses its receiver as soon as it leaves the access expression. The extractor's wrapper previously only fired for delegates whose first parameter carried \`[This]\`, so ordinary delegates (\`Action\`, \`Func\`, custom delegates without \`[This]\`) emitted the bare reference and broke \`this\` inside the body whenever the delegate was invoked through a different object.

Repro from the SampleCounterWithDomView consumer:

\`\`\`csharp
_view.OnButtonClick = OnButtonClicked;
\`\`\`

Before: \`this._view.onButtonClick = this.onButtonClicked;\` — \`this\` inside \`OnButtonClicked\` resolves to \`_view\` at call time, breaking \`this._state.Increment()\`.

After: \`this._view.onButtonClick = this.onButtonClicked.bind(this);\`

## Mechanism

- Rename \`WrapMethodGroupForThisDelegate\` → \`WrapMethodGroupForDelegate\`.
- Split the wrap into two independent steps:
  - Always emit \`.bind(receiver)\` for instance method groups assigned to any delegate slot. Static methods, type-qualified references, and bare-identifier shapes (locals, local functions) skip the bind — no instance to capture.
  - Stack \`bindReceiver(...)\` on top only when the delegate's first parameter carries \`[This]\`. That contract is unchanged; the trampoline still rebinds JS \`this\` into the method's first parameter.
- Dart target opts out via a new \`IsDartTarget\` guard. Dart tear-offs auto-bind, so the JS-only helpers would only get in the way.
- Extracted \`ShouldBindInstanceReceiver\` predicate for readability (Bob's clean-code review).

## Test plan

8 new tests in \`DelegateEventTests.cs\` cover:

- Assignment, return statement, argument passing — all bind \`.bind(this)\`.
- Static method group — skips bind.
- Ordinary call site — stays un-bound (locks the \`ConvertedType\` invariant).
- \`[This]\` + instance method group — stacks \`bindReceiver(...bind(this))\`.
- Dart opt-out — neither \`.bind\` nor \`bindReceiver\` appears.
- Event \`+= handler\` — \`event\$add(handler.bind(this))\`, no double-binding.

\`.DoesNotContain("bindReceiver")\` assertions on every non-\`[This]\` case pin the no-trampoline invariant.

- [x] Full .NET suite: 761/761 pass.
- [x] Sample regeneration: byte-identical (no sample uses method-group delegate assignment today).
- [x] Bun suites: 275 (runtime) + 18 (todo) + 142 (issue-tracker) + 33 (todo-service) green.
- [x] csharpier-format clean.

## Known limitation

\`.bind(receiver)\` evaluates the receiver subexpression twice when the receiver chain has side effects (\`Cache().Service.Tick\`). Pre-existing concern under the \`[This]\` path; the expanded surface area is tracked separately in #133.

## Reviews addressed pre-commit

- compiler-man: 4 Major test gaps (Dart opt-out, ordinary call site, \`[This]\`+instance stacking, no-double-bind assertions) — all locked in.
- bob: Clean-code polish — extracted \`IsDartTarget\` property and \`ShouldBindInstanceReceiver\` predicate, added blank-line spacing between early returns, switched the trailing if/return into a single ternary.

Closes #132
Part of #133