### PR TITLE
chore(release): route conventional commits to changelog categories

### DIFF
--- a/dotnet-releaser.toml
+++ b/dotnet-releaser.toml
@@ -26,3 +26,43 @@ enable = false
 # Coverage is not yet supported for Testing Platform (TUnit) projects.
 [coverage]
 enable = false
+
+# ── Changelog ────────────────────────────────────────────────────
+#
+# We use Conventional Commits (`feat:`, `fix:`, `chore:`, etc.) as the
+# canonical commit format. dotnet-releaser's built-in auto-labelers
+# expect imperative-English titles ("Add foo", "Fix bar"), so without
+# the entries below `feat:` and friends would fall through to the
+# catch-all `misc` label and every feature would land under "🧰 Misc"
+# in the release notes (which is what happened up to v0.8.0).
+#
+# Custom auto-labelers run BEFORE defaults, so listing them here
+# routes our commit titles to the appropriate categories. Each
+# pattern accepts an optional scope (`feat(ts):`, `fix(core):`).
+[[changelog.autolabeler]]
+label = "breaking-change"
+title = '^[A-Za-z]+(\(.+\))?!:'
+
+[[changelog.autolabeler]]
+label = "feature"
+title = '^[Ff]eat(\(.+\))?:'
+
+[[changelog.autolabeler]]
+label = "bugfix"
+title = '^[Ff]ix(\(.+\))?:'
+
+[[changelog.autolabeler]]
+label = "enhancement"
+title = '^([Rr]efactor|[Pp]erf|[Ss]tyle)(\(.+\))?:'
+
+[[changelog.autolabeler]]
+label = "maintenance"
+title = '^([Cc]hore|[Bb]uild|[Cc]i)(\(.+\))?:'
+
+[[changelog.autolabeler]]
+label = "tests"
+title = '^[Tt]est(\(.+\))?:'
+
+[[changelog.autolabeler]]
+label = "documentation"
+title = '^[Dd]ocs(\(.+\))?:'

--- a/dotnet-releaser.toml
+++ b/dotnet-releaser.toml
@@ -38,31 +38,41 @@ enable = false
 #
 # Custom auto-labelers run BEFORE defaults, so listing them here
 # routes our commit titles to the appropriate categories. Each
-# pattern accepts an optional scope (`feat(ts):`, `fix(core):`).
+# pattern accepts an optional scope (`feat(ts):`, `fix(core):`)
+# and an optional `!` breaking-change marker (`feat!:`,
+# `feat(ts)!:`). The scope class uses `[^)]+` instead of `.+` so a
+# stray colon or parenthesis later in the title cannot push the
+# regex past the closing paren of the scope.
+#
+# Type-prefixed labelers also accept the `!` marker so a breaking
+# feature gets BOTH the `feature` label and (via the dedicated
+# breaking-change labeler below) the `breaking-change` label —
+# dotnet-releaser fires every matching auto-labeler, so the same
+# commit can land in two categories.
 [[changelog.autolabeler]]
 label = "breaking-change"
-title = '^[A-Za-z]+(\(.+\))?!:'
+title = '^[A-Za-z]+(\([^)]+\))?!:'
 
 [[changelog.autolabeler]]
 label = "feature"
-title = '^[Ff]eat(\(.+\))?:'
+title = '^[Ff]eat(\([^)]+\))?!?:'
 
 [[changelog.autolabeler]]
 label = "bugfix"
-title = '^[Ff]ix(\(.+\))?:'
+title = '^[Ff]ix(\([^)]+\))?!?:'
 
 [[changelog.autolabeler]]
 label = "enhancement"
-title = '^([Rr]efactor|[Pp]erf|[Ss]tyle)(\(.+\))?:'
+title = '^([Rr]efactor|[Pp]erf|[Ss]tyle)(\([^)]+\))?!?:'
 
 [[changelog.autolabeler]]
 label = "maintenance"
-title = '^([Cc]hore|[Bb]uild|[Cc]i)(\(.+\))?:'
+title = '^([Cc]hore|[Bb]uild|[Cc]i)(\([^)]+\))?!?:'
 
 [[changelog.autolabeler]]
 label = "tests"
-title = '^[Tt]est(\(.+\))?:'
+title = '^[Tt]est(\([^)]+\))?!?:'
 
 [[changelog.autolabeler]]
 label = "documentation"
-title = '^[Dd]ocs(\(.+\))?:'
+title = '^[Dd]ocs(\([^)]+\))?!?:'


### PR DESCRIPTION
## Summary

dotnet-releaser's built-in auto-labelers expect imperative-English commit titles (\"Add foo\", \"Fix bar\"), but this repo uses Conventional Commits (\`feat:\`, \`fix:\`, \`chore:\`, etc.). Without explicit auto-labelers, every non-\`Fix\`-prefixed title falls through to the catch-all \`misc\` label and every feature lands under \"🧰 Misc\" — see [v0.8.0 release notes](https://github.com/danfma/metano/releases/tag/v0.8.0).

## Mechanism

Custom \`[[changelog.autolabeler]]\` entries run **before** the built-in defaults. Each pattern accepts the Conventional Commits shape \`<type>(<scope>)?(!)?:\` and routes the commit to the corresponding built-in category:

| Prefix | Section |
|---|---|
| \`feat:\` | ✨ New Features |
| \`fix:\` | 🐛 Bug Fixes |
| \`refactor:\` / \`perf:\` / \`style:\` | 🚀 Enhancements |
| \`chore:\` / \`build:\` / \`ci:\` | 🧰 Maintenance |
| \`test:\` | 🏭 Tests |
| \`docs:\` | 📚 Documentation |
| \`<type>!:\` (any type with breaking marker) | 🚨 Breaking Changes |

The \`misc\` catch-all (\`title = '.'\`) stays in place via the defaults, absorbing anything that doesn't match a Conventional-Commits prefix.

## Verification

Config-only change. Validation will happen on the next release tag — the v0.9.0 changelog should split feature/maintenance commits across the right sections instead of bundling them under Misc. If a commit type is missed, the fix is one extra autolabeler entry.