### PR TITLE
fix(ts): make package.json writes additive, not destructive

### DIFF
--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -143,54 +143,24 @@ public static class PackageJsonWriter
             };
         }
 
-        // [EmitPackage] is the source of truth for the package name when present.
-        if (authoritativePackageName is not null)
-        {
-            var existingName = root["name"]?.GetValue<string>();
-            if (existingName is not null && existingName != authoritativePackageName)
-            {
-                diagnostics.Add(
-                    new MetanoDiagnostic(
-                        MetanoDiagnosticSeverity.Warning,
-                        DiagnosticCodes.CrossPackageResolution,
-                        $"package.json#name '{existingName}' diverges from "
-                            + $"[assembly: EmitPackage(\"{authoritativePackageName}\")]. "
-                            + $"Overwriting with the attribute value — consumers will import via "
-                            + $"'{authoritativePackageName}'."
-                    )
-                );
-            }
-            root["name"] = authoritativePackageName;
-        }
+        ApplyAuthoritativePackageName(root, authoritativePackageName, diagnostics);
 
-        // Apply controlled fields
-        root["type"] = "module";
-        root["sideEffects"] = false;
+        // Seed defaults when the consumer has not picked their own
+        // values. The transpiler must not flip a hand-curated `type`
+        // or `sideEffects` value back on every regeneration.
+        WriteIfMissing(root, "type", "module");
+        WriteIfMissing(root, "sideEffects", false);
 
-        // Replace transpiler-managed entries while preserving user-defined ones.
-        // For imports, the transpiler manages "#" and "#/*" — stale aliases are removed.
+        // Imports: the transpiler owns `#` and `#/*` — stale aliases
+        // are removed; user-defined keys survive.
         HashSet<string> managedImportKeys = ["#", "#/*"];
         ReplacePreservingUserEntries(root, "imports", imports, managedImportKeys);
 
-        // Exports are fully transpiler-controlled — replace entirely.
-        if (exports is not null)
+        // Exports merge additively — see `MergeTranspilerManagedExports`
+        // for the shape-detection rule and the deep-merge contract.
+        if (exports is { Count: > 0 })
         {
-            if (root["exports"] is JsonObject existingExports)
-            {
-                // Replace in-place to preserve key ordering.
-                foreach (var k in existingExports.Select(e => e.Key).ToList())
-                    existingExports.Remove(k);
-                foreach (var (ek, ev) in exports)
-                    existingExports[ek] = ev?.DeepClone();
-            }
-            else
-            {
-                root["exports"] = exports;
-            }
-        }
-        else
-        {
-            root.Remove("exports");
+            MergeTranspilerManagedExports(root, exports, distDirRelativeToPackageRoot);
         }
 
         // Merge auto-generated cross-package dependencies into the existing
@@ -207,6 +177,158 @@ public static class PackageJsonWriter
         Directory.CreateDirectory(packageRoot);
         File.WriteAllText(packageJsonPath, root.ToJsonString(WriteOptions) + "\n");
         return diagnostics;
+    }
+
+    /// <summary>
+    /// Seeds <c>package.json#name</c> from <c>[assembly: EmitPackage(...)]</c>
+    /// on first creation. When the file already declares a name the
+    /// existing value wins; on divergence we surface MS0007 so the
+    /// consumer can re-align the two sources, but we never silently
+    /// overwrite a hand-edited name (a published package may have
+    /// links / docs / consumers tied to it).
+    /// </summary>
+    private static void ApplyAuthoritativePackageName(
+        JsonObject root,
+        string? authoritativePackageName,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (authoritativePackageName is null)
+            return;
+
+        var existingName = root["name"]?.GetValue<string>();
+        if (existingName is null)
+        {
+            root["name"] = authoritativePackageName;
+            return;
+        }
+
+        if (existingName == authoritativePackageName)
+            return;
+
+        diagnostics.Add(
+            new MetanoDiagnostic(
+                MetanoDiagnosticSeverity.Warning,
+                DiagnosticCodes.CrossPackageResolution,
+                $"package.json#name '{existingName}' diverges from "
+                    + $"[assembly: EmitPackage(\"{authoritativePackageName}\")]. "
+                    + $"The existing name was preserved; consumers keep importing via "
+                    + $"'{existingName}'. Update either the attribute or package.json#name "
+                    + $"to align them."
+            )
+        );
+    }
+
+    /// <summary>Seeds <paramref name="key"/> only when missing.</summary>
+    /// <remarks>
+    /// Used for scalar defaults like <c>type</c> and <c>sideEffects</c>:
+    /// once the consumer has set a value by hand, the transpiler never
+    /// overwrites it on regeneration.
+    /// </remarks>
+    private static void WriteIfMissing(JsonObject root, string key, JsonNode? value)
+    {
+        if (root.ContainsKey(key))
+            return;
+        root[key] = value;
+    }
+
+    /// <inheritdoc cref="WriteIfMissing(JsonObject, string, JsonNode?)"/>
+    private static void WriteIfMissing(JsonObject root, string key, bool value)
+    {
+        if (root.ContainsKey(key))
+            return;
+        root[key] = value;
+    }
+
+    /// <summary>
+    /// Merges the transpiler-emitted exports into the existing
+    /// <c>exports</c> object. Two rules combine to keep user
+    /// customizations intact across regenerations:
+    /// <list type="number">
+    ///   <item><b>Stale removal.</b> An existing entry whose key is
+    ///   not in <paramref name="generated"/> is dropped only when
+    ///   its value passes <see cref="IsTranspilerEmittedExportEntry"/>
+    ///   (looks like a previous transpiler output). User-added
+    ///   subpaths pointing outside the dist tree (assets, shims)
+    ///   survive.</item>
+    ///   <item><b>Per-key deep-merge.</b> When a generated key is
+    ///   already present, the transpiler's <c>types</c>/<c>import</c>
+    ///   fields refresh in place and any extra conditional fields
+    ///   the consumer added (e.g. <c>require</c>, <c>default</c>)
+    ///   stay untouched.</item>
+    /// </list>
+    /// </summary>
+    private static void MergeTranspilerManagedExports(
+        JsonObject root,
+        JsonObject generated,
+        string distRelative
+    )
+    {
+        var transpilerDistPrefix = "./" + NormalizePath(distRelative).TrimEnd('/');
+
+        if (root["exports"] is not JsonObject existing)
+        {
+            root["exports"] = generated;
+            return;
+        }
+
+        DropStaleTranspilerEntries(existing, generated, transpilerDistPrefix);
+        MergeGeneratedEntries(existing, generated);
+    }
+
+    private static void DropStaleTranspilerEntries(
+        JsonObject existing,
+        JsonObject generated,
+        string transpilerDistPrefix
+    )
+    {
+        foreach (var (entryKey, entryValue) in existing.ToList())
+        {
+            if (generated.ContainsKey(entryKey))
+                continue;
+            if (IsTranspilerEmittedExportEntry(entryValue, transpilerDistPrefix))
+                existing.Remove(entryKey);
+        }
+    }
+
+    private static void MergeGeneratedEntries(JsonObject existing, JsonObject generated)
+    {
+        foreach (var (entryKey, entryValue) in generated)
+        {
+            if (
+                existing[entryKey] is JsonObject existingEntry
+                && entryValue is JsonObject generatedEntry
+            )
+            {
+                foreach (var (fieldKey, fieldValue) in generatedEntry)
+                    existingEntry[fieldKey] = fieldValue?.DeepClone();
+            }
+            else
+            {
+                existing[entryKey] = entryValue?.DeepClone();
+            }
+        }
+    }
+
+    /// <summary>
+    /// True when an exports-entry value has the structural shape the
+    /// transpiler emits: a JSON object whose <c>types</c> and
+    /// <c>import</c> strings both point into the package's dist
+    /// directory. Used to tell stale transpiler outputs apart from
+    /// user-added entries that happen to live alongside them.
+    /// </summary>
+    private static bool IsTranspilerEmittedExportEntry(JsonNode? value, string transpilerDistPrefix)
+    {
+        if (value is not JsonObject obj)
+            return false;
+
+        var types = obj["types"]?.GetValue<string>();
+        var import = obj["import"]?.GetValue<string>();
+        if (types is null || import is null)
+            return false;
+
+        return types.StartsWith(transpilerDistPrefix, StringComparison.Ordinal)
+            && import.StartsWith(transpilerDistPrefix, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -157,8 +157,11 @@ public static class PackageJsonWriter
         ReplacePreservingUserEntries(root, "imports", imports, managedImportKeys);
 
         // Exports merge additively — see `MergeTranspilerManagedExports`
-        // for the shape-detection rule and the deep-merge contract.
-        if (exports is { Count: > 0 })
+        // for the shape-detection rule and the deep-merge contract. Run
+        // even when `exports` is empty (library that no longer emits
+        // any barrel) so stale transpiler-shaped entries from a prior
+        // run still get pruned while user-added subpaths survive.
+        if (exports is not null)
         {
             MergeTranspilerManagedExports(root, exports, distDirRelativeToPackageRoot);
         }
@@ -264,7 +267,13 @@ public static class PackageJsonWriter
         string distRelative
     )
     {
-        var transpilerDistPrefix = "./" + NormalizePath(distRelative).TrimEnd('/');
+        // Trailing slash is mandatory: with a bare `./dist` prefix,
+        // `StartsWith` would also match sibling directories like
+        // `./dist2/...` or `./dist-cjs/...` and misclassify the
+        // consumer's hand-curated exports there as stale transpiler
+        // output. The slash anchors the comparison to the directory
+        // boundary.
+        var transpilerDistPrefix = "./" + NormalizePath(distRelative).TrimEnd('/') + "/";
 
         if (root["exports"] is not JsonObject existing)
         {
@@ -322,13 +331,29 @@ public static class PackageJsonWriter
         if (value is not JsonObject obj)
             return false;
 
-        var types = obj["types"]?.GetValue<string>();
-        var import = obj["import"]?.GetValue<string>();
+        var types = ReadStringField(obj, "types");
+        var import = ReadStringField(obj, "import");
         if (types is null || import is null)
             return false;
 
         return types.StartsWith(transpilerDistPrefix, StringComparison.Ordinal)
             && import.StartsWith(transpilerDistPrefix, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reads a string-valued field from an exports-entry object,
+    /// returning null when the field is absent or holds a non-string
+    /// node (object, array, number). Defensive read: a hand-edited
+    /// <c>package.json</c> may put any JSON shape under
+    /// <c>types</c>/<c>import</c>, and <see cref="JsonValue.GetValue{T}"/>
+    /// throws on a type mismatch — crashing the transpiler on
+    /// merely-unusual user input is not acceptable.
+    /// </summary>
+    private static string? ReadStringField(JsonObject obj, string fieldName)
+    {
+        if (obj[fieldName] is not JsonValue value)
+            return null;
+        return value.TryGetValue<string>(out var s) ? s : null;
     }
 
     /// <summary>

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -94,8 +94,16 @@ public class EmitPackageTests
     }
 
     [Test]
-    public async Task ExistingFileWithDivergentName_WarnsAndOverwrites()
+    public async Task ExistingFileWithDivergentName_WarnsAndPreservesExisting()
     {
+        // Per #136, the transpiler is a write-if-missing
+        // collaborator: a hand-edited package.json#name survives
+        // every regeneration. When [EmitPackage] disagrees, we
+        // surface MS0007 so the consumer can re-align the two
+        // sources, but we never silently flip the name back —
+        // doing so would invalidate links / docs / cross-package
+        // imports the consumer may have already published with the
+        // existing name.
         var tempDir = CreateTempDir();
         var srcDir = Path.Combine(tempDir, "src");
         Directory.CreateDirectory(srcDir);
@@ -112,9 +120,9 @@ public class EmitPackageTests
         );
 
         var pkg = ReadJson(tempDir);
-        // Authoritative wins.
-        await Assert.That(pkg["name"]?.GetValue<string>()).IsEqualTo("new-name");
-        // And the writer reported MS0007.
+        // Existing name preserved.
+        await Assert.That(pkg["name"]?.GetValue<string>()).IsEqualTo("old-name");
+        // Writer still reported MS0007 so the divergence is visible.
         await Assert
             .That(diags.Any(d => d.Code == DiagnosticCodes.CrossPackageResolution))
             .IsTrue();
@@ -568,6 +576,215 @@ public class EmitPackageTests
         await Assert.That(exports).IsNotNull();
         await Assert.That(exports!.ContainsKey("./domain")).IsTrue();
         await Assert.That(exports.ContainsKey(".")).IsFalse();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    // ── Write-if-missing rule for hand-curated fields ────────────────
+
+    [Test]
+    public async Task ExistingTypeField_PreservedAcrossRegeneration()
+    {
+        // A consumer who set `"type": "commonjs"` (or "module" — the
+        // default — explicitly) keeps that value. The transpiler used
+        // to flip the field back to "module" on every run, which
+        // destroyed CJS dual-build configurations.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """{ "name": "consumer", "type": "commonjs" }"""
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")]
+        );
+
+        var pkg = ReadJson(tempDir);
+        await Assert.That(pkg["type"]?.GetValue<string>()).IsEqualTo("commonjs");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task MissingTypeField_SeededAsModule()
+    {
+        // First-run behavior is unchanged: when the consumer has
+        // not picked a value, the transpiler seeds "module" since
+        // every emitted file is ESM.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")]
+        );
+
+        var pkg = ReadJson(tempDir);
+        await Assert.That(pkg["type"]?.GetValue<string>()).IsEqualTo("module");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task ExistingSideEffectsArray_PreservedAcrossRegeneration()
+    {
+        // Hand-curated `sideEffects: [...]` (e.g. listing CSS imports
+        // for tree-shakers) survives. The transpiler seeded `false`
+        // unconditionally before, which clobbered carefully tuned
+        // bundler hints.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "sideEffects": ["./styles.css", "./register.ts"]
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")]
+        );
+
+        var pkg = ReadJson(tempDir);
+        var sideEffects = pkg["sideEffects"] as JsonArray;
+        await Assert.That(sideEffects).IsNotNull();
+        await Assert.That(sideEffects!.Count).IsEqualTo(2);
+        await Assert.That(sideEffects[0]?.GetValue<string>()).IsEqualTo("./styles.css");
+        await Assert.That(sideEffects[1]?.GetValue<string>()).IsEqualTo("./register.ts");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task UserAddedExport_SurvivesRegeneration()
+    {
+        // The user added a "./styles.css" export that points
+        // outside the dist tree. The transpiler must not strip it
+        // when refreshing transpiler-managed entries.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                "./styles.css": "./assets/styles.css",
+                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")],
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./styles.css")).IsTrue();
+        await Assert.That(exports.ContainsKey(".")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task UserAddedConditionalField_PreservedOnTranspilerKey()
+    {
+        // The consumer augmented the transpiler-managed `.` entry
+        // with a `require` condition (e.g. CJS dual build). The
+        // per-key deep-merge must refresh `types` and `import`
+        // without erasing `require`.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                ".": {
+                  "types": "./dist/index.d.ts",
+                  "import": "./dist/index.js",
+                  "require": "./dist/index.cjs"
+                }
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")],
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var rootExport = pkg["exports"]?[".".AsSpan().ToString()] as JsonObject;
+
+        await Assert.That(rootExport).IsNotNull();
+        await Assert.That(rootExport!["types"]?.GetValue<string>()).IsEqualTo("./dist/index.d.ts");
+        await Assert.That(rootExport["import"]?.GetValue<string>()).IsEqualTo("./dist/index.js");
+        await Assert.That(rootExport["require"]?.GetValue<string>()).IsEqualTo("./dist/index.cjs");
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task ExecutableConsumer_PreservesExistingExports()
+    {
+        // Executables don't get transpiler-emitted exports, so the
+        // writer must leave the consumer's hand-curated `exports`
+        // object untouched. The pre-fix behavior unconditionally
+        // removed the field on every run.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                "./styles.css": "./assets/styles.css"
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("program.ts", [], "")],
+            authoritativePackageName: "consumer",
+            isExecutable: true
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./styles.css")).IsTrue();
 
         Directory.Delete(tempDir, recursive: true);
     }

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -789,6 +789,131 @@ public class EmitPackageTests
         Directory.Delete(tempDir, recursive: true);
     }
 
+    [Test]
+    public async Task SiblingDistDirectoryExport_NotMisclassifiedAsStale()
+    {
+        // Path-boundary check: with `./dist` as the transpiler dist
+        // prefix, a hand-curated entry pointing into a sibling
+        // directory like `./dist-cjs/...` must not be misclassified
+        // as transpiler-emitted via a substring match.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                "./cjs": {
+                  "types": "./dist-cjs/index.d.ts",
+                  "import": "./dist-cjs/index.js"
+                },
+                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")],
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./cjs")).IsTrue();
+        await Assert.That(exports.ContainsKey(".")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task LibraryWithoutBarrels_PrunesStaleTranspilerEntries()
+    {
+        // Library generation that no longer emits any barrel still
+        // needs the merge pass: previously transpiler-shaped entries
+        // from an earlier run point at deleted dist files and must
+        // be dropped, while user-added subpaths survive.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+                "./styles.css": "./assets/styles.css"
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("internal.ts", [], "")],
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey(".")).IsFalse();
+        await Assert.That(exports.ContainsKey("./styles.css")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task NonStringExportFields_DoNotCrashWriter()
+    {
+        // Defensive read: a hand-edited entry might put a JSON
+        // object or array under `types` / `import` (e.g. nested
+        // conditional exports). The writer must classify the entry
+        // as user-curated and preserve it instead of crashing on
+        // the type mismatch.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "exports": {
+                "./nested": {
+                  "types": { "default": "./types/nested.d.ts" },
+                  "import": "./dist/nested.js"
+                }
+              }
+            }
+            """
+        );
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files: [new TsSourceFile("index.ts", [], "")],
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var exports = pkg["exports"] as JsonObject;
+
+        await Assert.That(exports).IsNotNull();
+        await Assert.That(exports!.ContainsKey("./nested")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
     private static string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"metasharp-test-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

Every transpiler run unconditionally rewrote \`type\`, \`sideEffects\`, \`name\`, and the \`exports\` object — destroying hand-curated values on every regeneration. The docstring already called the merge \"non-destructive\", but the implementation only honored that for \`imports\` and \`dependencies\`.

Switch all written fields to a write-if-missing rule:

- **\`type\` / \`sideEffects\`** — seeded with \`module\` / \`false\` only when absent. A consumer who set \`type: \"commonjs\"\` (CJS dual build) or \`sideEffects: [\"./styles.css\"]\` (tree-shaker hint) keeps that value across regenerations.
- **\`name\` (with \`[EmitPackage]\`)** — seeded only on first creation. Existing names are preserved; **MS0007 still fires on divergence** so the consumer notices the mismatch but published links and cross-package imports do not break.
- **\`exports\`** — additive merge with two layers:
  - **Stale removal**: an existing entry whose key is not in the generated set is dropped only when the value matches the transpiler-emitted shape (\`{types, import}\` strings both pointing into \`./{dist}/...\`). User-added subpaths (\`./styles.css\`, declaration shims) survive.
  - **Per-key deep-merge**: when a generated key is already present, only the transpiler's \`types\` / \`import\` fields refresh in place. Extra conditional fields the consumer added (e.g. \`require\` for CJS dual builds) stay untouched.

## Mechanism

\`UpdateOrCreate\` body now reads as a sequence of named steps. Policy decisions live in dedicated helpers:

- \`ApplyAuthoritativePackageName\` — name preservation + MS0007.
- \`WriteIfMissing\` — scalar seeding for \`type\`/\`sideEffects\`.
- \`MergeTranspilerManagedExports\` — additive merge entry point.
- \`DropStaleTranspilerEntries\` + \`MergeGeneratedEntries\` — the two layers of the exports merge.
- \`IsTranspilerEmittedExportEntry\` — shape predicate used by stale removal.

## Reviews addressed pre-commit

**compiler-man** flagged a Major: the prior version unconditionally overwrote generated keys via \`existing[key] = generated[key].DeepClone()\`, dropping user-augmented conditional fields. Fixed by deep-merging matching keys (only refresh transpiler-emitted fields; preserve extras).

**bob** flagged the body length and naming. Extracted \`ApplyAuthoritativePackageName\`, renamed the predicate to \`IsTranspilerEmittedExportEntry\`, and split the exports merge into two single-purpose helpers.

## Test plan

- [x] 5 new tests in \`EmitPackageTests.cs\`:
  - \`type: \"commonjs\"\` survives a regeneration; missing \`type\` is seeded as \`module\`.
  - \`sideEffects: [\"./styles.css\", ...]\` survives.
  - User-added \`./styles.css\` export survives.
  - User-augmented \`require\` field on a transpiler key survives while \`types\`/\`import\` refresh.
  - Executable consumer's existing \`exports\` object is preserved (was unconditionally removed before).
- [x] Renamed \`ExistingFileWithDivergentName_WarnsAndOverwrites\` → \`...WarnsAndPreservesExisting\` to reflect the new contract.
- [x] Existing \`Exports_StaleEntriesRemovedOnRegeneration\` still passes — the shape heuristic correctly classifies \`./old-barrel\` (transpiler-shaped) and drops it.
- [x] Full .NET suite: 768/768 pass.
- [x] csharpier-format clean.

Closes #136