### PR TITLE
fix(runtime): declare metano-runtime tree-shakeable

### DIFF
--- a/targets/js/metano-runtime/package.json
+++ b/targets/js/metano-runtime/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "description": "Runtime support library for Metano-generated TypeScript code",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

\`metano-runtime/package.json\` was missing \`\"sideEffects\": false\`. Bundlers conservatively assumed each module might run side-effectful code at top level and disabled tree-shaking for the whole package, pulling the entire runtime (Temporal polyfill, Decimal, HashSet, LINQ, JSON converters) into the consumer's bundle even when the consumer only imported \`HashCode\`.

## Verification

\`bun build\` against a minimal entry that imports only \`HashCode\`:

\`\`\`js
import { HashCode } from \"metano-runtime\";

const hc = new HashCode();
hc.add(42);
console.log(hc.toHashCode());
\`\`\`

| Bundle | Size | Temporal/Decimal refs |
|---|---|---|
| Before (no flag) | **175.1 KB** | yes |
| After (\`sideEffects: false\`) | **1.96 KB** | none |

**88× smaller.** The 175 KB figure exactly matches the size reported on \`sample-counter-with-dom-view\`.

## Why the flag is sound

The runtime is hand-authored and entirely declarative — function declarations, class declarations, const literals, no IIFEs, no top-level side-effectful registers. Even \`Symbol(\"delegate_listeners\")\` in \`delegates.ts\` is a single allocation read by the helpers in the same module; once the module is unused, the entire definition (including the symbol) is removed.

## Out of scope

\`sample-counter\` Vite build is currently broken on a separate, pre-existing issue: \`src/sample-counter/counter.ts(4,15) error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled\` (parameter property in constructor). I did not measure the bundle through that path because the build does not complete. The minimal-entry \`bun build\` measurement above directly exercises the tree-shake path that consumers' bundlers will follow.

## Test plan

- [x] Bun runtime tests: 275/275 pass — flag has no runtime semantics, only affects bundler hints.
- [x] Bundle measurement before/after captured in the table above.

Closes #137