### PR TITLE
fix(ts): apply write-if-missing to package.json imports field

### DIFF
--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -151,10 +151,15 @@ public static class PackageJsonWriter
         WriteIfMissing(root, "type", "module");
         WriteIfMissing(root, "sideEffects", false);
 
-        // Imports: the transpiler owns `#` and `#/*` — stale aliases
-        // are removed; user-defined keys survive.
-        HashSet<string> managedImportKeys = ["#", "#/*"];
-        ReplacePreservingUserEntries(root, "imports", imports, managedImportKeys);
+        // Imports follow the same write-if-missing rule as the
+        // scalar fields above: the transpiler seeds `#` and `#/*`
+        // on first creation, but a consumer who has retargeted
+        // either alias by hand (e.g. pointing `#/*` at `./lib/*`
+        // for a non-default build directory) keeps that mapping
+        // across regenerations. Keys absent from the existing
+        // object are added; existing keys — including transpiler-
+        // shaped ones from a previous run — are left alone.
+        SeedMissingImports(root, imports);
 
         // Exports merge additively — see `MergeTranspilerManagedExports`
         // for the shape-detection rule and the deep-merge contract. Run
@@ -357,42 +362,28 @@ public static class PackageJsonWriter
     }
 
     /// <summary>
-    /// Replaces the JSON object at <paramref name="key"/> with <paramref name="generated"/>,
-    /// preserving any user-defined entries whose keys are absent from the generated set.
-    /// Keys listed in <paramref name="managedKeys"/> are considered transpiler-managed — if
-    /// they appear in the existing object but not in <paramref name="generated"/>, they are
-    /// stale and silently dropped instead of being preserved.
+    /// Seeds the <c>imports</c> object with the transpiler's
+    /// <c>#</c> / <c>#/*</c> aliases on first creation while
+    /// leaving every existing key untouched on subsequent runs. A
+    /// consumer who retargeted <c>#/*</c> by hand (for a custom
+    /// build dir, alternate dist layout, or wrapper pre-processor)
+    /// keeps that mapping across regenerations — the transpiler
+    /// only fills in keys the consumer has not picked yet.
     /// </summary>
-    private static void ReplacePreservingUserEntries(
-        JsonObject root,
-        string key,
-        JsonObject generated,
-        IReadOnlySet<string>? managedKeys = null
-    )
+    private static void SeedMissingImports(JsonObject root, JsonObject generated)
     {
-        if (root[key] is JsonObject existing)
+        if (root["imports"] is not JsonObject existing)
         {
-            // Copy user-defined entries that the transpiler doesn't manage.
-            foreach (var (entryKey, entryValue) in existing.ToList())
-            {
-                if (generated.ContainsKey(entryKey))
-                    continue; // Already in generated — transpiler's version wins.
-                if (managedKeys is not null && managedKeys.Contains(entryKey))
-                    continue; // Stale transpiler key — drop it.
-                generated[entryKey] = entryValue?.DeepClone();
-            }
-
-            // Replace in-place to preserve key ordering in the JSON output.
-            // Clear the existing object and copy generated entries into it.
-            foreach (var k in existing.Select(e => e.Key).ToList())
-                existing.Remove(k);
-            foreach (var (entryKey, entryValue) in generated)
-                existing[entryKey] = entryValue?.DeepClone();
-            // existing is already parented to root at the correct position.
+            root["imports"] = generated;
             return;
         }
 
-        root[key] = generated;
+        foreach (var (entryKey, entryValue) in generated)
+        {
+            if (existing.ContainsKey(entryKey))
+                continue;
+            existing[entryKey] = entryValue?.DeepClone();
+        }
     }
 
     /// <summary>

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -384,13 +384,18 @@ public class EmitPackageTests
     }
 
     [Test]
-    public async Task Imports_StaleRootAliasRemovedWhenBarrelDisappears()
+    public async Task Imports_ExistingAliasesPreservedAcrossRegenerations()
     {
+        // Write-if-missing rule (per #136): both transpiler-shaped
+        // aliases (`#`, `#/*`) and user-defined ones survive across
+        // regenerations once they exist on disk. The transpiler
+        // only seeds new keys when the field is empty or missing
+        // an alias entirely. Removing the obsolete `#` when its
+        // barrel disappears would clobber a consumer who left the
+        // alias pointing at a hand-curated bundle output.
         var tempDir = CreateTempDir();
         var srcDir = Path.Combine(tempDir, "src");
         Directory.CreateDirectory(srcDir);
-
-        // Existing package.json with "#" root alias from a previous run that had index.ts
         File.WriteAllText(
             Path.Combine(tempDir, "package.json"),
             """
@@ -405,7 +410,6 @@ public class EmitPackageTests
             """
         );
 
-        // Current generation has no root barrel (no index.ts)
         var files = new[] { new TsSourceFile("item.ts", [], "") };
 
         PackageJsonWriter.UpdateOrCreate(
@@ -417,13 +421,56 @@ public class EmitPackageTests
 
         var pkg = ReadJson(tempDir);
         var imports = pkg["imports"] as JsonObject;
+
         await Assert.That(imports).IsNotNull();
-        // Stale "#" alias removed (no root barrel in current generation)
-        await Assert.That(imports!.ContainsKey("#")).IsFalse();
-        // "#/*" still present (always generated)
+        await Assert.That(imports!.ContainsKey("#")).IsTrue();
         await Assert.That(imports.ContainsKey("#/*")).IsTrue();
-        // User-defined entry preserved
         await Assert.That(imports.ContainsKey("#custom/*")).IsTrue();
+
+        Directory.Delete(tempDir, recursive: true);
+    }
+
+    [Test]
+    public async Task Imports_RetargetedAlias_PreservedAcrossRegenerations()
+    {
+        // The consumer pointed `#/*` at `./lib/*` instead of the
+        // default `./dist/*` — perhaps using a custom build
+        // pipeline that emits to `lib/`. The transpiler must not
+        // flip the alias back to `./dist/*` on every regeneration.
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "consumer",
+              "imports": {
+                "#/*": {
+                  "types": "./lib/*.d.ts",
+                  "import": "./lib/*.js",
+                  "default": "./src/*.ts"
+                }
+              }
+            }
+            """
+        );
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "consumer"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var subpathAlias = pkg["imports"]?["#/*"] as JsonObject;
+
+        await Assert.That(subpathAlias).IsNotNull();
+        await Assert.That(subpathAlias!["types"]?.GetValue<string>()).IsEqualTo("./lib/*.d.ts");
+        await Assert.That(subpathAlias["import"]?.GetValue<string>()).IsEqualTo("./lib/*.js");
 
         Directory.Delete(tempDir, recursive: true);
     }


### PR DESCRIPTION
## Summary

PR #138 made the writer non-destructive for \`type\`, \`sideEffects\`, \`name\`, and \`exports\`, but \`imports\` still treated \`#\` and \`#/*\` as transpiler-managed keys and overwrote them on every run. A consumer who retargeted \`#/*\` to \`./lib/*\` (non-default build directory, alternate dist layout) saw the mapping flip back to \`./dist/*\` after every regeneration.

## Mechanism

Apply the same write-if-missing rule to \`imports\`: seed \`#\` and \`#/*\` only when absent. Keys already present — including transpiler-shaped ones from a previous run — are left alone so hand-curated aliases survive.

Replace \`ReplacePreservingUserEntries\` (now unused) with \`SeedMissingImports\`, a single-purpose helper that mirrors the contract.

## Test plan

- [x] Renamed \`Imports_StaleRootAliasRemovedWhenBarrelDisappears\` → \`Imports_ExistingAliasesPreservedAcrossRegenerations\` to reflect the new contract. The obsolete \`#\` alias survives even when its barrel is removed — consumer's responsibility.
- [x] Added \`Imports_RetargetedAlias_PreservedAcrossRegenerations\` pinning the regression scenario: \`#/*\` retargeted to \`./lib/*\` stays at \`./lib/*\` after a new run.
- [x] Existing \`Imports_MergedWithUserDefinedEntries\` still passes — user-defined keys still preserved when seeding new ones.
- [x] Full .NET suite: 772/772 pass.
- [x] csharpier-format clean.

## Scope

Closes the residual gap reported on #136 follow-up. Imports + exports + scalars (\`type\`/\`sideEffects\`/\`name\`) all now obey the same write-if-missing contract end-to-end. Cross-package \`dependencies\` keep their additive-merge-with-version-overwrite semantics (transpiler is the source of truth for cross-package versions).

Part of #136