### PR TITLE
fix(core): evaluate impure receiver once on method-group .bind

### DIFF
--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -1288,21 +1288,34 @@ public sealed class IrExpressionExtractor
     /// method's body still runs against the current instance, which
     /// matches the C# semantics of <c>base</c>-qualified method
     /// groups (the dispatch is non-virtual but the receiver is
-    /// still <c>this</c>).
+    /// still <c>this</c>). The substitution recurses through
+    /// <see cref="IrMemberAccess"/> towers so a chain rooted in
+    /// <c>base</c> (<c>base.Property.Method</c>) becomes
+    /// <c>this.property.method.bind(this.property)</c> instead of
+    /// the invalid <c>super.property</c>.
     /// </summary>
     private static IrExpression BindArgumentFor(IrExpression receiver) =>
-        receiver is IrBaseExpression ? new IrThisExpression() : receiver;
+        receiver switch
+        {
+            IrBaseExpression => new IrThisExpression(),
+            IrMemberAccess access => access with { Target = BindArgumentFor(access.Target) },
+            _ => receiver,
+        };
 
     /// <summary>
     /// Builds the <c>.bind(receiver)</c> expression for an instance
-    /// method group. When the receiver chain is pure (identifier,
-    /// <c>this</c>, <c>base</c>, or a member-access tower over those)
-    /// emits the simple <c>obj.method.bind(obj)</c> shape. Otherwise
-    /// the receiver has observable side effects (call expressions,
-    /// indexers, getters that mutate) and duplicating it would run
-    /// the side effect twice — wrap the bind site in an IIFE arrow
-    /// that captures the receiver in a temporary so the chain is
-    /// evaluated exactly once:
+    /// method group. When the receiver chain reduces to a pure IR
+    /// shape (identifier, <c>this</c>, <c>base</c>, or a chain of
+    /// <see cref="IrMemberAccess"/> nodes rooted at one of those)
+    /// emits the simple <c>obj.method.bind(obj)</c>. The shape
+    /// predicate matches what <see cref="IsSimpleReceiver"/>
+    /// already accepts elsewhere in the extractor, so a property
+    /// getter that observably mutates state is treated as pure
+    /// here too — symbol-aware purity tracking is a separate
+    /// follow-up. Receivers whose IR shape includes a call
+    /// expression, indexer, or other non-member node are wrapped
+    /// in an IIFE arrow that captures the receiver in a temporary
+    /// so the chain is evaluated exactly once:
     /// <c>((__r) => __r.method.bind(__r))(originalReceiver)</c>.
     /// </summary>
     private static IrExpression BuildBoundReference(IrMemberAccess instanceAccess)

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -1266,10 +1266,7 @@ public sealed class IrExpressionExtractor
         var hasThisDelegate = HasThisParameter(invoke);
 
         var boundReference = ShouldBindInstanceReceiver(method, reference, out var instanceAccess)
-            ? new IrCallExpression(
-                new IrMemberAccess(instanceAccess, "bind"),
-                [new IrArgument(BindArgumentFor(instanceAccess.Target))]
-            )
+            ? BuildBoundReference(instanceAccess)
             : reference;
 
         return hasThisDelegate
@@ -1295,6 +1292,46 @@ public sealed class IrExpressionExtractor
     /// </summary>
     private static IrExpression BindArgumentFor(IrExpression receiver) =>
         receiver is IrBaseExpression ? new IrThisExpression() : receiver;
+
+    /// <summary>
+    /// Builds the <c>.bind(receiver)</c> expression for an instance
+    /// method group. When the receiver chain is pure (identifier,
+    /// <c>this</c>, <c>base</c>, or a member-access tower over those)
+    /// emits the simple <c>obj.method.bind(obj)</c> shape. Otherwise
+    /// the receiver has observable side effects (call expressions,
+    /// indexers, getters that mutate) and duplicating it would run
+    /// the side effect twice — wrap the bind site in an IIFE arrow
+    /// that captures the receiver in a temporary so the chain is
+    /// evaluated exactly once:
+    /// <c>((__r) => __r.method.bind(__r))(originalReceiver)</c>.
+    /// </summary>
+    private static IrExpression BuildBoundReference(IrMemberAccess instanceAccess)
+    {
+        var receiver = instanceAccess.Target;
+        if (IsSimpleReceiver(receiver))
+            return new IrCallExpression(
+                new IrMemberAccess(instanceAccess, "bind"),
+                [new IrArgument(BindArgumentFor(receiver))]
+            );
+
+        const string TempName = "__r";
+        var tempRef = new IrIdentifier(TempName);
+        var rebound = instanceAccess with { Target = tempRef };
+        var lambda = new IrLambdaExpression(
+            Parameters: [new IrParameter(TempName, new IrUnknownTypeRef(), HasExplicitType: false)],
+            ReturnType: null,
+            Body:
+            [
+                new IrReturnStatement(
+                    new IrCallExpression(
+                        new IrMemberAccess(rebound, "bind"),
+                        [new IrArgument(tempRef)]
+                    )
+                ),
+            ]
+        );
+        return new IrCallExpression(lambda, [new IrArgument(receiver)]);
+    }
 
     /// <summary>
     /// True when an instance method-group reference must

--- a/tests/Metano.Tests/DelegateEventTests.cs
+++ b/tests/Metano.Tests/DelegateEventTests.cs
@@ -207,6 +207,57 @@ public class DelegateEventTests
     }
 
     [Test]
+    public async Task MethodGroupAssignment_ImpureReceiver_EvaluatesChainOnce()
+    {
+        // The receiver chain has observable side effects (a method
+        // call). Duplicating it in `chain.method.bind(chain)` would
+        // run the call twice. Wrap the bind site in an IIFE arrow
+        // that captures the receiver in a temporary so the chain is
+        // evaluated exactly once.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Service
+            {
+                public Action OnTick { get; set; } = () => { };
+                public void Tick() { }
+            }
+
+            [Transpile]
+            public class Cache
+            {
+                public Service Service { get; } = new();
+            }
+
+            [Transpile]
+            public class Worker
+            {
+                private Cache GetCache() => new();
+
+                public void Wire(Service target)
+                {
+                    target.OnTick = GetCache().Service.Tick;
+                }
+            }
+            """
+        );
+
+        var output = result["worker.ts"];
+        // The IIFE captures the receiver once; the bind argument
+        // reads from the captured temporary instead of re-running
+        // the chain. The receiver expression itself appears exactly
+        // once in the emitted text.
+        await Assert.That(output).Contains("__r.tick.bind(__r)");
+        await Assert.That(output).Contains(")(this.getCache().service)");
+        var occurrences = System
+            .Text.RegularExpressions.Regex.Matches(output, @"this\.getCache\(\)")
+            .Count;
+        await Assert.That(occurrences).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task MethodGroupAsArgument_InstanceMethod_BindsThis()
     {
         // Method group passed as a delegate-typed argument flows

--- a/tests/Metano.Tests/DelegateEventTests.cs
+++ b/tests/Metano.Tests/DelegateEventTests.cs
@@ -428,6 +428,44 @@ public class DelegateEventTests
     }
 
     [Test]
+    public async Task BaseMemberAccessChain_MethodGroup_RecursivelySubstitutesSuper()
+    {
+        // `base.Forwarder.Handle` ends a member-access chain rooted
+        // in `base`. The bind argument must walk the chain and
+        // substitute `this` for the `super` root — `super.forwarder`
+        // is fine on the LHS (super property access is valid JS),
+        // but the bind argument cannot keep `super` because it is
+        // not a value expression.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public class Inner
+            {
+                public void Handle() { }
+            }
+
+            [Transpile]
+            public class BaseHandler
+            {
+                protected Inner Forwarder { get; } = new();
+            }
+
+            [Transpile]
+            public class DerivedHandler : BaseHandler
+            {
+                public Action GetBaseHandler() => base.Forwarder.Handle;
+            }
+            """
+        );
+
+        var output = result["derived-handler.ts"];
+        await Assert.That(output).Contains(".bind(this.forwarder)");
+        await Assert.That(output).DoesNotContain(".bind(super.forwarder)");
+    }
+
+    [Test]
     public async Task ThisDelegate_InstanceMethodGroup_StacksBindAndBindReceiver()
     {
         // `[This]`-bearing delegate assigned an instance method


### PR DESCRIPTION
## Summary

Method-group → delegate bind (PR #134) emits \`obj.method.bind(obj)\` — the receiver expression appears twice. For pure receivers (\`this\`, identifiers, member chains over those) duplication is observably equivalent. For receivers with side effects (calls, indexers, mutating getters) the chain runs twice.

\`\`\`csharp
target.OnTick = GetCache().Service.Tick;
\`\`\`

Before:
\`\`\`ts
target.onTick = this.getCache().service.tick.bind(this.getCache().service);
//              ^^^^^^^^^^^^^^^^^^^^^^^^                ^^^^^^^^^^^^^^^^^ second eval
\`\`\`

After:
\`\`\`ts
target.onTick = ((__r: any) => __r.tick.bind(__r))(this.getCache().service);
\`\`\`

## Mechanism

\`BuildBoundReference(IrMemberAccess instanceAccess)\` checks the receiver via the existing \`IsSimpleReceiver\` predicate. Pure shape → \`obj.method.bind(obj)\`. Impure shape → \`IrCallExpression(IrLambdaExpression([__r], return __r.method.bind(__r)), [originalReceiver])\`. The IIFE captures the receiver once.

## Test plan

- [x] \`MethodGroupAssignment_ImpureReceiver_EvaluatesChainOnce\` — asserts the IIFE shape and counts \`getCache()\` occurrences (expected 1).
- [x] Pre-existing pure-receiver tests still pass — no IIFE overhead when not needed.
- [x] Full suite: 782/782 pass.

Closes #133