### PR TITLE
feat(ts): emit default values for method and function parameters

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
@@ -399,12 +399,17 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
         IReadOnlyList<TsTypeParameter> TypeParameters
     ) LowerMethodSignature(IrMethodDeclaration irMethod, IrClassDeclaration owner)
     {
+        // TypeScript forbids parameter initializers in declaration-
+        // only positions (abstract / overload / interface signatures).
+        // For abstract methods drop the default expression but keep
+        // the parameter optional so callers may still omit it.
+        var emitDefaults = !irMethod.Semantics.IsAbstract;
         var parameters = irMethod
             .Parameters.Select(p => new TsParameter(
                 IrToTsNamingPolicy.ToParameterName(p.Name),
                 IrToTsTypeMapper.Map(p.Type, BclOverrides),
-                Optional: p.IsOptional,
-                DefaultValue: LowerDefaultValue(p)
+                Optional: p.IsOptional || (!emitDefaults && p.HasDefaultValue),
+                DefaultValue: emitDefaults ? LowerDefaultValue(p) : null
             ))
             .ToList();
         var returnType = IrToTsTypeMapper.Map(irMethod.ReturnType, BclOverrides);

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsClassEmitter.cs
@@ -402,7 +402,9 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
         var parameters = irMethod
             .Parameters.Select(p => new TsParameter(
                 IrToTsNamingPolicy.ToParameterName(p.Name),
-                IrToTsTypeMapper.Map(p.Type, BclOverrides)
+                IrToTsTypeMapper.Map(p.Type, BclOverrides),
+                Optional: p.IsOptional,
+                DefaultValue: LowerDefaultValue(p)
             ))
             .ToList();
         var returnType = IrToTsTypeMapper.Map(irMethod.ReturnType, BclOverrides);
@@ -619,6 +621,18 @@ public sealed class IrToTsClassEmitter(TypeScriptTransformContext context)
         IrToTsTypeMapper.Map(irType, BclOverrides);
 
     private BclExportTypeOverrides BclOverrides => _context.BclOverrides;
+
+    /// <summary>
+    /// Lowers an <see cref="IrParameter"/>'s default-value expression
+    /// into the TS form, or returns <c>null</c> when the parameter
+    /// has no explicit default. Routes through the standard
+    /// expression bridge so BCL-mapped initializers (decimal
+    /// literals, enum members, etc.) get their target form.
+    /// </summary>
+    private TsExpression? LowerDefaultValue(IrParameter parameter) =>
+        parameter.HasDefaultValue && parameter.DefaultValue is not null
+            ? IrToTsExpressionBridge.Map(parameter.DefaultValue, _context.DeclarativeMappings)
+            : null;
 
     /// <summary>
     /// Resolves the <c>super(...)</c> argument list for the bridge. Returns

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsModuleBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsModuleBridge.cs
@@ -44,7 +44,11 @@ public static class IrToTsModuleBridge
         var parameters = fn
             .Parameters.Select(p => new TsParameter(
                 TypeScriptNaming.ToCamelCase(p.Name),
-                IrToTsTypeMapper.Map(p.Type)
+                IrToTsTypeMapper.Map(p.Type),
+                Optional: p.IsOptional,
+                DefaultValue: p.HasDefaultValue && p.DefaultValue is not null
+                    ? IrToTsExpressionBridge.Map(p.DefaultValue, bclRegistry)
+                    : null
             ))
             .ToList();
         var body = IrToTsBodyHelpers.LowerOrNotImplemented(fn.Body, fn.Name, bclRegistry);

--- a/src/Metano.Compiler.TypeScript/TypeScript/AST/TsParameter.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/AST/TsParameter.cs
@@ -12,4 +12,16 @@ namespace Metano.TypeScript.AST;
 /// form that lets the TS caller omit it. Set by
 /// <c>[Optional]</c>-tagged parameters on <c>[PlainObject]</c> instance
 /// methods (and any future emission site that honors the attribute).</param>
-public sealed record TsParameter(string Name, TsType? Type, bool Optional = false);
+/// <param name="DefaultValue">When non-null the parameter renders as
+/// <c>name: Type = expr</c>. The <c>= expr</c> form already implies
+/// optionality at the call site, so it is mutually exclusive with the
+/// <c>?</c> suffix — declaration-only positions (interface members,
+/// abstract method signatures, overload signatures) must keep using
+/// <see cref="Optional"/> instead because TypeScript forbids
+/// initializers there.</param>
+public sealed record TsParameter(
+    string Name,
+    TsType? Type,
+    bool Optional = false,
+    TsExpression? DefaultValue = null
+);

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -1278,7 +1278,11 @@ public sealed class Printer(string indent = "  ")
             p =>
             {
                 _sb.Write(p.Name);
-                if (p.Optional)
+                // `?` and `= expr` both convey optionality, but TS
+                // forbids combining them — bias toward the default
+                // expression when both are set so the call site sees
+                // the seeded value instead of `undefined`.
+                if (p.Optional && p.DefaultValue is null)
                     _sb.Write("?");
                 // Null Type → skip the annotation entirely (used by lambdas whose source
                 // parameter is a [NoEmit] type, so TypeScript can infer from context).
@@ -1286,6 +1290,11 @@ public sealed class Printer(string indent = "  ")
                 {
                     _sb.Write(": ");
                     PrintType(p.Type);
+                }
+                if (p.DefaultValue is not null)
+                {
+                    _sb.Write(" = ");
+                    PrintExpression(p.DefaultValue);
                 }
             }
         );

--- a/tests/Metano.Tests/DefaultParameterValueTests.cs
+++ b/tests/Metano.Tests/DefaultParameterValueTests.cs
@@ -1,10 +1,14 @@
 namespace Metano.Tests;
 
 /// <summary>
-/// Default-value emission for method, function, and lambda parameters.
-/// The IR captures the default expression on every parameter site;
-/// these tests pin the TypeScript surface so callers see the same
-/// optional ergonomics the C# source intends.
+/// Default-value emission for instance / static method parameters and
+/// module-function parameters. The IR captures the default expression
+/// on these sites; these tests pin the TypeScript surface so callers
+/// see the same optional ergonomics the C# source intends. Lambda
+/// parameters are out of scope — C# disallows defaults on lambdas;
+/// declaration-only positions (abstract / overload / interface
+/// signatures) drop the initializer because TypeScript forbids them
+/// there but keep the parameter optional via the <c>?</c> suffix.
 /// </summary>
 public class DefaultParameterValueTests
 {
@@ -105,7 +109,32 @@ public class DefaultParameterValueTests
         );
 
         var output = result["plain.ts"];
-        await Assert.That(output).Contains("echo(value: string): string");
-        await Assert.That(output).DoesNotContain("=");
+        // Tighter assertion than `DoesNotContain("=")`: the signature
+        // ends right after the return-type annotation, with no
+        // initializer suffix between `value: string` and the body.
+        await Assert.That(output).Contains("echo(value: string): string {");
+    }
+
+    [Test]
+    public async Task AbstractMethod_DefaultValue_EmitsOptionalWithoutInitializer()
+    {
+        // TypeScript forbids parameter initializers in abstract method
+        // declarations. Drop the `= expr` form but keep the parameter
+        // optional via the `?` suffix so callers may omit it.
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public abstract class Renderer
+            {
+                public abstract string Render(string body, string title = "default");
+            }
+            """
+        );
+
+        var output = result["renderer.ts"];
+        await Assert.That(output).Contains("abstract render(body: string, title?: string): string");
+        await Assert.That(output).DoesNotContain("title: string = ");
     }
 }

--- a/tests/Metano.Tests/DefaultParameterValueTests.cs
+++ b/tests/Metano.Tests/DefaultParameterValueTests.cs
@@ -1,0 +1,111 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Default-value emission for method, function, and lambda parameters.
+/// The IR captures the default expression on every parameter site;
+/// these tests pin the TypeScript surface so callers see the same
+/// optional ergonomics the C# source intends.
+/// </summary>
+public class DefaultParameterValueTests
+{
+    [Test]
+    public async Task InstanceMethod_StringDefault_EmitsAssignment()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public sealed class Greeter
+            {
+                public string Greet(string name, string greeting = "hello") =>
+                    $"{greeting}, {name}";
+            }
+            """
+        );
+
+        var output = result["greeter.ts"];
+        await Assert.That(output).Contains("greet(name: string, greeting: string = \"hello\")");
+    }
+
+    [Test]
+    public async Task ModuleFunction_BoolDefault_EmitsAssignment()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            [ExportedAsModule]
+            public static class Builder
+            {
+                public static string Create(string tag, bool attached = true) =>
+                    attached ? tag : $"<{tag}>";
+            }
+            """
+        );
+
+        var output = result["builder.ts"];
+        await Assert
+            .That(output)
+            .Contains("function create(tag: string, attached: boolean = true): string");
+    }
+
+    [Test]
+    public async Task NumericDefault_EmitsLiteral()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public sealed class Counter
+            {
+                public int Tick(int step = 1) => step;
+            }
+            """
+        );
+
+        var output = result["counter.ts"];
+        await Assert.That(output).Contains("tick(step: number = 1)");
+    }
+
+    [Test]
+    public async Task NullDefault_EmitsNullLiteral()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public sealed class Logger
+            {
+                public void Log(string message, string? prefix = null) { }
+            }
+            """
+        );
+
+        var output = result["logger.ts"];
+        await Assert.That(output).Contains("log(message: string, prefix: string | null = null)");
+    }
+
+    [Test]
+    public async Task NoDefault_KeepsRequiredParameter()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            namespace App;
+
+            [Transpile]
+            public sealed class Plain
+            {
+                public string Echo(string value) => value;
+            }
+            """
+        );
+
+        var output = result["plain.ts"];
+        await Assert.That(output).Contains("echo(value: string): string");
+        await Assert.That(output).DoesNotContain("=");
+    }
+}


### PR DESCRIPTION
## Summary

C# parameter defaults (\`Greet(string name, string greeting = \"hello\")\`) now propagate to the emitted TypeScript signature so callers preserve the optional ergonomics the source intends. Closes #115.

\`\`\`csharp
public string Greet(string name, string greeting = \"hello\") => $\"{greeting}, {name}\";
\`\`\`

emits

\`\`\`ts
greet(name: string, greeting: string = \"hello\"): string {
  return \`\${greeting}, \${name}\`;
}
\`\`\`

## Mechanism

- \`TsParameter\` gains a \`DefaultValue: TsExpression?\` field. The printer emits \`name: T = expr\`, biased over the optional \`?\` suffix when both are set (TS forbids combining them and the call site needs the seeded value, not \`undefined\`).
- \`IrToTsClassEmitter.LowerMethodSignature\` and \`IrToTsModuleBridge.ConvertFunction\` thread \`HasDefaultValue\` + \`DefaultValue\` from the IR through the standard expression bridge — BCL-mapped initializers (decimal literals, enum members) get their target form.

Declaration-only positions (interface signatures, abstract method declarations, overload signatures) are not touched here — they keep using the \`?\` suffix because TS forbids initializers in those slots. Tracked as a follow-up if any of those surfaces start carrying defaults in real samples.

## Test plan

- [x] 5 new tests in \`DefaultParameterValueTests\`: instance method with string default, module function with bool default, numeric default, null default on a nullable, no-default parameter stays required.
- [x] Sample regen (SampleTodo, SampleIssueTracker) byte-identical — current samples don't use parameter defaults.
- [x] Full .NET suite: 795/795 pass.
- [x] csharpier-format clean.