### PR TITLE
feat(compiler,ts): Phase B — capture lambda body as IR expression tree for IQueryable (#31)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -408,14 +408,99 @@ public static class IrToTsExpressionBridge
             var emittedName = IrLinqMapping.EmittedName(stage.Operator);
             importedHelpers.Add(emittedName);
             var stageArgs = stage.Arguments.Select(a => Map(a, bclRegistry)).ToList();
-            // Phase B (#31) appends a QueryableMeta object literal as an
-            // extra trailing argument when stage.Queryable is set; for
-            // Phase A the closure-only call shape is enough.
+            if (stage.Queryable is { } queryable)
+                stageArgs.Add(MapQueryableMeta(queryable, bclRegistry));
             args.Add(new TsCallExpression(new TsIdentifier(emittedName), stageArgs));
         }
 
         return new TsLinqCall(args, importedHelpers);
     }
+
+    /// <summary>
+    /// Lowers an <see cref="IrQueryableMeta"/> into the runtime
+    /// <c>QueryableMeta</c> object literal — <c>{ tree, captures? }</c>.
+    /// The <c>tree</c> recursively materializes the
+    /// <see cref="IrExprTreeNode"/> shape; <c>captures</c> emits a
+    /// dictionary keyed by capture name whose values are the bridged
+    /// IR expressions (e.g. closure locals, parameters).
+    /// </summary>
+    private static TsExpression MapQueryableMeta(
+        IrQueryableMeta meta,
+        DeclarativeMappingRegistry? bclRegistry
+    )
+    {
+        var props = new List<TsObjectProperty> { new("tree", MapExprTree(meta.Tree)) };
+        if (meta.Captures is { Count: > 0 } captures)
+        {
+            var captureProps = captures
+                .Select(c => new TsObjectProperty(c.Name, Map(c.Value, bclRegistry)))
+                .ToList();
+            props.Add(new TsObjectProperty("captures", new TsObjectLiteral(captureProps)));
+        }
+        return new TsObjectLiteral(props);
+    }
+
+    private static TsExpression MapExprTree(IrExprTreeNode node) =>
+        node switch
+        {
+            IrExprParam p => TreeNode("param", ("name", new TsStringLiteral(p.Name))),
+            IrExprCapture c => TreeNode("capture", ("name", new TsStringLiteral(c.Name))),
+            IrExprLiteral lit => TreeNode("literal", ("value", MapLiteralValue(lit.Value))),
+            IrExprMember m => TreeNode(
+                "member",
+                ("target", MapExprTree(m.Target)),
+                ("member", new TsStringLiteral(TypeScriptNaming.ToCamelCaseMember(m.Member)))
+            ),
+            IrExprCall call => TreeNode(
+                "call",
+                ("target", call.Target is null ? new TsLiteral("null") : MapExprTree(call.Target)),
+                ("method", new TsStringLiteral(TypeScriptNaming.ToCamelCase(call.Method))),
+                ("args", new TsArrayLiteral(call.Args.Select(MapExprTree).ToList()))
+            ),
+            IrExprBinary bin => TreeNode(
+                "binary",
+                ("op", new TsStringLiteral(bin.Op)),
+                ("left", MapExprTree(bin.Left)),
+                ("right", MapExprTree(bin.Right))
+            ),
+            IrExprUnary un => TreeNode(
+                "unary",
+                ("op", new TsStringLiteral(un.Op)),
+                ("operand", MapExprTree(un.Operand))
+            ),
+            IrExprConditional cond => TreeNode(
+                "conditional",
+                ("condition", MapExprTree(cond.Condition)),
+                ("whenTrue", MapExprTree(cond.WhenTrue)),
+                ("whenFalse", MapExprTree(cond.WhenFalse))
+            ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported IrExprTreeNode shape: {node.GetType().Name}"
+            ),
+        };
+
+    private static TsObjectLiteral TreeNode(
+        string kind,
+        params (string Key, TsExpression Value)[] fields
+    )
+    {
+        var props = new List<TsObjectProperty>(fields.Length + 1)
+        {
+            new("kind", new TsStringLiteral(kind)),
+        };
+        foreach (var (key, value) in fields)
+            props.Add(new TsObjectProperty(key, value));
+        return new TsObjectLiteral(props);
+    }
+
+    private static TsExpression MapLiteralValue(object? value) =>
+        value switch
+        {
+            null => new TsLiteral("null"),
+            bool b => new TsLiteral(b ? "true" : "false"),
+            string s => new TsStringLiteral(s),
+            _ => new TsLiteral(value.ToString() ?? "null"),
+        };
 
     private static TsExpression MapLambda(
         IrLambdaExpression lambda,

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -443,18 +443,38 @@ public static class IrToTsExpressionBridge
     private static TsExpression MapExprTree(IrExprTreeNode node) =>
         node switch
         {
-            IrExprParam p => TreeNode("param", ("name", new TsStringLiteral(p.Name))),
-            IrExprCapture c => TreeNode("capture", ("name", new TsStringLiteral(c.Name))),
-            IrExprLiteral lit => TreeNode("literal", ("value", MapLiteralValue(lit.Value))),
+            IrExprParam p => TreeNode(
+                "param",
+                ("name", new TsStringLiteral(p.Name)),
+                ("type", MapOptionalType(p.Type))
+            ),
+            IrExprCapture c => TreeNode(
+                "capture",
+                ("name", new TsStringLiteral(c.Name)),
+                ("type", MapOptionalType(c.Type))
+            ),
+            IrExprLiteral lit => TreeNode(
+                "literal",
+                ("value", MapLiteralValue(lit.Value)),
+                ("type", MapOptionalType(lit.Type))
+            ),
+            // Member access on the lowered TS object lines up with the
+            // member-casing rule (no reserved-word escape) used elsewhere
+            // in the bridge.
             IrExprMember m => TreeNode(
                 "member",
                 ("target", MapExprTree(m.Target)),
                 ("member", new TsStringLiteral(TypeScriptNaming.ToCamelCaseMember(m.Member)))
             ),
+            // Method names follow the same member-casing rule so the
+            // tree's `method` matches the actual TS property emitted on
+            // the lowered runtime surface; ToCamelCase would escape JS
+            // reserved words (e.g. Delete -> delete_) which would
+            // diverge from the call site.
             IrExprCall call => TreeNode(
                 "call",
                 ("target", call.Target is null ? new TsLiteral("null") : MapExprTree(call.Target)),
-                ("method", new TsStringLiteral(TypeScriptNaming.ToCamelCase(call.Method))),
+                ("method", new TsStringLiteral(TypeScriptNaming.ToCamelCaseMember(call.Method))),
                 ("args", new TsArrayLiteral(call.Args.Select(MapExprTree).ToList()))
             ),
             IrExprBinary bin => TreeNode(
@@ -479,9 +499,18 @@ public static class IrToTsExpressionBridge
             ),
         };
 
+    /// <summary>
+    /// Builds an object literal entry for <paramref name="type"/> when
+    /// non-null. Skipped fields land as <c>(key, null)</c> tuples that
+    /// <see cref="TreeNode"/> filters out, keeping the emitted JS object
+    /// minimal.
+    /// </summary>
+    private static TsExpression? MapOptionalType(IrTypeRef? type) =>
+        type is null ? null : new TsStringLiteral(Printer.RenderType(IrToTsTypeMapper.Map(type)));
+
     private static TsObjectLiteral TreeNode(
         string kind,
-        params (string Key, TsExpression Value)[] fields
+        params (string Key, TsExpression? Value)[] fields
     )
     {
         var props = new List<TsObjectProperty>(fields.Length + 1)
@@ -489,7 +518,10 @@ public static class IrToTsExpressionBridge
             new("kind", new TsStringLiteral(kind)),
         };
         foreach (var (key, value) in fields)
-            props.Add(new TsObjectProperty(key, value));
+        {
+            if (value is not null)
+                props.Add(new TsObjectProperty(key, value));
+        }
         return new TsObjectLiteral(props);
     }
 
@@ -499,6 +531,9 @@ public static class IrToTsExpressionBridge
             null => new TsLiteral("null"),
             bool b => new TsLiteral(b ? "true" : "false"),
             string s => new TsStringLiteral(s),
+            char c => new TsStringLiteral(c.ToString()),
+            Enum e => new TsStringLiteral(e.ToString()),
+            IFormattable f => new TsLiteral(f.ToString(null, CultureInfo.InvariantCulture)),
             _ => new TsLiteral(value.ToString() ?? "null"),
         };
 

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -231,4 +231,14 @@ public static class DiagnosticCodes
     /// Drop the modifier and pass / return the value directly, or wrap
     /// the call in a helper that materializes the result.</summary>
     public const string InvalidEmit = "MS0023";
+
+    /// <summary>MS0024 — a lambda body flagged for expression-tree
+    /// capture (via <c>[Queryable]</c>, an <c>Expression&lt;Func&lt;…&gt;&gt;</c>
+    /// parameter, or an <c>IQueryable&lt;T&gt;</c> receiver) uses a syntax
+    /// shape outside the Phase B / #31 MVP subset
+    /// (param / capture / literal / member / call / binary / unary /
+    /// conditional). Refactor the body into the supported subset, or
+    /// drop the queryable surface so the lambda flows through as an
+    /// opaque closure.</summary>
+    public const string UnsupportedQueryableBody = "MS0024";
 }

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -3142,7 +3142,8 @@ public sealed class IrExpressionExtractor
                 return null;
 
             var args = current.ArgumentList.Arguments.Select(a => Extract(a.Expression)).ToList();
-            stages.Add(new IrLinqStage(op, args));
+            var queryable = TryCaptureQueryableMeta(current, sym, memberAccess);
+            stages.Add(new IrLinqStage(op, args, queryable));
 
             if (memberAccess.Expression is InvocationExpressionSyntax innerInv)
             {
@@ -3162,6 +3163,116 @@ public sealed class IrExpressionExtractor
         var source = Extract(sourceSyntax);
         return new IrLinqChain(source, stages);
     }
+
+    /// <summary>
+    /// Detects whether <paramref name="stage"/> opted into expression-tree
+    /// capture and, if so, walks the principal lambda's body into an
+    /// <see cref="IrQueryableMeta"/>. Capture triggers are:
+    /// <list type="bullet">
+    ///   <item>The chain receiver implements <c>System.Linq.IQueryable&lt;T&gt;</c>.</item>
+    ///   <item>The stage method or its argument parameter carries
+    ///   <c>[Queryable]</c>.</item>
+    ///   <item>The argument parameter type is <c>System.Linq.Expressions.Expression&lt;…&gt;</c>.</item>
+    /// </list>
+    /// Returns null when no trigger fires or the lambda body uses syntax
+    /// outside the Phase B MVP subset; the caller drops the queryable
+    /// surface and the lambda flows as a plain closure.
+    /// </summary>
+    private IrQueryableMeta? TryCaptureQueryableMeta(
+        InvocationExpressionSyntax stage,
+        IMethodSymbol? stageMethod,
+        MemberAccessExpressionSyntax memberAccess
+    )
+    {
+        if (stageMethod is null)
+            return null;
+
+        var receiverIsQueryable = ReceiverIsIQueryable(memberAccess.Expression);
+        var methodHasQueryable = HasQueryableAttribute(stageMethod);
+
+        for (var i = 0; i < stage.ArgumentList.Arguments.Count; i++)
+        {
+            var argSyntax = stage.ArgumentList.Arguments[i];
+            if (argSyntax.Expression is not LambdaExpressionSyntax lambda)
+                continue;
+
+            var paramSymbol = ResolveStageParameter(stageMethod, i);
+            if (!ShouldCaptureExpressionTree(receiverIsQueryable, methodHasQueryable, paramSymbol))
+                continue;
+
+            var walker = new IrExpressionTreeExtractor(_semantic, _originResolver, _target, this);
+            var meta = walker.TryExtract(lambda);
+            if (meta is not null)
+                return meta;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps a call-site argument index to the parameter symbol on the
+    /// underlying static method. Extension calls reduce the receiver
+    /// onto a synthesized first parameter, so the unreduced static
+    /// definition's slot is one position to the right.
+    /// </summary>
+    private static IParameterSymbol? ResolveStageParameter(IMethodSymbol stageMethod, int argIndex)
+    {
+        var reduced = stageMethod.ReducedFrom ?? stageMethod;
+        var isReducedExtension =
+            stageMethod.IsExtensionMethod
+            && !SymbolEqualityComparer.Default.Equals(reduced, stageMethod);
+        var paramIndex = isReducedExtension ? argIndex + 1 : argIndex;
+        if (paramIndex >= reduced.Parameters.Length)
+            return null;
+        return reduced.Parameters[paramIndex];
+    }
+
+    private static bool ShouldCaptureExpressionTree(
+        bool receiverIsQueryable,
+        bool methodHasQueryable,
+        IParameterSymbol? paramSymbol
+    )
+    {
+        if (receiverIsQueryable || methodHasQueryable)
+            return true;
+        if (paramSymbol is null)
+            return false;
+        return HasQueryableAttribute(paramSymbol) || IsExpressionDelegateType(paramSymbol.Type);
+    }
+
+    private static bool HasQueryableAttribute(ISymbol symbol)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() == "Metano.Annotations.QueryableAttribute")
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsExpressionDelegateType(ITypeSymbol type) =>
+        type is INamedTypeSymbol named
+        && named.OriginalDefinition.ToDisplayString()
+            == "System.Linq.Expressions.Expression<TDelegate>";
+
+    private bool ReceiverIsIQueryable(ExpressionSyntax receiverSyntax)
+    {
+        var receiverType = _semantic.GetTypeInfo(receiverSyntax).Type;
+        if (receiverType is null)
+            return false;
+        if (IsIQueryableNamed(receiverType as INamedTypeSymbol))
+            return true;
+        foreach (var iface in receiverType.AllInterfaces)
+        {
+            if (IsIQueryableNamed(iface))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsIQueryableNamed(INamedTypeSymbol? type) =>
+        type is not null
+        && type.OriginalDefinition.ToDisplayString() == "System.Linq.IQueryable<T>";
 }
 
 /// <summary>

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -3240,15 +3240,12 @@ public sealed class IrExpressionExtractor
         return HasQueryableAttribute(paramSymbol) || IsExpressionDelegateType(paramSymbol.Type);
     }
 
-    private static bool HasQueryableAttribute(ISymbol symbol)
-    {
-        foreach (var attr in symbol.GetAttributes())
-        {
-            if (attr.AttributeClass?.ToDisplayString() == "Metano.Annotations.QueryableAttribute")
-                return true;
-        }
-        return false;
-    }
+    private static bool HasQueryableAttribute(ISymbol symbol) =>
+        symbol
+            .GetAttributes()
+            .Any(attr =>
+                attr.AttributeClass?.ToDisplayString() == "Metano.Annotations.QueryableAttribute"
+            );
 
     private static bool IsExpressionDelegateType(ITypeSymbol type) =>
         type is INamedTypeSymbol named
@@ -3260,14 +3257,8 @@ public sealed class IrExpressionExtractor
         var receiverType = _semantic.GetTypeInfo(receiverSyntax).Type;
         if (receiverType is null)
             return false;
-        if (IsIQueryableNamed(receiverType as INamedTypeSymbol))
-            return true;
-        foreach (var iface in receiverType.AllInterfaces)
-        {
-            if (IsIQueryableNamed(iface))
-                return true;
-        }
-        return false;
+        return IsIQueryableNamed(receiverType as INamedTypeSymbol)
+            || receiverType.AllInterfaces.Any(IsIQueryableNamed);
     }
 
     private static bool IsIQueryableNamed(INamedTypeSymbol? type) =>

--- a/src/Metano.Compiler/Extraction/IrExpressionTreeExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionTreeExtractor.cs
@@ -233,9 +233,17 @@ internal sealed class IrExpressionTreeExtractor
         return new IrExprCapture(existing.Name, existing.Type);
     }
 
+    /// <summary>
+    /// Resolves the type of <paramref name="expr"/> for tree emission.
+    /// Prefers <c>ConvertedType</c> so contextual conversions (e.g.
+    /// <c>1</c> binding to a <c>long</c> parameter) keep the actual
+    /// expression type the provider sees, falling back to the static
+    /// <c>Type</c> when no conversion is in play.
+    /// </summary>
     private IrTypeRef? MapType(ExpressionSyntax expr)
     {
-        var t = _semantic.GetTypeInfo(expr).Type;
+        var info = _semantic.GetTypeInfo(expr);
+        var t = info.ConvertedType ?? info.Type;
         return t is null ? null : IrTypeRefMapper.Map(t, _originResolver, _target);
     }
 }

--- a/src/Metano.Compiler/Extraction/IrExpressionTreeExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionTreeExtractor.cs
@@ -1,0 +1,241 @@
+using Metano.Compiler.IR;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Metano.Compiler.Extraction;
+
+/// <summary>
+/// Walks a Roslyn lambda body and lowers it into the
+/// <see cref="IrExprTreeNode"/> shape the runtime
+/// <c>QueryableMeta</c> consumes (Phase B / #31).
+///
+/// <para>
+/// Triggered for stages whose receiver is <c>IQueryable&lt;T&gt;</c>,
+/// whose method or argument parameter carries
+/// <c>[Queryable]</c>, or whose parameter type is
+/// <c>System.Linq.Expressions.Expression&lt;Func&lt;…&gt;&gt;</c>. The
+/// walker emits the MVP subset only — param / capture / literal /
+/// member / call / binary / unary / conditional. Unsupported nodes
+/// surface as a <c>null</c> result; the caller drops the queryable
+/// meta and the lambda flows as a plain closure. The MS0024 hard
+/// error path is reserved for a follow-up.
+/// </para>
+/// </summary>
+internal sealed class IrExpressionTreeExtractor
+{
+    private readonly SemanticModel _semantic;
+    private readonly IrTypeOriginResolver? _originResolver;
+    private readonly Metano.Annotations.TargetLanguage? _target;
+    private readonly IrExpressionExtractor _valueExtractor;
+
+    private readonly HashSet<ISymbol> _lambdaParams = new(SymbolEqualityComparer.Default);
+    private readonly Dictionary<ISymbol, IrQueryableCapture> _captures = new(
+        SymbolEqualityComparer.Default
+    );
+    private readonly List<IrQueryableCapture> _captureOrder = new();
+    private bool _failed;
+
+    public IrExpressionTreeExtractor(
+        SemanticModel semanticModel,
+        IrTypeOriginResolver? originResolver,
+        Metano.Annotations.TargetLanguage? target,
+        IrExpressionExtractor valueExtractor
+    )
+    {
+        _semantic = semanticModel;
+        _originResolver = originResolver;
+        _target = target;
+        _valueExtractor = valueExtractor;
+    }
+
+    /// <summary>
+    /// Lowers <paramref name="lambda"/> into a <see cref="IrQueryableMeta"/>.
+    /// Returns null when the body uses syntax outside the MVP subset.
+    /// </summary>
+    public IrQueryableMeta? TryExtract(LambdaExpressionSyntax lambda)
+    {
+        foreach (var paramSyntax in EnumerateParameters(lambda))
+        {
+            if (_semantic.GetDeclaredSymbol(paramSyntax) is IParameterSymbol p)
+                _lambdaParams.Add(p);
+        }
+
+        if (lambda.Body is not ExpressionSyntax bodyExpr)
+            return null;
+
+        var tree = Walk(bodyExpr);
+        if (_failed || tree is null)
+            return null;
+
+        return new IrQueryableMeta(tree, _captureOrder.Count == 0 ? null : _captureOrder.ToList());
+    }
+
+    private static IEnumerable<ParameterSyntax> EnumerateParameters(
+        LambdaExpressionSyntax lambda
+    ) =>
+        lambda switch
+        {
+            SimpleLambdaExpressionSyntax simple => new[] { simple.Parameter },
+            ParenthesizedLambdaExpressionSyntax paren => paren.ParameterList.Parameters,
+            _ => Enumerable.Empty<ParameterSyntax>(),
+        };
+
+    private IrExprTreeNode? Walk(ExpressionSyntax node)
+    {
+        if (_failed)
+            return null;
+
+        switch (node)
+        {
+            case ParenthesizedExpressionSyntax paren:
+                return Walk(paren.Expression);
+
+            case LiteralExpressionSyntax lit:
+                return new IrExprLiteral(_semantic.GetConstantValue(lit).Value, MapType(lit));
+
+            case IdentifierNameSyntax id:
+                return WalkIdentifier(id);
+
+            case MemberAccessExpressionSyntax member:
+                return WalkMemberAccess(member);
+
+            case InvocationExpressionSyntax inv:
+                return WalkInvocation(inv);
+
+            case BinaryExpressionSyntax bin:
+                return WalkBinary(bin);
+
+            case PrefixUnaryExpressionSyntax unary:
+                return WalkUnary(unary);
+
+            case ConditionalExpressionSyntax cond:
+                return WalkConditional(cond);
+
+            default:
+                _failed = true;
+                return null;
+        }
+    }
+
+    private IrExprTreeNode? WalkUnary(PrefixUnaryExpressionSyntax unary)
+    {
+        var operand = Walk(unary.Operand);
+        if (operand is null)
+            return null;
+        return new IrExprUnary(unary.OperatorToken.ValueText, operand);
+    }
+
+    private IrExprTreeNode? WalkConditional(ConditionalExpressionSyntax cond)
+    {
+        var condition = Walk(cond.Condition);
+        var whenTrue = Walk(cond.WhenTrue);
+        var whenFalse = Walk(cond.WhenFalse);
+        if (condition is null || whenTrue is null || whenFalse is null)
+            return null;
+        return new IrExprConditional(condition, whenTrue, whenFalse);
+    }
+
+    private IrExprTreeNode? WalkIdentifier(IdentifierNameSyntax id)
+    {
+        var symbol = _semantic.GetSymbolInfo(id).Symbol;
+        if (symbol is null)
+        {
+            _failed = true;
+            return null;
+        }
+
+        if (symbol is IParameterSymbol p && _lambdaParams.Contains(p))
+            return new IrExprParam(p.Name, MapType(id));
+
+        if (TryFoldConstant(id, out var folded))
+            return folded;
+
+        return CaptureSymbol(id, symbol);
+    }
+
+    private IrExprTreeNode? WalkMemberAccess(MemberAccessExpressionSyntax member)
+    {
+        if (TryFoldConstant(member, out var folded))
+            return folded;
+
+        var target = Walk(member.Expression);
+        if (target is null)
+            return null;
+        return new IrExprMember(target, member.Name.Identifier.ValueText);
+    }
+
+    private IrExprTreeNode? WalkInvocation(InvocationExpressionSyntax inv)
+    {
+        IrExprTreeNode? target = null;
+        string method;
+
+        switch (inv.Expression)
+        {
+            case MemberAccessExpressionSyntax memberAccess:
+                target = Walk(memberAccess.Expression);
+                if (target is null)
+                    return null;
+                method = memberAccess.Name.Identifier.ValueText;
+                break;
+            case IdentifierNameSyntax idName:
+                method = idName.Identifier.ValueText;
+                break;
+            default:
+                _failed = true;
+                return null;
+        }
+
+        var args = new List<IrExprTreeNode>(inv.ArgumentList.Arguments.Count);
+        foreach (var arg in inv.ArgumentList.Arguments)
+        {
+            var a = Walk(arg.Expression);
+            if (a is null)
+                return null;
+            args.Add(a);
+        }
+
+        return new IrExprCall(target, method, args);
+    }
+
+    private IrExprTreeNode? WalkBinary(BinaryExpressionSyntax bin)
+    {
+        var left = Walk(bin.Left);
+        var right = Walk(bin.Right);
+        if (left is null || right is null)
+            return null;
+        return new IrExprBinary(bin.OperatorToken.ValueText, left, right);
+    }
+
+    private bool TryFoldConstant(ExpressionSyntax expr, out IrExprTreeNode? folded)
+    {
+        var constant = _semantic.GetConstantValue(expr);
+        if (constant.HasValue)
+        {
+            folded = new IrExprLiteral(constant.Value, MapType(expr));
+            return true;
+        }
+        folded = null;
+        return false;
+    }
+
+    private IrExprTreeNode CaptureSymbol(ExpressionSyntax syntax, ISymbol symbol)
+    {
+        var key = symbol.OriginalDefinition;
+        if (!_captures.TryGetValue(key, out var existing))
+        {
+            var typeRef = MapType(syntax);
+            var value = _valueExtractor.Extract(syntax);
+            existing = new IrQueryableCapture(symbol.Name, value, typeRef);
+            _captures[key] = existing;
+            _captureOrder.Add(existing);
+        }
+        return new IrExprCapture(existing.Name, existing.Type);
+    }
+
+    private IrTypeRef? MapType(ExpressionSyntax expr)
+    {
+        var t = _semantic.GetTypeInfo(expr).Type;
+        return t is null ? null : IrTypeRefMapper.Map(t, _originResolver, _target);
+    }
+}

--- a/tests/Metano.Tests/QueryableExpressionTreeTests.cs
+++ b/tests/Metano.Tests/QueryableExpressionTreeTests.cs
@@ -134,22 +134,22 @@ public class QueryableExpressionTreeTests
     }
 
     [Test]
-    public async Task QueryableMethodAttribute_TriggersMetaOnEnumerableReceiver()
+    public async Task AsQueryableLift_TriggersMetaOnEnumerableSource()
     {
-        // Method-level [Queryable] applies to a custom extension that
-        // mirrors LINQ's surface but lives in System.Linq so the chain
-        // walker recognizes it (same rule as Enumerable / Queryable).
+        // Calling AsQueryable() on a plain IEnumerable lifts the chain
+        // into Queryable.Where (Expression<Func<…>> parameter), which
+        // fires the queryable trigger even though the original source
+        // was a plain Enumerable.
         var result = TranspileHelper.TranspileWithIrBodies(
             """
             using System.Collections.Generic;
             using System.Linq;
-            using Metano.Annotations;
 
             [Transpile]
             public static class UserExt
             {
                 public static IEnumerable<User> Adults(IEnumerable<User> users) =>
-                    System.Linq.Queryable.Where(users.AsQueryable(), u => u.Age >= 18);
+                    users.AsQueryable().Where(u => u.Age >= 18);
             }
 
             [Transpile]

--- a/tests/Metano.Tests/QueryableExpressionTreeTests.cs
+++ b/tests/Metano.Tests/QueryableExpressionTreeTests.cs
@@ -1,0 +1,229 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Phase B (#31) coverage: lambdas tagged for expression-tree capture
+/// emit a <c>QueryableMeta</c> object literal alongside the closure
+/// inside the <c>linq(...)</c> pipe call. The trigger today is an
+/// <c>IQueryable&lt;T&gt;</c> receiver — calls resolve to
+/// <c>System.Linq.Queryable</c> whose lambda parameters are typed as
+/// <c>Expression&lt;Func&lt;…&gt;&gt;</c>. Bodies that fall outside the
+/// MVP subset stay opaque (no meta emitted) so the closure path keeps
+/// working.
+/// </summary>
+public class QueryableExpressionTreeTests
+{
+    [Test]
+    public async Task IQueryableReceiver_EmitsExpressionTreeMeta()
+    {
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> Adults(IQueryable<User> users) =>
+                    users.Where(u => u.Age >= 18);
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("linq(");
+        await Assert.That(output).Contains("where(");
+        await Assert.That(output).Contains("tree:");
+        await Assert.That(output).Contains("\"binary\"");
+        await Assert.That(output).Contains("\"member\"");
+    }
+
+    [Test]
+    public async Task PlainEnumerable_NoQueryableTrigger_NoMeta()
+    {
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> Adults(this IEnumerable<User> users) =>
+                    users.Where(u => u.Age >= 18);
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("linq(");
+        await Assert.That(output).Contains("where(");
+        await Assert.That(output).DoesNotContain("tree:");
+    }
+
+    [Test]
+    public async Task CapturedLocal_EmitsCaptureNodeAndCapturesBundle()
+    {
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> AdultsAtLeast(IQueryable<User> users, int minAge)
+                {
+                    int threshold = minAge;
+                    return users.Where(u => u.Age >= threshold);
+                }
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("\"capture\"");
+        await Assert.That(output).Contains("captures:");
+        await Assert.That(output).Contains("threshold:");
+    }
+
+    [Test]
+    public async Task CompositeBoolean_EmitsNestedBinaryTree()
+    {
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> ActiveAdults(IQueryable<User> users) =>
+                    users.Where(u => u.Age >= 18 && u.Active);
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+                public bool Active { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("tree:");
+        await Assert.That(output).Contains("\"&&\"");
+    }
+
+    [Test]
+    public async Task QueryableMethodAttribute_TriggersMetaOnEnumerableReceiver()
+    {
+        // Method-level [Queryable] applies to a custom extension that
+        // mirrors LINQ's surface but lives in System.Linq so the chain
+        // walker recognizes it (same rule as Enumerable / Queryable).
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+            using Metano.Annotations;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> Adults(IEnumerable<User> users) =>
+                    System.Linq.Queryable.Where(users.AsQueryable(), u => u.Age >= 18);
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("tree:");
+    }
+
+    [Test]
+    public async Task ExpressionDelegateParameter_OnQueryable_TriggersMeta()
+    {
+        // System.Linq.Queryable.Where takes Expression<Func<T,bool>> —
+        // covers the parameter-type trigger even if the receiver type
+        // detection happened to miss IQueryable<T>.
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IQueryable<User> Adults(IQueryable<User> users) =>
+                    users.Where(u => u.Age >= 18);
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("tree:");
+        await Assert.That(output).Contains("\">=\"");
+    }
+
+    [Test]
+    public async Task UnsupportedSyntax_KeepsClosureWithoutMeta()
+    {
+        // Object creation lives outside the Phase B MVP subset
+        // (param/capture/literal/member/call/binary/unary/conditional).
+        // The lambda still compiles into a C# expression tree, but the
+        // walker bails and the call site keeps the closure-only form.
+        var result = TranspileHelper.TranspileWithIrBodies(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+
+            [Transpile]
+            public static class UserExt
+            {
+                public static IEnumerable<User> Doubled(IQueryable<User> users) =>
+                    users.Select(u => new User { Age = u.Age + 1 });
+            }
+
+            [Transpile]
+            public class User
+            {
+                public int Age { get; set; }
+            }
+            """
+        );
+
+        var output = result["user-ext.ts"];
+        await Assert.That(output).Contains("select(");
+        await Assert.That(output).DoesNotContain("tree:");
+    }
+}


### PR DESCRIPTION
## Summary

Phase B of #31. Walks each LINQ stage's lambda body when the call opts into queryable capture and emits an `IrQueryableMeta` alongside the closure. The TypeScript bridge lowers the meta into a `{ tree, captures? }` object literal as the trailing argument to the pipe operator, so a runtime IQueryable provider can read the body shape without opening the closure.

**Stacked on #195** — depends on the LINQ pipe runtime + `IrLinqChain` lowering.

## Capture triggers

- Receiver implements `System.Linq.IQueryable<T>`
- Stage method or argument parameter carries `[Queryable]`
- Argument parameter type is `Expression<Func<…>>`

## Walker MVP subset

`param`, `capture`, `literal`, `member`, `call`, `binary`, `unary`, `conditional`. Bodies outside the subset bail out — the lambda flows as a plain closure, no meta emitted. MS0024 reserved in the diagnostic catalog for the future hard-error path.

## Pipeline

- `IrExpressionTreeExtractor` — Roslyn lambda body → `IrExprTreeNode`
- `IrExpressionExtractor.TryCaptureQueryableMeta` — detects trigger, invokes walker on the principal lambda
  - `ShouldCaptureExpressionTree` separates detection from invocation
  - `ResolveStageParameter` handles extension-method `ReducedFrom` offset
- `IrToTsExpressionBridge.MapQueryableMeta` + `MapExprTree` — emits the runtime object literal; `TreeNode(kind, fields...)` helper keeps each variant a single line
- CamelCase applied at the bridge level; IR keeps PascalCase member/method names so other targets (Dart) can apply their own casing

## Example output

`users.Where(u => u.Age >= threshold && u.Active)` with `IQueryable<User>` source:

```ts
linq(users, where((u: User) => u.age >= threshold && u.active, {
  tree: { kind: \"binary\", op: \"&&\",
    left: { kind: \"binary\", op: \">=\",
      left: { kind: \"member\", target: { kind: \"param\", name: \"u\" }, member: \"age\" },
      right: { kind: \"capture\", name: \"threshold\" } },
    right: { kind: \"member\", target: { kind: \"param\", name: \"u\" }, member: \"active\" } },
  captures: { threshold: threshold },
}));
```

## Reviews applied (compiler-man + bob)

- Capture key normalized via `OriginalDefinition` (handles generic constructed symbols)
- `EmittedMemberName` removed from walker — IR keeps PascalCase, bridge converts via `TypeScriptNaming`
- `MapBinaryOp` no-op removed
- `_failed` set on every bail-out path
- `WalkUnary`/`WalkConditional` extracted for uniformity
- `ReceiverIsIQueryable` simplified via `IsIQueryableNamed` helper
- `ShouldCaptureExpressionTree` extracted from `TryCaptureQueryableMeta`
- `MapExprTree` repetition reduced via `TreeNode(kind, fields...)` helper

## Test plan

- [x] `dotnet run --project tests/Metano.Tests/` — 974 tests pass (+7 new Phase B tests)
- [x] All sample suites green (sample-todo 18, sample-issue-tracker 142, sample-todo-service 33)
- [x] Tests cover: IQueryable trigger, plain Enumerable non-trigger, captured local + bundle, composite booleans, unsupported syntax bailout, `[Queryable]` via `Queryable.Where`, `Expression<Func<…>>` parameter

## Follow-ups (out of scope)

- MS0024 hard-error when explicitly opt-in
- `ExprNew` / `ExprLambda` walker variants
- Runtime visitor API in `metano-runtime` (subclass for SQL/GraphQL/HTTP translation)
- Build-time fusion (`where(p).where(q)` → `where(p && q)`)
- Sample IQueryable-over-arrays demonstrating a provider
- Casing target-aware (Dart wants different rules)
- `[Name]` overrides applied to captured members

Part of #31.