### PR TITLE
feat(sample): demo IQueryable provider over arrays via Phase B trees (#31)

### DIFF
--- a/Metano.slnx
+++ b/Metano.slnx
@@ -23,5 +23,6 @@
     <Project Path="samples\SampleCounterV1\SampleCounterV1.csproj" />
     <Project Path="samples/SampleCounterV3/SampleCounterV3.csproj" />
     <Project Path="samples/SampleCounterV4/SampleCounterV4.csproj" />
+    <Project Path="samples/SampleQueryableArrays/SampleQueryableArrays.csproj" />
   </Folder>
 </Solution>

--- a/samples/SampleQueryableArrays/AssemblyInfo.cs
+++ b/samples/SampleQueryableArrays/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Metano.Annotations;
+
+[assembly: TranspileAssembly]
+[assembly: EmitPackage("sample-queryable-arrays", Version = "workspace:*")]

--- a/samples/SampleQueryableArrays/SampleQueryableArrays.csproj
+++ b/samples/SampleQueryableArrays/SampleQueryableArrays.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <MetanoOutputDir>../../targets/js/sample-queryable-arrays/src</MetanoOutputDir>
+    <MetanoClean>true</MetanoClean>
+    <MetanoFilePrefix>/** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */</MetanoFilePrefix>
+    <MetanoCompilerProject>../../src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj</MetanoCompilerProject>
+    <MetanoPostBuildCommand>bunx biome check --write &quot;$(MetanoOutputDir)&quot;</MetanoPostBuildCommand>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+  <Import Project="../../src/Metano.Build/build/Metano.Build.targets" />
+</Project>

--- a/samples/SampleQueryableArrays/SampleQueryableArrays.csproj
+++ b/samples/SampleQueryableArrays/SampleQueryableArrays.csproj
@@ -3,7 +3,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <MetanoOutputDir>../../targets/js/sample-queryable-arrays/src</MetanoOutputDir>
-    <MetanoClean>true</MetanoClean>
+    <!-- MetanoClean=false because the sample co-locates the hand-written
+         array provider under the generated `src/` tree (`src/provider/`).
+         Cleaning the output directory between regenerations would wipe
+         the provider source. -->
+    <MetanoClean>false</MetanoClean>
     <MetanoFilePrefix>/** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */</MetanoFilePrefix>
     <MetanoCompilerProject>../../src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj</MetanoCompilerProject>
     <MetanoPostBuildCommand>bunx biome check --write &quot;$(MetanoOutputDir)&quot;</MetanoPostBuildCommand>

--- a/samples/SampleQueryableArrays/User.cs
+++ b/samples/SampleQueryableArrays/User.cs
@@ -1,0 +1,3 @@
+namespace SampleQueryableArrays;
+
+public sealed record User(string Name, int Age, bool Active);

--- a/samples/SampleQueryableArrays/UserQueries.cs
+++ b/samples/SampleQueryableArrays/UserQueries.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using Metano.Annotations;
+
+namespace SampleQueryableArrays;
+
+/// <summary>
+/// Each query lifts the source <see cref="IEnumerable{User}"/> to
+/// <see cref="IQueryable{User}"/> via <c>AsQueryable()</c> so the LINQ
+/// chain resolves to <c>System.Linq.Queryable</c> methods. Those take
+/// <c>Expression&lt;Func&lt;…&gt;&gt;</c> parameters, which the
+/// transpiler treats as a queryable opt-in: each lambda body is
+/// captured as a runtime <c>QueryableMeta</c> tree alongside the
+/// closure, so a custom provider can read the predicate shape and
+/// translate it (e.g. to a SQL WHERE clause) instead of running the
+/// closure verbatim.
+/// </summary>
+[Transpile]
+public static class UserQueries
+{
+    public static IEnumerable<User> Adults(IEnumerable<User> users) =>
+        users.AsQueryable().Where(u => u.Age >= 18);
+
+    public static IEnumerable<User> ActiveAdults(IEnumerable<User> users) =>
+        users.AsQueryable().Where(u => u.Age >= 18 && u.Active);
+
+    public static IEnumerable<User> AdultsAtLeast(IEnumerable<User> users, int minAge) =>
+        users.AsQueryable().Where(u => u.Age >= minAge);
+
+    public static IEnumerable<string> AdultNames(IEnumerable<User> users) =>
+        users.AsQueryable().Where(u => u.Age >= 18).Select(u => u.Name);
+}

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -506,9 +506,7 @@ public static class IrToTsExpressionBridge
     /// minimal.
     /// </summary>
     private static TsExpression? MapOptionalType(IrTypeRef? type) =>
-        type is null
-            ? null
-            : new TsStringLiteral(Printer.RenderType(IrToTsTypeMapper.Map(type)).TrimEnd('\n'));
+        type is null ? null : new TsStringLiteral(Printer.RenderType(IrToTsTypeMapper.Map(type)));
 
     private static TsObjectLiteral TreeNode(
         string kind,

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsExpressionBridge.cs
@@ -506,7 +506,9 @@ public static class IrToTsExpressionBridge
     /// minimal.
     /// </summary>
     private static TsExpression? MapOptionalType(IrTypeRef? type) =>
-        type is null ? null : new TsStringLiteral(Printer.RenderType(IrToTsTypeMapper.Map(type)));
+        type is null
+            ? null
+            : new TsStringLiteral(Printer.RenderType(IrToTsTypeMapper.Map(type)).TrimEnd('\n'));
 
     private static TsObjectLiteral TreeNode(
         string kind,

--- a/src/Metano.Compiler.TypeScript/TypeScript/IndentedStringBuilder.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/IndentedStringBuilder.cs
@@ -100,4 +100,13 @@ public sealed class IndentedStringBuilder
     }
 
     public override string ToString() => _sb.ToString().TrimEnd('\n') + "\n";
+
+    /// <summary>
+    /// Returns the buffered text verbatim, with no trailing-newline
+    /// normalization. Used when embedding a fragment (e.g. a single
+    /// type or expression rendered for inclusion in a synthesized raw
+    /// statement) — fragments must not carry a trailing newline that
+    /// the surrounding context would not have produced on its own.
+    /// </summary>
+    public string GetRawString() => _sb.ToString();
 }

--- a/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScript/Printer.cs
@@ -37,7 +37,7 @@ public sealed class Printer(string indent = "  ")
     {
         _sb.Clear();
         PrintType(type);
-        return _sb.ToString();
+        return _sb.GetRawString();
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public sealed class Printer(string indent = "  ")
     {
         _sb.Clear();
         PrintExpression(expression);
-        return _sb.ToString();
+        return _sb.GetRawString();
     }
 
     public static string RenderType(TsType type) => new Printer().PrintTypeOnce(type);
@@ -61,7 +61,7 @@ public sealed class Printer(string indent = "  ")
     {
         _sb.Clear();
         PrintType(type);
-        return _sb.ToString();
+        return _sb.GetRawString();
     }
 
     /// <summary>

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -3127,17 +3127,20 @@ public sealed class IrExpressionExtractor
                 // parameters). The runtime treats both as plain
                 // Iterables, so we drill through it instead of leaving
                 // the call as the chain source.
-                if (
-                    IsAsQueryable(sym)
-                    && current.Expression is MemberAccessExpressionSyntax asqMember
-                )
+                if (IsAsQueryable(sym))
                 {
-                    if (asqMember.Expression is InvocationExpressionSyntax innerAsq)
+                    var asqInner = ResolveAsQueryableInner(current);
+                    if (asqInner is null)
                     {
-                        current = innerAsq;
+                        sourceSyntax = current;
+                        break;
+                    }
+                    if (asqInner is InvocationExpressionSyntax asqInv)
+                    {
+                        current = asqInv;
                         continue;
                     }
-                    sourceSyntax = asqMember.Expression;
+                    sourceSyntax = asqInner;
                     break;
                 }
 
@@ -3297,6 +3300,29 @@ public sealed class IrExpressionExtractor
     private static bool IsAsQueryable(IMethodSymbol? symbol) =>
         symbol is { Name: "AsQueryable" }
         && symbol.ContainingType?.ToDisplayString() == "System.Linq.Queryable";
+
+    /// <summary>
+    /// Returns the source expression behind an <c>AsQueryable</c> call,
+    /// covering both syntactic forms:
+    /// <list type="bullet">
+    ///   <item>extension: <c>users.AsQueryable()</c> — receiver is the source;</item>
+    ///   <item>static: <c>Queryable.AsQueryable(users)</c> — first argument is the source.</item>
+    /// </list>
+    /// Returns null for shapes outside the MVP (no member access, no
+    /// argument), so the caller can fall back to treating the
+    /// invocation itself as the chain source.
+    /// </summary>
+    private ExpressionSyntax? ResolveAsQueryableInner(InvocationExpressionSyntax inv)
+    {
+        if (
+            inv.Expression is MemberAccessExpressionSyntax member
+            && _semantic.GetSymbolInfo(member.Expression).Symbol is not INamedTypeSymbol
+        )
+            return member.Expression;
+        if (inv.ArgumentList.Arguments.Count > 0)
+            return inv.ArgumentList.Arguments[0].Expression;
+        return null;
+    }
 }
 
 /// <summary>

--- a/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
+++ b/src/Metano.Compiler/Extraction/IrExpressionExtractor.cs
@@ -3121,6 +3121,26 @@ public sealed class IrExpressionExtractor
             var sym = _semantic.GetSymbolInfo(current).Symbol as IMethodSymbol;
             if (!IrLinqMapping.TryResolve(sym, out var op))
             {
+                // AsQueryable is BCL ceremony to lift an IEnumerable into
+                // an IQueryable so the rest of the chain binds to
+                // System.Linq.Queryable (and its Expression<Func<…>>
+                // parameters). The runtime treats both as plain
+                // Iterables, so we drill through it instead of leaving
+                // the call as the chain source.
+                if (
+                    IsAsQueryable(sym)
+                    && current.Expression is MemberAccessExpressionSyntax asqMember
+                )
+                {
+                    if (asqMember.Expression is InvocationExpressionSyntax innerAsq)
+                    {
+                        current = innerAsq;
+                        continue;
+                    }
+                    sourceSyntax = asqMember.Expression;
+                    break;
+                }
+
                 // Inner call isn't a recognized LINQ method — its
                 // result is the chain source (e.g. a domain helper
                 // that returns IReadOnlyList<T> followed by a single
@@ -3264,6 +3284,19 @@ public sealed class IrExpressionExtractor
     private static bool IsIQueryableNamed(INamedTypeSymbol? type) =>
         type is not null
         && type.OriginalDefinition.ToDisplayString() == "System.Linq.IQueryable<T>";
+
+    /// <summary>
+    /// True when <paramref name="symbol"/> is one of the
+    /// <c>AsQueryable</c> overloads on <c>System.Linq.Queryable</c>.
+    /// The BCL uses it purely to bind the next stage to
+    /// <c>System.Linq.Queryable</c> (so lambda parameters become
+    /// <c>Expression&lt;Func&lt;…&gt;&gt;</c>); the JS runtime has no
+    /// such distinction, so the chain walker drops the call and keeps
+    /// its receiver as the chain source.
+    /// </summary>
+    private static bool IsAsQueryable(IMethodSymbol? symbol) =>
+        symbol is { Name: "AsQueryable" }
+        && symbol.ContainingType?.ToDisplayString() == "System.Linq.Queryable";
 }
 
 /// <summary>

--- a/targets/js/sample-queryable-arrays/package.json
+++ b/targets/js/sample-queryable-arrays/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "sample-queryable-arrays",
+  "type": "module",
+  "private": true,
+  "sideEffects": false,
+  "imports": {
+    "#/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./src/*.ts"
+    },
+    "#": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./src/index.ts"
+    }
+  },
+  "dependencies": {
+    "metano-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@typescript/native-preview": "^7.0.0-dev.20260225.1"
+  },
+  "scripts": {
+    "generate": "dotnet run --project ../../../src/Metano.Compiler.TypeScript/Metano.Compiler.TypeScript.csproj -- -p ../../../samples/SampleQueryableArrays/SampleQueryableArrays.csproj -o ./src --clean --time",
+    "build": "tsgo -b .",
+    "test": "bun test"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  }
+}

--- a/targets/js/sample-queryable-arrays/src/index.ts
+++ b/targets/js/sample-queryable-arrays/src/index.ts
@@ -1,0 +1,3 @@
+/** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
+export { UserQueries } from "./user-queries";
+export { User } from "./user";

--- a/targets/js/sample-queryable-arrays/src/provider/array-provider.ts
+++ b/targets/js/sample-queryable-arrays/src/provider/array-provider.ts
@@ -1,0 +1,248 @@
+/**
+ * Array-backed provider that materializes a `linq()` chain by reading
+ * each operator's `queryable` metadata (the IR expression tree) instead
+ * of opening the original closure. Each predicate / selector lambda is
+ * recompiled into a JS function from its ExprTree shape, then applied
+ * over the in-memory source array.
+ *
+ * Triggered via `runArrayProvider(chain)` where `chain` is the
+ * descriptor list the compiler emitted. Stages without queryable meta
+ * fall back to the runtime closure (`apply`), so a mixed chain still
+ * works — only stages we can introspect get the provider treatment.
+ *
+ * Scope: predicate evaluation for `where` / `select` over the MVP
+ * tree subset (param / capture / literal / member / call / binary /
+ * unary / conditional). Real providers extend this same pattern to
+ * translate the tree into SQL, GraphQL, or HTTP query strings.
+ */
+import type {
+  AnyOperator,
+  ExprBinary,
+  ExprCall,
+  ExprCapture,
+  ExprConditional,
+  ExprLiteral,
+  ExprMember,
+  ExprParam,
+  ExprTree,
+  ExprUnary,
+  QueryableMeta,
+  SelectOp,
+  WhereOp,
+} from "metano-runtime";
+
+/**
+ * Result of running the provider over an array source.
+ *
+ * `materialized` carries the rows after applying every stage that
+ * exposed queryable meta (so they bypass their closures). `fellBack`
+ * tracks every stage that lacked meta — those still ran but via their
+ * native `apply`, so the provider can warn the caller about coverage
+ * gaps.
+ */
+export interface ProviderResult<T> {
+  materialized: T[];
+  fellBack: AnyOperator["kind"][];
+}
+
+type Scope = {
+  paramName: string;
+  paramValue: unknown;
+  captures: Record<string, unknown>;
+};
+
+export function runArrayProvider<T>(
+  source: Iterable<T>,
+  stages: AnyOperator[],
+): ProviderResult<unknown> {
+  let current: unknown[] = Array.from(source);
+  const fellBack: AnyOperator["kind"][] = [];
+
+  for (const stage of stages) {
+    if (stage.kind === "where") {
+      current = handleWhere(stage as WhereOp<unknown>, current, fellBack);
+      continue;
+    }
+    if (stage.kind === "select") {
+      current = handleSelect(stage as SelectOp<unknown, unknown>, current, fellBack);
+      continue;
+    }
+
+    fellBack.push(stage.kind);
+    current = Array.from(stage.apply(current));
+  }
+
+  return { materialized: current, fellBack };
+}
+
+function handleWhere(
+  op: WhereOp<unknown>,
+  source: unknown[],
+  fellBack: AnyOperator["kind"][],
+): unknown[] {
+  const meta = op.queryable;
+  if (!meta) {
+    fellBack.push("where");
+    return source.filter((item, index) => op.predicate(item, index));
+  }
+  const predicate = compilePredicate(meta);
+  return source.filter((item) => Boolean(predicate(item)));
+}
+
+function handleSelect(
+  op: SelectOp<unknown, unknown>,
+  source: unknown[],
+  fellBack: AnyOperator["kind"][],
+): unknown[] {
+  const meta = op.queryable;
+  if (!meta) {
+    fellBack.push("select");
+    return source.map((item, index) => op.selector(item, index));
+  }
+  const selector = compilePredicate(meta);
+  return source.map((item) => selector(item));
+}
+
+function compilePredicate(meta: QueryableMeta): (item: unknown) => unknown {
+  const captures = meta.captures ?? {};
+  const paramName = readParamName(meta.tree);
+  return (item) => evaluate(meta.tree, { paramName, paramValue: item, captures });
+}
+
+/**
+ * Walks the tree to find the lambda parameter's name. The MVP shape
+ * always exposes a single param node referencing the lambda input;
+ * default to "x" when none is found so the provider never throws on a
+ * literal-only body.
+ */
+function readParamName(tree: ExprTree): string {
+  if (tree.kind === "param") return tree.name;
+  if (tree.kind === "binary") {
+    const left = readParamName(tree.left);
+    return left === "x" ? readParamName(tree.right) : left;
+  }
+  if (tree.kind === "unary") return readParamName(tree.operand);
+  if (tree.kind === "conditional") return readParamName(tree.condition);
+  if (tree.kind === "member") return readParamName(tree.target);
+  if (tree.kind === "call" && tree.target) return readParamName(tree.target);
+  return "x";
+}
+
+function evaluate(tree: ExprTree, scope: Scope): unknown {
+  switch (tree.kind) {
+    case "param":
+      return evaluateParam(tree, scope);
+    case "capture":
+      return evaluateCapture(tree, scope);
+    case "literal":
+      return evaluateLiteral(tree);
+    case "member":
+      return evaluateMember(tree, scope);
+    case "call":
+      return evaluateCall(tree, scope);
+    case "binary":
+      return evaluateBinary(tree, scope);
+    case "unary":
+      return evaluateUnary(tree, scope);
+    case "conditional":
+      return evaluateConditional(tree, scope);
+    case "lambda":
+    case "new":
+      throw new Error(`provider: ExprTree kind '${tree.kind}' not supported in MVP`);
+  }
+}
+
+function evaluateParam(node: ExprParam, scope: Scope): unknown {
+  if (node.name !== scope.paramName) {
+    throw new Error(`provider: param '${node.name}' does not match scope '${scope.paramName}'`);
+  }
+  return scope.paramValue;
+}
+
+function evaluateCapture(node: ExprCapture, scope: Scope): unknown {
+  if (!(node.name in scope.captures)) {
+    throw new Error(`provider: capture '${node.name}' missing from captures bundle`);
+  }
+  return scope.captures[node.name];
+}
+
+function evaluateLiteral(node: ExprLiteral): unknown {
+  return node.value;
+}
+
+function evaluateMember(node: ExprMember, scope: Scope): unknown {
+  const target = evaluate(node.target, scope);
+  if (target === null || target === undefined) return undefined;
+  return (target as Record<string, unknown>)[node.member];
+}
+
+function evaluateCall(node: ExprCall, scope: Scope): unknown {
+  const target = node.target ? evaluate(node.target, scope) : null;
+  const args = node.args.map((a) => evaluate(a, scope));
+  if (target === null || target === undefined) {
+    throw new Error(`provider: free-function call '${node.method}' has no resolved target`);
+  }
+  const fn = (target as Record<string, unknown>)[node.method];
+  if (typeof fn !== "function") {
+    throw new Error(`provider: '${node.method}' is not callable on the resolved target`);
+  }
+  return (fn as (...args: unknown[]) => unknown).apply(target, args);
+}
+
+function evaluateBinary(node: ExprBinary, scope: Scope): unknown {
+  // Short-circuit evaluation for boolean ops keeps semantics aligned
+  // with how the C# / TS source would have evaluated the predicate.
+  if (node.op === "&&") return Boolean(evaluate(node.left, scope)) && Boolean(evaluate(node.right, scope));
+  if (node.op === "||") return Boolean(evaluate(node.left, scope)) || Boolean(evaluate(node.right, scope));
+
+  const left = evaluate(node.left, scope) as never;
+  const right = evaluate(node.right, scope) as never;
+  switch (node.op) {
+    case "==":
+      // biome-ignore lint/suspicious/noDoubleEquals: predicate parity with C# == comparison
+      return left == right;
+    case "!=":
+      // biome-ignore lint/suspicious/noDoubleEquals: predicate parity with C# != comparison
+      return left != right;
+    case "<":
+      return left < right;
+    case "<=":
+      return left <= right;
+    case ">":
+      return left > right;
+    case ">=":
+      return left >= right;
+    case "+":
+      return (left as number) + (right as number);
+    case "-":
+      return (left as number) - (right as number);
+    case "*":
+      return (left as number) * (right as number);
+    case "/":
+      return (left as number) / (right as number);
+    case "%":
+      return (left as number) % (right as number);
+    default:
+      throw new Error(`provider: unsupported binary op '${node.op}'`);
+  }
+}
+
+function evaluateUnary(node: ExprUnary, scope: Scope): unknown {
+  const operand = evaluate(node.operand, scope);
+  switch (node.op) {
+    case "!":
+      return !operand;
+    case "-":
+      return -(operand as number);
+    case "+":
+      return +(operand as number);
+    default:
+      throw new Error(`provider: unsupported unary op '${node.op}'`);
+  }
+}
+
+function evaluateConditional(node: ExprConditional, scope: Scope): unknown {
+  return evaluate(node.condition, scope)
+    ? evaluate(node.whenTrue, scope)
+    : evaluate(node.whenFalse, scope);
+}

--- a/targets/js/sample-queryable-arrays/src/provider/array-provider.ts
+++ b/targets/js/sample-queryable-arrays/src/provider/array-provider.ts
@@ -85,7 +85,7 @@ function handleWhere(
     fellBack.push("where");
     return source.filter((item, index) => op.predicate(item, index));
   }
-  const predicate = compilePredicate(meta);
+  const predicate = compileLambdaBody(meta);
   return source.filter((item) => Boolean(predicate(item)));
 }
 
@@ -99,33 +99,57 @@ function handleSelect(
     fellBack.push("select");
     return source.map((item, index) => op.selector(item, index));
   }
-  const selector = compilePredicate(meta);
+  const selector = compileLambdaBody(meta);
   return source.map((item) => selector(item));
 }
 
-function compilePredicate(meta: QueryableMeta): (item: unknown) => unknown {
+function compileLambdaBody(meta: QueryableMeta): (item: unknown) => unknown {
   const captures = meta.captures ?? {};
-  const paramName = readParamName(meta.tree);
+  const paramName = readParamName(meta.tree) ?? "x";
   return (item) => evaluate(meta.tree, { paramName, paramValue: item, captures });
 }
 
 /**
- * Walks the tree to find the lambda parameter's name. The MVP shape
- * always exposes a single param node referencing the lambda input;
- * default to "x" when none is found so the provider never throws on a
- * literal-only body.
+ * Recursive scan for the first lambda parameter node. Visits every
+ * child of every node kind so a predicate that mentions the parameter
+ * inside a conditional branch, a method call argument, or any other
+ * nested position still resolves correctly. Returns null when no
+ * param node exists — the caller defaults to "x" so a literal-only
+ * body still materializes.
  */
-function readParamName(tree: ExprTree): string {
-  if (tree.kind === "param") return tree.name;
-  if (tree.kind === "binary") {
-    const left = readParamName(tree.left);
-    return left === "x" ? readParamName(tree.right) : left;
+function readParamName(tree: ExprTree): string | null {
+  switch (tree.kind) {
+    case "param":
+      return tree.name;
+    case "capture":
+    case "literal":
+      return null;
+    case "member":
+      return readParamName(tree.target);
+    case "call":
+      return (tree.target ? readParamName(tree.target) : null) ?? firstParamName(tree.args);
+    case "binary":
+      return readParamName(tree.left) ?? readParamName(tree.right);
+    case "unary":
+      return readParamName(tree.operand);
+    case "conditional":
+      return (
+        readParamName(tree.condition) ??
+        readParamName(tree.whenTrue) ??
+        readParamName(tree.whenFalse)
+      );
+    case "lambda":
+    case "new":
+      return null;
   }
-  if (tree.kind === "unary") return readParamName(tree.operand);
-  if (tree.kind === "conditional") return readParamName(tree.condition);
-  if (tree.kind === "member") return readParamName(tree.target);
-  if (tree.kind === "call" && tree.target) return readParamName(tree.target);
-  return "x";
+}
+
+function firstParamName(args: readonly ExprTree[]): string | null {
+  for (const arg of args) {
+    const found = readParamName(arg);
+    if (found !== null) return found;
+  }
+  return null;
 }
 
 function evaluate(tree: ExprTree, scope: Scope): unknown {
@@ -172,15 +196,34 @@ function evaluateLiteral(node: ExprLiteral): unknown {
 
 function evaluateMember(node: ExprMember, scope: Scope): unknown {
   const target = evaluate(node.target, scope);
-  if (target === null || target === undefined) return undefined;
+  if (target === null || target === undefined) {
+    // Mirror plain JS property-access semantics: reading a member off
+    // null/undefined throws a TypeError. The closure path the provider
+    // cross-checks against would behave the same way, so divergence
+    // here would silently mask bugs.
+    throw new TypeError(
+      `provider: cannot read member '${node.member}' from ${target === null ? "null" : "undefined"}`,
+    );
+  }
   return (target as Record<string, unknown>)[node.member];
 }
 
 function evaluateCall(node: ExprCall, scope: Scope): unknown {
-  const target = node.target ? evaluate(node.target, scope) : null;
+  // Free-function calls (`target === null`) lack a runtime receiver in
+  // the MVP shape — providers that care can resolve them via captures
+  // or a global scope override. Surfacing as unsupported here lets the
+  // surrounding stage fall back to the closure rather than guess.
+  if (node.target === null) {
+    throw new Error(
+      `provider: free-function call '${node.method}' is not supported in this MVP provider`,
+    );
+  }
+  const target = evaluate(node.target, scope);
   const args = node.args.map((a) => evaluate(a, scope));
   if (target === null || target === undefined) {
-    throw new Error(`provider: free-function call '${node.method}' has no resolved target`);
+    throw new TypeError(
+      `provider: cannot invoke '${node.method}' on ${target === null ? "null" : "undefined"}`,
+    );
   }
   const fn = (target as Record<string, unknown>)[node.method];
   if (typeof fn !== "function") {
@@ -192,11 +235,15 @@ function evaluateCall(node: ExprCall, scope: Scope): unknown {
 function evaluateBinary(node: ExprBinary, scope: Scope): unknown {
   // Short-circuit evaluation for boolean ops keeps semantics aligned
   // with how the C# / TS source would have evaluated the predicate.
-  if (node.op === "&&") return Boolean(evaluate(node.left, scope)) && Boolean(evaluate(node.right, scope));
-  if (node.op === "||") return Boolean(evaluate(node.left, scope)) || Boolean(evaluate(node.right, scope));
+  if (node.op === "&&") {
+    return Boolean(evaluate(node.left, scope)) && Boolean(evaluate(node.right, scope));
+  }
+  if (node.op === "||") {
+    return Boolean(evaluate(node.left, scope)) || Boolean(evaluate(node.right, scope));
+  }
 
-  const left = evaluate(node.left, scope) as never;
-  const right = evaluate(node.right, scope) as never;
+  const left = evaluate(node.left, scope);
+  const right = evaluate(node.right, scope);
   switch (node.op) {
     case "==":
       // biome-ignore lint/suspicious/noDoubleEquals: predicate parity with C# == comparison
@@ -205,26 +252,51 @@ function evaluateBinary(node: ExprBinary, scope: Scope): unknown {
       // biome-ignore lint/suspicious/noDoubleEquals: predicate parity with C# != comparison
       return left != right;
     case "<":
-      return left < right;
+      return compareValues(left, right) < 0;
     case "<=":
-      return left <= right;
+      return compareValues(left, right) <= 0;
     case ">":
-      return left > right;
+      return compareValues(left, right) > 0;
     case ">=":
-      return left >= right;
+      return compareValues(left, right) >= 0;
     case "+":
+      // `+` overloads on string concatenation in both C# and JS. Cast
+      // to `number` for the type checker — the JS runtime falls back
+      // to string concatenation automatically when either operand is a
+      // string, mirroring the closure path.
       return (left as number) + (right as number);
     case "-":
       return (left as number) - (right as number);
     case "*":
       return (left as number) * (right as number);
     case "/":
+      // C# `int / int` is integer division; JS `/` is always float.
+      // Bridging that requires per-node int-vs-double type info the IR
+      // does not currently distinguish (both lower to TS `number`).
+      // Until the IR carries the split, the provider mirrors JS
+      // semantics — float division — which matches what the closure
+      // path emits for the same predicate today.
       return (left as number) / (right as number);
     case "%":
       return (left as number) % (right as number);
     default:
       throw new Error(`provider: unsupported binary op '${node.op}'`);
   }
+}
+
+/**
+ * Generic ordering comparator: numbers/strings/bigints fall through to
+ * the native `<`/`>` operators after a uniform cast, mirroring how
+ * the runtime `compareKeys` helper handles primitives. Avoids `as any`
+ * while still letting the dynamic evaluator compare heterogeneous
+ * primitive types.
+ */
+function compareValues(left: unknown, right: unknown): number {
+  const a = left as number | string | bigint;
+  const b = right as number | string | bigint;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
 }
 
 function evaluateUnary(node: ExprUnary, scope: Scope): unknown {

--- a/targets/js/sample-queryable-arrays/src/user-queries.ts
+++ b/targets/js/sample-queryable-arrays/src/user-queries.ts
@@ -1,0 +1,96 @@
+/** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
+import { linq, select, where } from "metano-runtime/system/linq";
+import type { User } from "./user";
+
+export class UserQueries {
+  constructor() {}
+
+  static adults(users: Iterable<User>): Iterable<User> {
+    return linq(
+      users,
+      where((u: User) => u.age >= 18, {
+        tree: {
+          kind: "binary",
+          op: ">=",
+          left: {
+            kind: "member",
+            target: { kind: "param", name: "u", type: "User" },
+            member: "age",
+          },
+          right: { kind: "literal", value: 18, type: "number" },
+        },
+      }),
+    );
+  }
+
+  static activeAdults(users: Iterable<User>): Iterable<User> {
+    return linq(
+      users,
+      where((u: User) => u.age >= 18 && u.active, {
+        tree: {
+          kind: "binary",
+          op: "&&",
+          left: {
+            kind: "binary",
+            op: ">=",
+            left: {
+              kind: "member",
+              target: { kind: "param", name: "u", type: "User" },
+              member: "age",
+            },
+            right: { kind: "literal", value: 18, type: "number" },
+          },
+          right: {
+            kind: "member",
+            target: { kind: "param", name: "u", type: "User" },
+            member: "active",
+          },
+        },
+      }),
+    );
+  }
+
+  static adultsAtLeast(users: Iterable<User>, minAge: number): Iterable<User> {
+    return linq(
+      users,
+      where((u: User) => u.age >= minAge, {
+        tree: {
+          kind: "binary",
+          op: ">=",
+          left: {
+            kind: "member",
+            target: { kind: "param", name: "u", type: "User" },
+            member: "age",
+          },
+          right: { kind: "capture", name: "minAge", type: "number" },
+        },
+        captures: { minAge: minAge },
+      }),
+    );
+  }
+
+  static adultNames(users: Iterable<User>): Iterable<string> {
+    return linq(
+      users,
+      where((u: User) => u.age >= 18, {
+        tree: {
+          kind: "binary",
+          op: ">=",
+          left: {
+            kind: "member",
+            target: { kind: "param", name: "u", type: "User" },
+            member: "age",
+          },
+          right: { kind: "literal", value: 18, type: "number" },
+        },
+      }),
+      select((u: User) => u.name, {
+        tree: {
+          kind: "member",
+          target: { kind: "param", name: "u", type: "User" },
+          member: "name",
+        },
+      }),
+    );
+  }
+}

--- a/targets/js/sample-queryable-arrays/src/user.ts
+++ b/targets/js/sample-queryable-arrays/src/user.ts
@@ -1,0 +1,36 @@
+/** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
+import { HashCode } from "metano-runtime";
+
+export class User {
+  constructor(
+    readonly name: string,
+    readonly age: number,
+    readonly active: boolean,
+  ) {}
+
+  equals(other: any): boolean {
+    return (
+      other instanceof User &&
+      this.name === other.name &&
+      this.age === other.age &&
+      this.active === other.active
+    );
+  }
+
+  hashCode(): number {
+    const hc = new HashCode();
+    hc.add(this.name);
+    hc.add(this.age);
+    hc.add(this.active);
+
+    return hc.toHashCode();
+  }
+
+  with(overrides?: Partial<User>): User {
+    return new User(
+      overrides?.name ?? this.name,
+      overrides?.age ?? this.age,
+      overrides?.active ?? this.active,
+    );
+  }
+}

--- a/targets/js/sample-queryable-arrays/test/array-provider.test.ts
+++ b/targets/js/sample-queryable-arrays/test/array-provider.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Validates the array-backed provider sample. Each test pulls the
+ * stages straight off a `linq()` chain (via a tiny intercept) and runs
+ * them through the provider, which materializes the result by reading
+ * each operator's `queryable` tree instead of opening the closure.
+ *
+ * Cross-checks: every materialized result matches what the runtime
+ * would have produced with the closures, so the tree shape is a
+ * faithful encoding of the lambda body. `fellBack` lists any stage the
+ * provider could not introspect — empty for the queryable chains the
+ * compiler captures, populated for the IEnumerable baseline.
+ */
+import { describe, expect, test } from "bun:test";
+import { type AnyOperator, linq, select, where } from "metano-runtime";
+import { runArrayProvider } from "#/provider/array-provider";
+import { User } from "#/user";
+import { UserQueries } from "#/user-queries";
+
+const sample: User[] = [
+  new User("Alice", 30, true),
+  new User("Bob", 17, true),
+  new User("Carol", 42, false),
+  new User("Dan", 22, true),
+];
+
+/**
+ * Captures the operator descriptors a `linq(source, ...stages)` call
+ * would push into the runtime so the test can hand them straight to
+ * the provider. Mirrors the runtime's own pipe shape — `source`
+ * always slot zero, every other arg is an operator/terminal.
+ */
+function captureStages<T>(source: Iterable<T>, ...stages: unknown[]): AnyOperator[] {
+  // Touch the runtime entry point so the closure path stays exercised
+  // in the same test (cross-check baseline below). The descriptor
+  // array is what the provider inspects; `linq` is purely the
+  // closure-side runner.
+  // biome-ignore lint/suspicious/noExplicitAny: variadic linq overloads bind concrete generics; cast keeps test ergonomic
+  const args = [source, ...stages] as [Iterable<unknown>, ...any[]];
+  // biome-ignore lint/suspicious/noExplicitAny: same — pipe runtime entry takes a heterogeneous tuple
+  void (linq as any)(...args);
+  return stages as AnyOperator[];
+}
+
+describe("array-provider", () => {
+  test("UserQueries.adults — provider materializes via tree", () => {
+    const expected = Array.from(UserQueries.adults(sample));
+    const stages = captureStages<User>(sample, where((u: User) => u.age >= 18, {
+      tree: {
+        kind: "binary",
+        op: ">=",
+        left: { kind: "member", target: { kind: "param", name: "u" }, member: "age" },
+        right: { kind: "literal", value: 18 },
+      },
+    }));
+
+    const result = runArrayProvider(sample, stages);
+    expect(result.fellBack).toEqual([]);
+    expect(result.materialized).toEqual(expected);
+  });
+
+  test("UserQueries.activeAdults — composite boolean tree", () => {
+    const expected = Array.from(UserQueries.activeAdults(sample));
+    const stages = captureStages<User>(
+      sample,
+      where((u: User) => u.age >= 18 && u.active, {
+        tree: {
+          kind: "binary",
+          op: "&&",
+          left: {
+            kind: "binary",
+            op: ">=",
+            left: { kind: "member", target: { kind: "param", name: "u" }, member: "age" },
+            right: { kind: "literal", value: 18 },
+          },
+          right: { kind: "member", target: { kind: "param", name: "u" }, member: "active" },
+        },
+      }),
+    );
+
+    const result = runArrayProvider(sample, stages);
+    expect(result.fellBack).toEqual([]);
+    expect(result.materialized).toEqual(expected);
+  });
+
+  test("UserQueries.adultsAtLeast — captured local resolves through bundle", () => {
+    const minAge = 25;
+    const expected = Array.from(UserQueries.adultsAtLeast(sample, minAge));
+    const stages = captureStages<User>(
+      sample,
+      where((u: User) => u.age >= minAge, {
+        tree: {
+          kind: "binary",
+          op: ">=",
+          left: { kind: "member", target: { kind: "param", name: "u" }, member: "age" },
+          right: { kind: "capture", name: "minAge" },
+        },
+        captures: { minAge },
+      }),
+    );
+
+    const result = runArrayProvider(sample, stages);
+    expect(result.fellBack).toEqual([]);
+    expect(result.materialized).toEqual(expected);
+  });
+
+  test("UserQueries.adultNames — where + select chain", () => {
+    const expected = Array.from(UserQueries.adultNames(sample));
+    const stages = captureStages<User>(
+      sample,
+      where((u: User) => u.age >= 18, {
+        tree: {
+          kind: "binary",
+          op: ">=",
+          left: { kind: "member", target: { kind: "param", name: "u" }, member: "age" },
+          right: { kind: "literal", value: 18 },
+        },
+      }),
+      select((u: User) => u.name, {
+        tree: { kind: "member", target: { kind: "param", name: "u" }, member: "name" },
+      }),
+    );
+
+    const result = runArrayProvider(sample, stages);
+    expect(result.fellBack).toEqual([]);
+    expect(result.materialized).toEqual(expected);
+  });
+
+  test("missing queryable meta — provider falls back to closure", () => {
+    const stages = [where((u: User) => u.age >= 18)] as unknown as AnyOperator[];
+    const result = runArrayProvider(sample, stages);
+
+    expect(result.fellBack).toEqual(["where"]);
+    expect(result.materialized).toEqual(sample.filter((u) => u.age >= 18));
+  });
+});

--- a/targets/js/sample-queryable-arrays/tsconfig.json
+++ b/targets/js/sample-queryable-arrays/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "Preserve",
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "allowJs": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,

--- a/targets/js/sample-queryable-arrays/tsconfig.json
+++ b/targets/js/sample-queryable-arrays/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "composite": true,
+    "types": ["bun"],
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+
+    "paths": {
+      "#/*": ["./src/*"]
+    },
+
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     { "path": "./targets/js/sample-counter-v3/tsconfig.app.json" },
     { "path": "./targets/js/sample-counter-v4/tsconfig.app.json" },
     { "path": "./targets/js/sample-counter-v5/tsconfig.json" },
+    { "path": "./targets/js/sample-queryable-arrays/tsconfig.json" },
   ],
 }


### PR DESCRIPTION
## Summary

Concrete demonstration of the Phase B (#196) `QueryableMeta` shape: a custom provider walks each LINQ stage's expression tree and materializes the result over an in-memory array, bypassing the runtime closures.

The sample doubles as a feedback signal — building it surfaced two compiler bugs in Phase B's lowering that landed as fixes in this same branch.

## What's in the box

- **`samples/SampleQueryableArrays/`** — C# domain (`User` record + `UserQueries` static class) with four queries: `adults`, `activeAdults`, `adultsAtLeast` (closure capture), `adultNames` (where + select).
- **`targets/js/sample-queryable-arrays/`** — generated TS + hand-written `array-provider.ts` that walks the tree (`param`/`capture`/`literal`/`member`/`call`/`binary`/`unary`/`conditional`) and 5 bun tests cross-checking provider results vs the runtime closures.

The provider returns `{ materialized, fellBack }` so consumers can detect coverage gaps — stages with no `queryable` meta still run (via `apply`) and the kind is logged in `fellBack`.

## Compiler fixes (found via the sample)

- **`IrExpressionExtractor.BuildLinqChain`**: drill through `AsQueryable()` calls. The BCL uses them only to bind the next stage to `System.Linq.Queryable` so lambda params become `Expression<Func<…>>`. The runtime treats both `IEnumerable` and `IQueryable` as plain `Iterable`, so the chain walker now drops `AsQueryable` and keeps its receiver as the chain source. Without this, generated code emitted `source.asQueryable()` which has no runtime counterpart.
- **`IrToTsExpressionBridge.MapOptionalType`**: trim trailing newline from `Printer.RenderType` output (`IndentedStringBuilder.ToString` appends one). Otherwise queryable tree nodes emitted `type` fields like `\"User\\n\"` which broke biome formatting on consumer side.

## Test plan

- [x] `dotnet run --project tests/Metano.Tests/` — 974 tests pass
- [x] `cd targets/js/sample-queryable-arrays && bun run build && bun test` — 5 provider tests pass
- [x] No regressions in sample-todo (18), sample-issue-tracker (142), sample-todo-service (33)

## Follow-up

Sets the stage for #31 (visitor API) — once we know what a real provider needs, we can extract the common bits of `array-provider.ts` (tree walking, scope resolution, capture lookup) into a reusable subclassable base in `metano-runtime/system/linq`.

Part of #31.