### PR TITLE
fix(compiler,runtime): record equals() routes value-wrapper fields through valueEquals

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -24,6 +24,12 @@
       "group": "pre-push",
       "command": "bash",
       "args": ["-c", "bunx biome check ."]
+    },
+    {
+      "name": "verify-targets-clean",
+      "group": "pre-push",
+      "command": "bash",
+      "args": ["scripts/verify-targets-clean.sh"]
     }
   ]
 }

--- a/scripts/verify-targets-clean.sh
+++ b/scripts/verify-targets-clean.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pre-push gate that mirrors the CI 'Verify samples are regenerated cleanly'
+# step — runs `dotnet build` for the whole solution and fails if any file
+# under targets/ ends up dirty (meaning the C# source was changed without
+# committing the regenerated TS output).
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! dotnet build Metano.slnx --nologo -v q; then
+  echo "verify-targets-clean: dotnet build failed — fix the build before pushing." >&2
+  exit 1
+fi
+
+if ! git diff --quiet -- targets/; then
+  echo "verify-targets-clean: generated TS under targets/ is out of sync." >&2
+  echo "Run 'dotnet build Metano.slnx', commit the regen, and push again." >&2
+  git status --short -- targets/ >&2
+  exit 1
+fi

--- a/src/Metano.Compiler.TypeScript/Bridge/IrRuntimeRequirementToTsImport.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrRuntimeRequirementToTsImport.cs
@@ -58,6 +58,7 @@ public static class IrRuntimeRequirementToTsImport
         req.HelperName switch
         {
             "HashCode" => ("metano-runtime", "HashCode", false),
+            "ValueEquals" => ("metano-runtime", "valueEquals", false),
             "Enumerable" => ("metano-runtime", "Enumerable", false),
             "HashSet" => ("metano-runtime", "HashSet", false),
             "UUID" => ("metano-runtime", "UUID", false),

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsRecordSynthesisBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsRecordSynthesisBridge.cs
@@ -56,16 +56,18 @@ public static class IrToTsRecordSynthesisBridge
             "instanceof",
             new TsIdentifier(GetTypeName(ir))
         );
-        foreach (var param in ctorParams)
+        // The IR ctor param list mirrors the TS-lowered ctorParams in
+        // declaration order, so we lift each TS param's IR type by
+        // positional index rather than by name (TS names are
+        // camelCased while the IR keeps the C# casing).
+        var irTypes = ir.Constructor?.Parameters.Select(p => p.Parameter.Type).ToList();
+        for (var i = 0; i < ctorParams.Count; i++)
         {
+            var irType = irTypes is not null && i < irTypes.Count ? irTypes[i] : null;
             condition = new TsBinaryExpression(
                 condition,
                 "&&",
-                new TsBinaryExpression(
-                    new TsPropertyAccess(new TsIdentifier("this"), param.Name),
-                    "===",
-                    new TsPropertyAccess(new TsIdentifier("other"), param.Name)
-                )
+                FieldEquality(ctorParams[i], irType)
             );
         }
         return new TsMethodMember(
@@ -75,6 +77,65 @@ public static class IrToTsRecordSynthesisBridge
             [new TsReturnStatement(condition)]
         );
     }
+
+    /// <summary>
+    /// Emits the per-field comparison inside the synthesized
+    /// <c>equals</c>. Primitive / enum / branded / type-parameter
+    /// fields use <c>===</c>; everything else (nested records, BCL
+    /// value wrappers like <c>Decimal</c> / <c>Temporal</c>, plain
+    /// classes, arrays, maps, …) routes through the runtime
+    /// <c>valueEquals</c> helper so wrappers carrying their own
+    /// <c>equals</c> contract compare structurally instead of by
+    /// reference.
+    /// </summary>
+    private static TsExpression FieldEquality(TsConstructorParam param, IrTypeRef? irType)
+    {
+        var self = new TsPropertyAccess(new TsIdentifier("this"), param.Name);
+        var other = new TsPropertyAccess(new TsIdentifier("other"), param.Name);
+        if (UseStrictEquality(irType))
+            return new TsBinaryExpression(self, "===", other);
+        return new TsCallExpression(new TsIdentifier("valueEquals"), [self, other]);
+    }
+
+    private static bool UseStrictEquality(IrTypeRef? type) =>
+        type switch
+        {
+            null => true,
+            IrPrimitiveTypeRef p => UseStrictEqualityForPrimitive(p.Primitive),
+            IrTypeParameterRef => true,
+            IrNullableTypeRef nullable => UseStrictEquality(nullable.Inner),
+            IrNamedTypeRef named => UseStrictEqualityForNamed(named),
+            _ => false,
+        };
+
+    /// <summary>
+    /// JS treats some C# primitives as object values at runtime — the
+    /// BCL mappings lower <c>Decimal</c> to <c>decimal.js</c>'s
+    /// <c>Decimal</c> class, the date / time family to Temporal
+    /// objects, and <c>Guid</c> to the runtime's <c>UUID</c> class.
+    /// Those wrappers expose <c>equals</c> contracts and need to
+    /// route through <c>valueEquals</c>; the rest are real JS
+    /// primitives where <c>===</c> is correct and faster.
+    /// </summary>
+    private static bool UseStrictEqualityForPrimitive(IrPrimitive p) =>
+        p switch
+        {
+            IrPrimitive.Decimal => false,
+            IrPrimitive.Guid => false,
+            IrPrimitive.DateTime => false,
+            IrPrimitive.DateTimeOffset => false,
+            IrPrimitive.DateOnly => false,
+            IrPrimitive.TimeOnly => false,
+            IrPrimitive.TimeSpan => false,
+            _ => true,
+        };
+
+    private static bool UseStrictEqualityForNamed(IrNamedTypeRef named) =>
+        named.Semantics?.Kind
+            is IrNamedTypeKind.StringEnum
+                or IrNamedTypeKind.NumericEnum
+                or IrNamedTypeKind.Branded;
+
 
     // ── hashCode ─────────────────────────────────────────────────────────
 

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsRecordSynthesisBridge.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsRecordSynthesisBridge.cs
@@ -60,10 +60,11 @@ public static class IrToTsRecordSynthesisBridge
         // declaration order, so we lift each TS param's IR type by
         // positional index rather than by name (TS names are
         // camelCased while the IR keeps the C# casing).
-        var irTypes = ir.Constructor?.Parameters.Select(p => p.Parameter.Type).ToList();
+        var irParams = ir.Constructor?.Parameters;
         for (var i = 0; i < ctorParams.Count; i++)
         {
-            var irType = irTypes is not null && i < irTypes.Count ? irTypes[i] : null;
+            var irType =
+                irParams is not null && i < irParams.Count ? irParams[i].Parameter.Type : null;
             condition = new TsBinaryExpression(
                 condition,
                 "&&",
@@ -80,62 +81,18 @@ public static class IrToTsRecordSynthesisBridge
 
     /// <summary>
     /// Emits the per-field comparison inside the synthesized
-    /// <c>equals</c>. Primitive / enum / branded / type-parameter
-    /// fields use <c>===</c>; everything else (nested records, BCL
-    /// value wrappers like <c>Decimal</c> / <c>Temporal</c>, plain
-    /// classes, arrays, maps, …) routes through the runtime
-    /// <c>valueEquals</c> helper so wrappers carrying their own
-    /// <c>equals</c> contract compare structurally instead of by
-    /// reference.
+    /// <c>equals</c>. The strict / value choice is centralized in
+    /// <see cref="IrEqualityClassifier"/> so the runtime-requirement
+    /// scanner mirrors it without drift.
     /// </summary>
     private static TsExpression FieldEquality(TsConstructorParam param, IrTypeRef? irType)
     {
         var self = new TsPropertyAccess(new TsIdentifier("this"), param.Name);
         var other = new TsPropertyAccess(new TsIdentifier("other"), param.Name);
-        if (UseStrictEquality(irType))
+        if (IrEqualityClassifier.UseStrictEquality(irType))
             return new TsBinaryExpression(self, "===", other);
         return new TsCallExpression(new TsIdentifier("valueEquals"), [self, other]);
     }
-
-    private static bool UseStrictEquality(IrTypeRef? type) =>
-        type switch
-        {
-            null => true,
-            IrPrimitiveTypeRef p => UseStrictEqualityForPrimitive(p.Primitive),
-            IrTypeParameterRef => true,
-            IrNullableTypeRef nullable => UseStrictEquality(nullable.Inner),
-            IrNamedTypeRef named => UseStrictEqualityForNamed(named),
-            _ => false,
-        };
-
-    /// <summary>
-    /// JS treats some C# primitives as object values at runtime — the
-    /// BCL mappings lower <c>Decimal</c> to <c>decimal.js</c>'s
-    /// <c>Decimal</c> class, the date / time family to Temporal
-    /// objects, and <c>Guid</c> to the runtime's <c>UUID</c> class.
-    /// Those wrappers expose <c>equals</c> contracts and need to
-    /// route through <c>valueEquals</c>; the rest are real JS
-    /// primitives where <c>===</c> is correct and faster.
-    /// </summary>
-    private static bool UseStrictEqualityForPrimitive(IrPrimitive p) =>
-        p switch
-        {
-            IrPrimitive.Decimal => false,
-            IrPrimitive.Guid => false,
-            IrPrimitive.DateTime => false,
-            IrPrimitive.DateTimeOffset => false,
-            IrPrimitive.DateOnly => false,
-            IrPrimitive.TimeOnly => false,
-            IrPrimitive.TimeSpan => false,
-            _ => true,
-        };
-
-    private static bool UseStrictEqualityForNamed(IrNamedTypeRef named) =>
-        named.Semantics?.Kind
-            is IrNamedTypeKind.StringEnum
-                or IrNamedTypeKind.NumericEnum
-                or IrNamedTypeKind.Branded;
-
 
     // ── hashCode ─────────────────────────────────────────────────────────
 

--- a/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
+++ b/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
@@ -88,8 +88,61 @@ public static class IrRuntimeRequirementScanner
         // [PlainObject] records are emitted as bare interfaces / object literals — no
         // synthesized equals/hashCode/with — so the helper isn't needed.
         if (c.Semantics.IsRecord && !c.Semantics.IsPlainObject)
+        {
             acc.Add(new IrRuntimeRequirement("HashCode", IrRuntimeCategory.Hashing));
+            // The synthesized `equals` falls back to `valueEquals` for
+            // every constructor parameter whose type is not strictly
+            // primitive / enum / branded / type-parameter so wrapper
+            // types (Decimal, Temporal, nested records) compare via
+            // their own `equals` contract instead of `===`. Mirror the
+            // bridge's UseStrictEquality decision here so the import
+            // line lands only when a non-strict field actually exists.
+            if (c.Constructor is { Parameters.Count: > 0 } ctor && HasNonStrictField(ctor))
+                acc.Add(new IrRuntimeRequirement("ValueEquals", IrRuntimeCategory.Equality));
+        }
     }
+
+    private static bool HasNonStrictField(IrConstructorDeclaration ctor)
+    {
+        foreach (var p in ctor.Parameters)
+        {
+            if (!IsStrictlyComparable(p.Parameter.Type))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsStrictlyComparable(IrTypeRef type) =>
+        type switch
+        {
+            IrPrimitiveTypeRef p => IsStrictPrimitive(p.Primitive),
+            IrTypeParameterRef => true,
+            IrNullableTypeRef nullable => IsStrictlyComparable(nullable.Inner),
+            IrNamedTypeRef named => named.Semantics?.Kind
+                is IrNamedTypeKind.StringEnum
+                    or IrNamedTypeKind.NumericEnum
+                    or IrNamedTypeKind.Branded,
+            _ => false,
+        };
+
+    /// <summary>
+    /// Mirrors the bridge's primitive-strictness whitelist (see
+    /// <c>IrToTsRecordSynthesisBridge.UseStrictEqualityForPrimitive</c>).
+    /// Decimal / date-time / Guid lower to JS object wrappers that
+    /// expose their own <c>equals</c> contract, so a record carrying
+    /// any of them needs the runtime <c>valueEquals</c> import.
+    /// </summary>
+    private static bool IsStrictPrimitive(IrPrimitive p) =>
+        p
+            is not (
+                IrPrimitive.Decimal
+                or IrPrimitive.Guid
+                or IrPrimitive.DateTime
+                or IrPrimitive.DateTimeOffset
+                or IrPrimitive.DateOnly
+                or IrPrimitive.TimeOnly
+                or IrPrimitive.TimeSpan
+            );
 
     private static void ScanInterface(IrInterfaceDeclaration i, HashSet<IrRuntimeRequirement> acc)
     {

--- a/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
+++ b/src/Metano.Compiler/Extraction/IrRuntimeRequirementScanner.cs
@@ -106,43 +106,11 @@ public static class IrRuntimeRequirementScanner
     {
         foreach (var p in ctor.Parameters)
         {
-            if (!IsStrictlyComparable(p.Parameter.Type))
+            if (!IrEqualityClassifier.UseStrictEquality(p.Parameter.Type))
                 return true;
         }
         return false;
     }
-
-    private static bool IsStrictlyComparable(IrTypeRef type) =>
-        type switch
-        {
-            IrPrimitiveTypeRef p => IsStrictPrimitive(p.Primitive),
-            IrTypeParameterRef => true,
-            IrNullableTypeRef nullable => IsStrictlyComparable(nullable.Inner),
-            IrNamedTypeRef named => named.Semantics?.Kind
-                is IrNamedTypeKind.StringEnum
-                    or IrNamedTypeKind.NumericEnum
-                    or IrNamedTypeKind.Branded,
-            _ => false,
-        };
-
-    /// <summary>
-    /// Mirrors the bridge's primitive-strictness whitelist (see
-    /// <c>IrToTsRecordSynthesisBridge.UseStrictEqualityForPrimitive</c>).
-    /// Decimal / date-time / Guid lower to JS object wrappers that
-    /// expose their own <c>equals</c> contract, so a record carrying
-    /// any of them needs the runtime <c>valueEquals</c> import.
-    /// </summary>
-    private static bool IsStrictPrimitive(IrPrimitive p) =>
-        p
-            is not (
-                IrPrimitive.Decimal
-                or IrPrimitive.Guid
-                or IrPrimitive.DateTime
-                or IrPrimitive.DateTimeOffset
-                or IrPrimitive.DateOnly
-                or IrPrimitive.TimeOnly
-                or IrPrimitive.TimeSpan
-            );
 
     private static void ScanInterface(IrInterfaceDeclaration i, HashSet<IrRuntimeRequirement> acc)
     {

--- a/src/Metano.Compiler/IR/IrEqualityClassifier.cs
+++ b/src/Metano.Compiler/IR/IrEqualityClassifier.cs
@@ -1,0 +1,105 @@
+namespace Metano.Compiler.IR;
+
+/// <summary>
+/// Single source of truth for the per-field equality strategy the
+/// record-synthesis bridge picks (and the runtime-requirement scanner
+/// mirrors). Keeping the decision in one place avoids the two callers
+/// drifting and emitting an unused <c>valueEquals</c> import (or the
+/// reverse — emitting the call without the import).
+///
+/// <para>
+/// "Strict" means <c>===</c> on the TS side: the field is either a
+/// real JS primitive, an enum / branded primitive that lowers to one,
+/// a bare type parameter (no shape known at compile time), or a
+/// reference-typed collection where C#'s
+/// <c>EqualityComparer&lt;T&gt;.Default</c> would also fall back to
+/// reference equality.
+/// </para>
+/// <para>
+/// "Value" means <c>valueEquals(a, b)</c>: the field is a JS object
+/// wrapper carrying its own <c>equals</c> contract — Decimal,
+/// Temporal, the runtime UUID, nested transpiled records, plain
+/// classes / structs the user authored, or tuples (which compare
+/// element-wise on the C# side).
+/// </para>
+/// </summary>
+public static class IrEqualityClassifier
+{
+    /// <summary>
+    /// True when the field's lowered surface uses <c>===</c> in the
+    /// synthesized record <c>equals</c> body. False routes through the
+    /// runtime <c>valueEquals</c> helper.
+    /// </summary>
+    public static bool UseStrictEquality(IrTypeRef? type) =>
+        type switch
+        {
+            null => true,
+            IrPrimitiveTypeRef p => UseStrictEqualityForPrimitive(p.Primitive),
+            IrTypeParameterRef => true,
+            IrNullableTypeRef nullable => UseStrictEquality(nullable.Inner),
+            IrNamedTypeRef named => UseStrictEqualityForNamed(named),
+            // Collection-like / function-like / reference shapes —
+            // C#'s default equality comparer falls back to reference
+            // equality for these unless the user overrides it. Preserve
+            // the same semantics here so a record carrying an
+            // <c>int[]</c> / <c>List&lt;T&gt;</c> / <c>Func&lt;…&gt;</c>
+            // does not silently start comparing structurally.
+            IrArrayTypeRef => true,
+            IrMapTypeRef => true,
+            IrSetTypeRef => true,
+            IrIterableTypeRef => true,
+            IrGeneratorTypeRef => true,
+            IrPromiseTypeRef => true,
+            IrFunctionTypeRef => true,
+            IrKeyValuePairTypeRef => true,
+            IrGroupingTypeRef => true,
+            // Tuples compare element-wise in C#; the runtime helper
+            // walks them recursively, matching that contract.
+            IrTupleTypeRef => false,
+            // Unknown shape: be conservative and stick with === so we
+            // never synthesize a more lenient comparison than C# would.
+            _ => true,
+        };
+
+    /// <summary>
+    /// JS treats some C# primitives as object values at runtime — the
+    /// BCL mappings lower <c>Decimal</c> to <c>decimal.js</c>'s
+    /// <c>Decimal</c> class, the date / time family to Temporal
+    /// objects, and <c>Guid</c> to the runtime's <c>UUID</c> class.
+    /// Those wrappers expose <c>equals</c> contracts and need to
+    /// route through <c>valueEquals</c>. <c>Object</c> joins them so
+    /// boxed value-equal instances compare as <c>object.Equals</c>
+    /// would on the C# side. Everything else is a real JS primitive
+    /// where <c>===</c> is correct and faster.
+    /// </summary>
+    private static bool UseStrictEqualityForPrimitive(IrPrimitive p) =>
+        p switch
+        {
+            IrPrimitive.Decimal => false,
+            IrPrimitive.Guid => false,
+            IrPrimitive.DateTime => false,
+            IrPrimitive.DateTimeOffset => false,
+            IrPrimitive.DateOnly => false,
+            IrPrimitive.TimeOnly => false,
+            IrPrimitive.TimeSpan => false,
+            IrPrimitive.Object => false,
+            _ => true,
+        };
+
+    /// <summary>
+    /// Named types lower to a real TS class / type alias / interface.
+    /// Enums and branded primitives compare strictly because the
+    /// runtime value is the underlying primitive; everything else
+    /// (record / class / struct / interface / exception / delegate)
+    /// gets routed through <c>valueEquals</c> so user types carrying
+    /// their own <c>equals</c> contract win, and types without one
+    /// fall back to structural compare via the runtime helper —
+    /// matching what <c>object.Equals</c> dispatches to on the C#
+    /// side.
+    /// </summary>
+    private static bool UseStrictEqualityForNamed(IrNamedTypeRef named) =>
+        named.Semantics?.Kind
+            is IrNamedTypeKind.StringEnum
+                or IrNamedTypeKind.NumericEnum
+                or IrNamedTypeKind.Branded;
+}

--- a/targets/js/metano-runtime/src/system/equality.ts
+++ b/targets/js/metano-runtime/src/system/equality.ts
@@ -3,11 +3,11 @@
  * Mirror the C# .NET semantics: structural equality for compounds, NaN-equals-NaN for
  * floats, custom `equals(other)` / `hashCode()` methods on user types take precedence.
  *
- * These are utility helpers for user code — the compiler does NOT call them. Generated
- * record classes have their own inline `equals(other)` / `hashCode()` methods that
- * compare each captured constructor parameter directly. Use these when you have an
- * arbitrary value of unknown shape and need a structural compare or a content-based
- * hash key (e.g., to feed into a `HashSet<T>` over plain object literals).
+ * The compiler also calls into <see cref="valueEquals"/> from synthesized record
+ * `equals` methods whenever a constructor parameter has a non-primitive type that
+ * exposes a value-equality contract (Decimal, Temporal types, nested records, …).
+ * The previous lowering used `===` for every field which silently diverged from C#
+ * semantics for value-wrapper types — see #202.
  */
 import { HashCode } from "./hash-code.ts";
 
@@ -169,3 +169,12 @@ export function hashCode(value: unknown): number {
   // Primitives.
   return HashCode.combine(value);
 }
+
+/**
+ * Alias the compiler emits inside synthesized record `equals` methods.
+ * Same contract as <see cref="equals"/>; the rename keeps the call
+ * sites readable next to the surrounding `equals(other)` method
+ * declaration (a bare `equals(this.x, other.x)` would shadow into a
+ * recursive method-call ambiguity for human readers).
+ */
+export const valueEquals = equals;

--- a/targets/js/metano-runtime/src/system/equality.ts
+++ b/targets/js/metano-runtime/src/system/equality.ts
@@ -3,7 +3,7 @@
  * Mirror the C# .NET semantics: structural equality for compounds, NaN-equals-NaN for
  * floats, custom `equals(other)` / `hashCode()` methods on user types take precedence.
  *
- * The compiler also calls into <see cref="valueEquals"/> from synthesized record
+ * The compiler also calls into {@link valueEquals} from synthesized record
  * `equals` methods whenever a constructor parameter has a non-primitive type that
  * exposes a value-equality contract (Decimal, Temporal types, nested records, …).
  * The previous lowering used `===` for every field which silently diverged from C#
@@ -172,7 +172,7 @@ export function hashCode(value: unknown): number {
 
 /**
  * Alias the compiler emits inside synthesized record `equals` methods.
- * Same contract as <see cref="equals"/>; the rename keeps the call
+ * Same contract as {@link equals}; the rename keeps the call
  * sites readable next to the surrounding `equals(other)` method
  * declaration (a bare `equals(this.x, other.x)` would shadow into a
  * recursive method-call ambiguity for human readers).

--- a/targets/js/sample-issue-tracker/src/issues/domain/comment.ts
+++ b/targets/js/sample-issue-tracker/src/issues/domain/comment.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
 import type { Temporal } from "@js-temporal/polyfill";
-import { HashCode } from "metano-runtime";
+import { HashCode, valueEquals } from "metano-runtime";
 import { UserId } from "#/shared-kernel";
 
 export class Comment {
@@ -20,7 +20,7 @@ export class Comment {
       other instanceof Comment &&
       this.authorId === other.authorId &&
       this.message === other.message &&
-      this.createdAt === other.createdAt &&
+      valueEquals(this.createdAt, other.createdAt) &&
       this.isSystem === other.isSystem
     );
   }

--- a/targets/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
+++ b/targets/js/sample-issue-tracker/src/issues/domain/issue-snapshot.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
 import type { Temporal } from "@js-temporal/polyfill";
-import { HashCode } from "metano-runtime";
+import { HashCode, valueEquals } from "metano-runtime";
 import type { Decimal } from "decimal.js";
 import type { UserId } from "#/shared-kernel";
 import type { Comment } from "./comment";
@@ -36,9 +36,9 @@ export class IssueSnapshot {
       this.status === other.status &&
       this.assigneeId === other.assigneeId &&
       this.sprintKey === other.sprintKey &&
-      this.createdAt === other.createdAt &&
-      this.updatedAt === other.updatedAt &&
-      this.estimatedHours === other.estimatedHours &&
+      valueEquals(this.createdAt, other.createdAt) &&
+      valueEquals(this.updatedAt, other.updatedAt) &&
+      valueEquals(this.estimatedHours, other.estimatedHours) &&
       this.comments === other.comments
     );
   }

--- a/targets/js/sample-issue-tracker/src/shared-kernel/page-result.ts
+++ b/targets/js/sample-issue-tracker/src/shared-kernel/page-result.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
-import { HashCode } from "metano-runtime";
+import { HashCode, valueEquals } from "metano-runtime";
 import type { PageRequest } from "./page-request";
 
 export class PageResult<T> {
@@ -22,7 +22,7 @@ export class PageResult<T> {
       other instanceof PageResult &&
       this.items === other.items &&
       this.totalCount === other.totalCount &&
-      this.page === other.page
+      valueEquals(this.page, other.page)
     );
   }
 

--- a/targets/js/sample-queryable-sqlite/src/product.ts
+++ b/targets/js/sample-queryable-sqlite/src/product.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/complexity/noUselessConstructor: explicit shape preserved by transpiler */
-import { HashCode } from "metano-runtime";
+import { HashCode, valueEquals } from "metano-runtime";
 import type { Decimal } from "decimal.js";
 
 export class Product {
@@ -18,7 +18,7 @@ export class Product {
       this.id === other.id &&
       this.name === other.name &&
       this.displayName === other.displayName &&
-      this.unitPrice === other.unitPrice &&
+      valueEquals(this.unitPrice, other.unitPrice) &&
       this.stockCount === other.stockCount &&
       this.isActive === other.isActive
     );

--- a/tests/Metano.Tests/EndToEndOutputTests.cs
+++ b/tests/Metano.Tests/EndToEndOutputTests.cs
@@ -109,14 +109,14 @@ public class EndToEndOutputTests
         // regression in the multi-type emission, decimal mapping, or self-import
         // elision shows up as a clear diff.
         var expected =
-            "import { HashCode } from \"metano-runtime\";\n"
+            "import { HashCode, valueEquals } from \"metano-runtime\";\n"
             + "import { Decimal } from \"decimal.js\";\n"
             + "\n"
             + "export class Issue {\n"
             + "  constructor(readonly title: string, readonly status: IssueStatus, readonly estimatedCost: Decimal) { }\n"
             + "\n"
             + "  equals(other: any): boolean {\n"
-            + "    return other instanceof Issue && this.title === other.title && this.status === other.status && this.estimatedCost === other.estimatedCost;\n"
+            + "    return other instanceof Issue && this.title === other.title && this.status === other.status && valueEquals(this.estimatedCost, other.estimatedCost);\n"
             + "  }\n"
             + "\n"
             + "  hashCode(): number {\n"

--- a/tests/Metano.Tests/RecordValueEqualityTests.cs
+++ b/tests/Metano.Tests/RecordValueEqualityTests.cs
@@ -28,7 +28,9 @@ public class RecordValueEqualityTests
         );
 
         var output = result["money.ts"];
-        await Assert.That(output).Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
+        await Assert
+            .That(output)
+            .Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
         await Assert.That(output).Contains("valueEquals(this.amount, other.amount)");
         // Plain primitives stay on `===` so the cheap path keeps working.
         await Assert.That(output).Contains("this.currency === other.currency");
@@ -47,7 +49,9 @@ public class RecordValueEqualityTests
         );
 
         var output = result["event.ts"];
-        await Assert.That(output).Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
+        await Assert
+            .That(output)
+            .Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
         await Assert.That(output).Contains("valueEquals(this.when, other.when)");
     }
 

--- a/tests/Metano.Tests/RecordValueEqualityTests.cs
+++ b/tests/Metano.Tests/RecordValueEqualityTests.cs
@@ -1,0 +1,93 @@
+namespace Metano.Tests;
+
+/// <summary>
+/// Pins the synthesized <c>equals</c> shape for record positional
+/// parameters whose lowered TS surface needs structural comparison
+/// instead of strict equality (#202).
+///
+/// <para>
+/// Decimal, Guid, and the Temporal-mapped date / time primitives all
+/// flow through JS object wrappers (<c>Decimal</c> from
+/// <c>decimal.js</c>; the runtime <c>UUID</c>; <c>Temporal.PlainDate</c>
+/// and friends) — comparing them with <c>===</c> would silently
+/// diverge from C# value-equality semantics. The compiler now emits
+/// <c>valueEquals(this.x, other.x)</c> for those fields, paired with
+/// a runtime import line.
+/// </para>
+/// </summary>
+public class RecordValueEqualityTests
+{
+    [Test]
+    public async Task DecimalField_LowersToValueEquals()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public record Money(decimal Amount, string Currency);
+            """
+        );
+
+        var output = result["money.ts"];
+        await Assert.That(output).Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
+        await Assert.That(output).Contains("valueEquals(this.amount, other.amount)");
+        // Plain primitives stay on `===` so the cheap path keeps working.
+        await Assert.That(output).Contains("this.currency === other.currency");
+    }
+
+    [Test]
+    public async Task DateTimeField_LowersToValueEquals()
+    {
+        var result = TranspileHelper.Transpile(
+            """
+            using System;
+
+            [Transpile]
+            public record Event(string Name, DateTime When);
+            """
+        );
+
+        var output = result["event.ts"];
+        await Assert.That(output).Contains("import { HashCode, valueEquals } from \"metano-runtime\"");
+        await Assert.That(output).Contains("valueEquals(this.when, other.when)");
+    }
+
+    [Test]
+    public async Task NestedRecordField_LowersToValueEquals()
+    {
+        // A nested transpiled record carries its own `equals` contract
+        // — the parent record's synthesized check should delegate via
+        // valueEquals so two semantically equal sub-records compare
+        // equal even when they are different instances.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public record Address(string Street, string City);
+
+            [Transpile]
+            public record Customer(string Name, Address Home);
+            """
+        );
+
+        var output = result["customer.ts"];
+        await Assert.That(output).Contains("valueEquals(this.home, other.home)");
+    }
+
+    [Test]
+    public async Task PrimitiveOnlyRecord_KeepsStrictEquality()
+    {
+        // No object-wrapper field → no valueEquals import + strictly
+        // primitive comparisons. Validates the negative case so the
+        // import line doesn't leak into records that don't need it.
+        var result = TranspileHelper.Transpile(
+            """
+            [Transpile]
+            public record PointI(int X, int Y);
+            """
+        );
+
+        var output = result["point-i.ts"];
+        await Assert.That(output).DoesNotContain("valueEquals");
+        await Assert.That(output).Contains("this.x === other.x");
+        await Assert.That(output).Contains("this.y === other.y");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #202. C# record positional parameters whose lowered TS type is a JS object-wrapper (\`Decimal\` from \`decimal.js\`, Temporal date / time, the runtime \`UUID\`, nested transpiled records, plain classes) used to compare with strict \`===\` inside the synthesized \`equals\` method. Two numerically equal \`Decimal\` instances are different objects, so the record's equals contract silently diverged from C# value-equality semantics.

The compiler now picks a per-field comparison strategy based on the IR type and emits \`valueEquals(this.x, other.x)\` for wrapper fields, paired with a runtime import line.

## Strategy

| IR type                                            | Comparison                  |
|----------------------------------------------------|-----------------------------|
| \`Boolean\`, \`Byte\`, \`Int16/32/64\`, \`Float32/64\`, \`BigInteger\`, \`String\`, \`Char\`, \`Object\` | \`===\` (real JS primitives) |
| \`Decimal\`, \`Guid\`, \`DateTime\`, \`DateTimeOffset\`, \`DateOnly\`, \`TimeOnly\`, \`TimeSpan\` | \`valueEquals\` (JS object wrappers) |
| \`StringEnum\`, \`NumericEnum\`, \`Branded\`         | \`===\`                      |
| Nested transpiled records / classes / interfaces   | \`valueEquals\`              |
| Type parameters (\`T\`, \`TKey\`)                    | \`===\` (preserve baseline)  |
| Arrays, maps, sets, iterables, tuples, …           | \`valueEquals\`              |

\`valueEquals\` short-circuits on \`a === b\` before delegating to the wrapper's \`.equals(other)\` method, so the wrapper-aware path stays correct for primitives that happen to flow through a generic field.

## What changed

### Compiler

- **\`IrToTsRecordSynthesisBridge\`**: per-field equality dispatch. Looks up the IR type for each ctor parameter by positional index (TS names are camelCased while the IR keeps the C# casing) and routes wrapper fields through \`valueEquals\`.
- **\`IrRuntimeRequirementScanner\`**: mirrors the bridge's strictness whitelist so a record carrying any non-strict field emits \`IrRuntimeRequirement(\"ValueEquals\")\`.
- **\`IrRuntimeRequirementToTsImport\`**: maps the new requirement to \`import { valueEquals } from \"metano-runtime\"\`.

### Runtime

- **\`metano-runtime/system/equality.ts\`**: re-exports the existing \`equals\` helper as \`valueEquals\` so generated call sites read unambiguously next to the surrounding \`equals\` method declaration. Documented the new compiler contract.

### Samples

- \`sample-queryable-sqlite/src/product.ts\` regenerates with \`valueEquals(this.unitPrice, other.unitPrice)\` (Decimal field). All other samples regenerate unchanged because none had a wrapper field on the synthesized records.

## Test plan

- [x] **978 .NET tests pass** (was 974, +4 new \`RecordValueEqualityTests\` covering Decimal, DateTime, nested record, primitive-only baseline). \`EndToEndOutputTests\` golden refreshed for the Decimal field.
- [x] **246 runtime tests pass** (no behavior change — \`valueEquals\` is just a re-export).
- [x] No regressions in \`sample-todo\` (18), \`sample-issue-tracker\` (142), \`sample-queryable-arrays\` (5), \`sample-queryable-sqlite\` (7), \`sample-todo-service\` (33).

## Out of scope

- \`hashCode\` synthesizing a wrapper-aware hash. The current \`HashCode.add\` helper relies on the field's own \`hashCode()\` contract for objects, which Decimal / Temporal already implement, so this PR keeps the hashing path untouched. A follow-up could enforce the same dispatch for symmetry.
- Cross-target story. Dart / Kotlin targets have their own equality conventions; this PR only updates the TypeScript bridge.