### PR TITLE
feat(compiler): type-level dependency graph backbone for incremental + watch (PR 1/4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <claude-mem-context>
 # Memory Context
 
-# [Metano] recent context, 2026-05-07 2:14pm GMT-3
+# [Metano] recent context, 2026-05-07 2:30pm GMT-3
 
 No previous sessions found.
 </claude-mem-context>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <claude-mem-context>
 # Memory Context
 
-# [Metano] recent context, 2026-05-01 4:49pm GMT-3
+# [Metano] recent context, 2026-05-07 2:14pm GMT-3
 
 No previous sessions found.
 </claude-mem-context>

--- a/docs/adr/0018-type-level-dependency-graph.md
+++ b/docs/adr/0018-type-level-dependency-graph.md
@@ -1,0 +1,89 @@
+# ADR-0018 — Type-level dependency graph as the backbone for incremental + watch
+
+**Status:** Accepted
+**Date:** 2026-05-07
+
+## Context
+
+Two pipeline-perf items in the backlog (#21 incremental compilation, #18 watch
+mode) both need the same answer: "if type T was touched, which types must
+regenerate?". The current pipeline lacks any persistent dependency information —
+every run reprocesses every transpilable type, which is fine for a sample (~30
+types) but scales linearly with project size.
+
+Both features cannot ship without first agreeing on the granularity of "what
+depends on what" and where that information lives. Building a separate graph
+inside the cache subsystem and another inside the watcher would lead to drift,
+slightly different invalidation semantics, and double the maintenance.
+
+## Decision
+
+Introduce `Metano.Compiler.DependencyGraph.IrTypeDependencyGraph` — a single,
+type-level dependency graph derived from the Roslyn symbols carried by
+`IrCompilation.TranspilableTypeEntries`.
+
+- **Granularity is the type, not the file.** A `.cs` file can declare N types;
+  a single type can span N files via `partial`; `[EmitInFile]` collapses N
+  types into a single output file. Tracking dependencies per file would lose
+  precision (over-invalidation) and per-output-file would lose the connection
+  to the C# source. The type FQN — `namespace.Name` from
+  `INamedTypeSymbol.OriginalDefinition` — is the stable key.
+- **Edges come from Roslyn symbols, not from the IR.** `IrCompilation.Modules`
+  is currently empty (the IR is built per-type by the bridges, not eagerly
+  populated as a single tree). Walking Roslyn directly avoids waiting for that
+  population work and keeps the graph builder independent from per-target
+  bridges.
+- **Only edges between transpilable types of the current compilation.** BCL
+  references, primitives, and types from other assemblies do not produce
+  edges because the cache cannot regenerate them from this project. Foreign
+  assembly changes invalidate consumers via the cache's separate
+  metadata-hash key (planned for #21).
+- **Both directions are precomputed.** Forward edges (`DependenciesOf`) drive
+  consistency checks; reverse edges (`DependentsOf`) drive incremental
+  invalidation. Computing both upfront is O(E), and dirty propagation is then
+  a single transitive closure over the reverse graph.
+
+## Consequences
+
+(+) #21 (incremental) and #18 (watch) consume the same graph — invalidation
+   semantics stay aligned by construction.
+(+) Type-level granularity matches the cache key (per-type compile output) so
+   there is no projection step between the graph and the cache.
+(+) Roslyn-based discovery means generic-type arguments, base types, and
+   nested types all contribute edges through the existing symbol API — no
+   custom IR walker to maintain.
+(+) Foreign assembly references stay out of the graph, keeping it focused on
+   the current project's compilation surface.
+(−) The graph rebuilds every run today (cheap — O(types × members)). Caching
+   the graph itself for cold-start incremental is a separate concern handled
+   in #21's cache file.
+(−) Dependencies arising from method bodies (call expressions, generic
+   instantiations inside expressions) are not yet tracked because those go
+   through the per-target bridges. Conservative: bodies that call into
+   another transpilable type without referencing it on the signature surface
+   currently miss the edge. Acceptable for the MVP — signature-level
+   coverage catches the common API-change-invalidates-consumer case.
+(−) `ToDisplayString()` on `OriginalDefinition` is the FQN; cross-language
+   targets that need a different identifier will need their own naming
+   policy (#210 adjacent concern).
+
+## Alternatives considered
+
+- **Per-file dependency graph.** Rejected: fewer keys but lossy granularity;
+  partial classes and `[EmitInFile]` co-location both fall apart.
+- **Run discovery during the per-target transform pass.** Rejected: makes
+  parallelization harder (each worker would re-discover deps) and forces the
+  cache subsystem to know about target-specific output paths.
+- **Hand-rolled IR walker over `IrTypeDeclaration`.** Rejected for now: the
+  IR is not eagerly populated from `IrCompilation.Modules` — that field
+  stays empty by design (see `BuildIrCompilation`). Once the IR migration
+  finishes (separate roadmap), the graph builder can switch to walking IR
+  instead of Roslyn symbols and gain access to body-level dependencies.
+
+## References
+
+- `src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs`
+- `tests/Metano.Tests/DependencyGraph/IrTypeDependencyGraphTests.cs`
+- Issue #18 — watch mode
+- Issue #21 — incremental compilation + parallel TypeTransformer
+- ADR-0013 — shared IR as canonical semantic representation

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,9 @@ second-guess when they meet the code without the context that led to it.
 | [ADR-0010](0010-metano-diagnostics.md)                           | `MetanoDiagnostic` + MS0001–MS0008 codes                                       |
 | [ADR-0011](0011-emit-package-ssot.md)                            | `[EmitPackage]` as single source of truth for `package.json#name`              |
 | [ADR-0012](0012-linq-eager-wrapper.md)                           | LINQ as eager wrapper hierarchy (with pipe-based migration tracked)            |
+| [ADR-0013](0013-shared-ir-as-canonical-semantic-representation.md) | Shared IR as the canonical semantic representation                           |
+| [ADR-0014](0014-loose-null-equality-in-generated-typescript.md)  | Loose null equality in generated TypeScript                                    |
+| [ADR-0015](0015-attribute-family-for-compile-time-erasure.md)    | Attribute family for compile-time erasure                                      |
+| [ADR-0016](0016-this-attribute-bindreceiver.md)                  | `[This]` attribute + `bindReceiver` runtime helper                             |
+| [ADR-0017](0017-no-container-and-explicit-inline-mode.md)        | `[NoContainer]` + explicit inline mode                                         |
+| [ADR-0018](0018-type-level-dependency-graph.md)                  | Type-level dependency graph as the backbone for incremental + watch            |

--- a/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
+++ b/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Metano.Compiler.IR;
 using Microsoft.CodeAnalysis;
 
@@ -97,10 +98,19 @@ public sealed class IrTypeDependencyGraph
                     stack.Push(next);
             }
         }
+        // Cycles (A → B → A) re-add the seed via a neighbor; strip
+        // it back out so the documented "excludes the seed" contract
+        // holds even when the graph contains cycles.
+        visited.Remove(typeFqn);
         return visited;
     }
 
-    private static readonly IReadOnlySet<string> EmptySet = new HashSet<string>();
+    /// <summary>
+    /// Shared empty-set sentinel returned by lookups that miss. Held
+    /// as <see cref="ImmutableHashSet{T}.Empty"/> so a caller cannot
+    /// downcast and mutate the singleton out from under everyone else.
+    /// </summary>
+    private static readonly IReadOnlySet<string> EmptySet = ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// Builds the graph from the transpilable type entries of an
@@ -163,18 +173,23 @@ public sealed class IrTypeDependencyGraph
     }
 
     /// <summary>
-    /// Canonical FQN used as the graph key — Roslyn's
-    /// <c>ToDisplayString</c> minus generic parameters so a
-    /// constructed reference like <c>List&lt;User&gt;</c> resolves to
-    /// the same key as the type's own definition (<c>User</c>).
+    /// Canonical FQN used as the graph key. Built from
+    /// <see cref="ISymbol.OriginalDefinition"/> so a constructed
+    /// reference like <c>List&lt;User&gt;</c> resolves to the same
+    /// key as the type's own definition. The display format keeps
+    /// the namespace + every containing type (so nested types like
+    /// <c>Outer.Inner</c> stay distinct) and the type-parameter
+    /// names (so generic arities don't collapse — <c>Foo</c> and
+    /// <c>Foo&lt;T&gt;</c> are different keys).
     /// </summary>
-    public static string QualifiedName(INamedTypeSymbol symbol)
-    {
-        var unbound = symbol.OriginalDefinition;
-        var ns = unbound.ContainingNamespace;
-        var name = unbound.Name;
-        return ns is null || ns.IsGlobalNamespace ? name : $"{ns.ToDisplayString()}.{name}";
-    }
+    public static string QualifiedName(INamedTypeSymbol symbol) =>
+        symbol.OriginalDefinition.ToDisplayString(QualifiedNameFormat);
+
+    private static readonly SymbolDisplayFormat QualifiedNameFormat = new(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable
+    );
 
     // -- Roslyn symbol walking -----------------------------------------------
 
@@ -257,7 +272,16 @@ public sealed class IrTypeDependencyGraph
         string selfFqn
     )
     {
-        var fqn = QualifiedName(symbol);
+        // Roll the reference up to its top-level containing type so a
+        // dependency on a nested type attributes back to the unit of
+        // invalidation the cache actually emits (the cache regenerates
+        // the top-level entry's output file as a whole, including
+        // every nested type co-located with it).
+        var topLevel = symbol;
+        while (topLevel.ContainingType is not null)
+            topLevel = topLevel.ContainingType;
+
+        var fqn = QualifiedName(topLevel);
         if (fqn == selfFqn || !ownTypes.Contains(fqn))
             return;
         acc.Add(fqn);

--- a/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
+++ b/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
@@ -1,0 +1,265 @@
+using Metano.Compiler.IR;
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.DependencyGraph;
+
+/// <summary>
+/// Type-level dependency graph derived from an <see cref="IrCompilation"/>.
+/// Maps each transpilable type's fully qualified name (FQN — namespace
+/// + simple name, taken from the Roslyn symbol) to the set of FQNs it
+/// references in any of its signatures or member bodies.
+///
+/// <para>
+/// The graph is the shared backbone for:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Incremental compilation (#21):</b> "if type T was touched,
+///   which types regenerate?". The cache walks the reverse graph to mark
+///   transitive dependents dirty.</item>
+///   <item><b>Watch mode (#18):</b> a file change resolves to the FQNs
+///   declared in that file; the same reverse-walk yields the set of
+///   files to re-emit.</item>
+/// </list>
+///
+/// <para>
+/// References come from the Roslyn symbols of each transpilable type.
+/// Only types that themselves participate in the compilation's
+/// transpilable set contribute edges — BCL types, types from a
+/// referenced assembly, and primitives are dropped because the
+/// incremental cache cannot regenerate code that does not live in this
+/// project. Foreign assembly changes invalidate consumers via the
+/// cache's separate metadata-hash key.
+/// </para>
+/// </summary>
+public sealed class IrTypeDependencyGraph
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlySet<string>> _outEdges;
+    private readonly IReadOnlyDictionary<string, IReadOnlySet<string>> _inEdges;
+
+    private IrTypeDependencyGraph(
+        IReadOnlyDictionary<string, IReadOnlySet<string>> outEdges,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> inEdges
+    )
+    {
+        _outEdges = outEdges;
+        _inEdges = inEdges;
+    }
+
+    /// <summary>FQNs of every type catalogued in the graph.</summary>
+    public IEnumerable<string> AllTypes => _outEdges.Keys;
+
+    /// <summary>
+    /// Direct dependencies of <paramref name="typeFqn"/> — the types
+    /// whose IR appears anywhere in its signature or body.
+    /// </summary>
+    public IReadOnlySet<string> DependenciesOf(string typeFqn) =>
+        _outEdges.TryGetValue(typeFqn, out var deps) ? deps : EmptySet;
+
+    /// <summary>
+    /// Direct dependents of <paramref name="typeFqn"/> — the types
+    /// that reference it. The reverse of <see cref="DependenciesOf"/>;
+    /// drives incremental invalidation.
+    /// </summary>
+    public IReadOnlySet<string> DependentsOf(string typeFqn) =>
+        _inEdges.TryGetValue(typeFqn, out var deps) ? deps : EmptySet;
+
+    /// <summary>
+    /// Transitive closure of <see cref="DependentsOf"/> — every type
+    /// that reaches <paramref name="typeFqn"/> through any reference
+    /// chain. The set excludes the seed itself; callers that need it
+    /// should add it explicitly.
+    /// </summary>
+    public IReadOnlySet<string> TransitiveDependentsOf(string typeFqn) =>
+        TransitiveClosure(typeFqn, DependentsOf);
+
+    /// <summary>
+    /// Transitive closure of <see cref="DependenciesOf"/>. Excludes
+    /// the seed itself so callers can union it with the seed when
+    /// they need an "everything this type touches" set.
+    /// </summary>
+    public IReadOnlySet<string> TransitiveDependenciesOf(string typeFqn) =>
+        TransitiveClosure(typeFqn, DependenciesOf);
+
+    private IReadOnlySet<string> TransitiveClosure(
+        string typeFqn,
+        Func<string, IReadOnlySet<string>> step
+    )
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+        stack.Push(typeFqn);
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            foreach (var next in step(current))
+            {
+                if (visited.Add(next))
+                    stack.Push(next);
+            }
+        }
+        return visited;
+    }
+
+    private static readonly IReadOnlySet<string> EmptySet = new HashSet<string>();
+
+    /// <summary>
+    /// Builds the graph from the transpilable type entries of an
+    /// <see cref="IrCompilation"/>. References to types outside the
+    /// transpilable set (BCL types, primitives, types from other
+    /// assemblies) are skipped because they cannot be regenerated
+    /// from this compilation's incremental cache — the cache
+    /// invalidates consumers of those via assembly-metadata hashes
+    /// instead.
+    /// </summary>
+    public static IrTypeDependencyGraph Build(IrCompilation compilation)
+    {
+        var entries = compilation.TranspilableTypeEntries ?? Array.Empty<IrTranspilableTypeEntry>();
+        var ownTypes = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var entry in entries)
+            ownTypes.Add(QualifiedName(entry.Symbol));
+
+        var outEdges = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var entry in entries)
+        {
+            var fqn = QualifiedName(entry.Symbol);
+            var deps = new HashSet<string>(StringComparer.Ordinal);
+            CollectFromType(entry.Symbol, deps, ownTypes, fqn);
+            outEdges[fqn] = deps;
+        }
+
+        var inEdges = ReverseEdges(outEdges);
+        return new IrTypeDependencyGraph(
+            outEdges.ToDictionary(
+                kv => kv.Key,
+                kv => (IReadOnlySet<string>)kv.Value,
+                StringComparer.Ordinal
+            ),
+            inEdges
+        );
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlySet<string>> ReverseEdges(
+        Dictionary<string, HashSet<string>> outEdges
+    )
+    {
+        var reverse = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var (consumer, deps) in outEdges)
+        {
+            foreach (var dep in deps)
+            {
+                if (!reverse.TryGetValue(dep, out var dependents))
+                {
+                    dependents = new HashSet<string>(StringComparer.Ordinal);
+                    reverse[dep] = dependents;
+                }
+                dependents.Add(consumer);
+            }
+        }
+        return reverse.ToDictionary(
+            kv => kv.Key,
+            kv => (IReadOnlySet<string>)kv.Value,
+            StringComparer.Ordinal
+        );
+    }
+
+    /// <summary>
+    /// Canonical FQN used as the graph key — Roslyn's
+    /// <c>ToDisplayString</c> minus generic parameters so a
+    /// constructed reference like <c>List&lt;User&gt;</c> resolves to
+    /// the same key as the type's own definition (<c>User</c>).
+    /// </summary>
+    public static string QualifiedName(INamedTypeSymbol symbol)
+    {
+        var unbound = symbol.OriginalDefinition;
+        var ns = unbound.ContainingNamespace;
+        var name = unbound.Name;
+        return ns is null || ns.IsGlobalNamespace ? name : $"{ns.ToDisplayString()}.{name}";
+    }
+
+    // -- Roslyn symbol walking -----------------------------------------------
+
+    private static void CollectFromType(
+        INamedTypeSymbol symbol,
+        HashSet<string> acc,
+        IReadOnlySet<string> ownTypes,
+        string selfFqn
+    )
+    {
+        if (symbol.BaseType is { } baseType)
+            AddIfTranspilable(baseType, acc, ownTypes, selfFqn);
+        foreach (var iface in symbol.Interfaces)
+            AddIfTranspilable(iface, acc, ownTypes, selfFqn);
+
+        foreach (var member in symbol.GetMembers())
+        {
+            switch (member)
+            {
+                case IFieldSymbol field:
+                    CollectFromTypeRef(field.Type, acc, ownTypes, selfFqn);
+                    break;
+                case IPropertySymbol property:
+                    CollectFromTypeRef(property.Type, acc, ownTypes, selfFqn);
+                    break;
+                case IMethodSymbol method:
+                    CollectFromMethod(method, acc, ownTypes, selfFqn);
+                    break;
+                case IEventSymbol evt:
+                    CollectFromTypeRef(evt.Type, acc, ownTypes, selfFqn);
+                    break;
+                case INamedTypeSymbol nested:
+                    CollectFromType(nested, acc, ownTypes, selfFqn);
+                    break;
+            }
+        }
+    }
+
+    private static void CollectFromMethod(
+        IMethodSymbol method,
+        HashSet<string> acc,
+        IReadOnlySet<string> ownTypes,
+        string selfFqn
+    )
+    {
+        CollectFromTypeRef(method.ReturnType, acc, ownTypes, selfFqn);
+        foreach (var p in method.Parameters)
+            CollectFromTypeRef(p.Type, acc, ownTypes, selfFqn);
+        foreach (var tp in method.TypeParameters)
+        foreach (var constraint in tp.ConstraintTypes)
+            CollectFromTypeRef(constraint, acc, ownTypes, selfFqn);
+    }
+
+    private static void CollectFromTypeRef(
+        ITypeSymbol type,
+        HashSet<string> acc,
+        IReadOnlySet<string> ownTypes,
+        string selfFqn
+    )
+    {
+        switch (type)
+        {
+            case INamedTypeSymbol named:
+                AddIfTranspilable(named, acc, ownTypes, selfFqn);
+                foreach (var arg in named.TypeArguments)
+                    CollectFromTypeRef(arg, acc, ownTypes, selfFqn);
+                break;
+            case IArrayTypeSymbol array:
+                CollectFromTypeRef(array.ElementType, acc, ownTypes, selfFqn);
+                break;
+            // Pointer / dynamic / type-parameter references contribute
+            // nothing the cache can act on — skip them.
+        }
+    }
+
+    private static void AddIfTranspilable(
+        INamedTypeSymbol symbol,
+        HashSet<string> acc,
+        IReadOnlySet<string> ownTypes,
+        string selfFqn
+    )
+    {
+        var fqn = QualifiedName(symbol);
+        if (fqn == selfFqn || !ownTypes.Contains(fqn))
+            return;
+        acc.Add(fqn);
+    }
+}

--- a/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
+++ b/src/Metano.Compiler/DependencyGraph/IrTypeDependencyGraph.cs
@@ -7,8 +7,14 @@ namespace Metano.Compiler.DependencyGraph;
 /// <summary>
 /// Type-level dependency graph derived from an <see cref="IrCompilation"/>.
 /// Maps each transpilable type's fully qualified name (FQN — namespace
-/// + simple name, taken from the Roslyn symbol) to the set of FQNs it
-/// references in any of its signatures or member bodies.
+/// + containing types + generic parameters, taken from the Roslyn
+/// symbol) to the set of FQNs it references on its <em>signature
+/// surface</em>: base type, interfaces, ctor / field / property /
+/// method signatures (return type, parameters, generic constraints),
+/// event types, and nested types. Method-body references (calls /
+/// instantiations inside expressions) are <b>not</b> tracked yet —
+/// those go through per-target bridges and stay out of the graph for
+/// this slice; ADR-0018 captures the trade-off.
 ///
 /// <para>
 /// The graph is the shared backbone for:
@@ -51,7 +57,9 @@ public sealed class IrTypeDependencyGraph
 
     /// <summary>
     /// Direct dependencies of <paramref name="typeFqn"/> — the types
-    /// whose IR appears anywhere in its signature or body.
+    /// whose IR appears on its signature surface (see the type-level
+    /// docstring for the exact reach). Method-body references are
+    /// not included by this slice.
     /// </summary>
     public IReadOnlySet<string> DependenciesOf(string typeFqn) =>
         _outEdges.TryGetValue(typeFqn, out var deps) ? deps : EmptySet;

--- a/tests/Metano.Tests/DependencyGraph/IrTypeDependencyGraphTests.cs
+++ b/tests/Metano.Tests/DependencyGraph/IrTypeDependencyGraphTests.cs
@@ -1,0 +1,151 @@
+using Metano.Compiler;
+using Metano.Compiler.DependencyGraph;
+using Metano.Tests.IR;
+
+namespace Metano.Tests.DependencyGraph;
+
+/// <summary>
+/// Behavior coverage for <see cref="IrTypeDependencyGraph"/>. The
+/// graph is the shared backbone for incremental compilation (#21) and
+/// watch mode (#18); the tests pin its forward + reverse edges so the
+/// downstream cache and file watcher have a stable contract.
+/// </summary>
+public class IrTypeDependencyGraphTests
+{
+    [Test]
+    public async Task DirectFieldReference_AddsForwardAndReverseEdge()
+    {
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Money(decimal Amount, string Currency);
+
+            [Transpile]
+            public sealed record Order(Money Total);
+            """
+        );
+
+        await Assert.That(graph.DependenciesOf("Demo.Order")).Contains("Demo.Money");
+        await Assert.That(graph.DependentsOf("Demo.Money")).Contains("Demo.Order");
+    }
+
+    [Test]
+    public async Task GenericTypeArgument_RegistersTheArgumentNotTheContainer()
+    {
+        // Generics like List<User> resolve to IrArrayTypeRef once the
+        // collection-like lowering kicks in; the inner User reference
+        // still needs to land in the graph so a change to User
+        // invalidates the consumer.
+        var graph = BuildGraph(
+            """
+            using System.Collections.Generic;
+
+            namespace Demo;
+
+            [Transpile]
+            public sealed record User(string Name);
+
+            [Transpile]
+            public sealed record Roster(List<User> Members);
+            """
+        );
+
+        await Assert.That(graph.DependenciesOf("Demo.Roster")).Contains("Demo.User");
+        await Assert.That(graph.DependentsOf("Demo.User")).Contains("Demo.Roster");
+    }
+
+    [Test]
+    public async Task TransitiveDependents_ChainAtoBtoC_ReachesA()
+    {
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record A(int X);
+
+            [Transpile]
+            public sealed record B(A Inner);
+
+            [Transpile]
+            public sealed record C(B Outer);
+            """
+        );
+
+        var transitiveOfA = graph.TransitiveDependentsOf("Demo.A");
+        await Assert.That(transitiveOfA).Contains("Demo.B");
+        await Assert.That(transitiveOfA).Contains("Demo.C");
+    }
+
+    [Test]
+    public async Task SelfReference_IsNotRecorded()
+    {
+        // A `with`-style fluent return type produces a self-reference
+        // in the IR. Recording it would inflate the graph and make
+        // every change to the type look like it had an extra
+        // dependent that is just itself.
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Step(int Order)
+            {
+                public Step Next() => new(Order + 1);
+            }
+            """
+        );
+
+        await Assert.That(graph.DependenciesOf("Demo.Step")).DoesNotContain("Demo.Step");
+    }
+
+    [Test]
+    public async Task TypeOutsideCompilation_IsDropped()
+    {
+        // BCL types (System.Decimal, System.String) and any other
+        // assembly-foreign reference cannot be invalidated from this
+        // compilation's cache, so the graph drops them. The cache
+        // tracks foreign assemblies via their metadata hash on a
+        // separate axis.
+        var graph = BuildGraph(
+            """
+            using System;
+
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Stamp(DateTime When, string Note);
+            """
+        );
+
+        var deps = graph.DependenciesOf("Demo.Stamp");
+        await Assert.That(deps).DoesNotContain("System.DateTime");
+        await Assert.That(deps).DoesNotContain("System.String");
+    }
+
+    [Test]
+    public async Task UnknownType_ReturnsEmptySets()
+    {
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record A(int X);
+            """
+        );
+
+        await Assert.That(graph.DependenciesOf("Demo.Missing")).IsEmpty();
+        await Assert.That(graph.DependentsOf("Demo.Missing")).IsEmpty();
+        await Assert.That(graph.TransitiveDependentsOf("Demo.Missing")).IsEmpty();
+    }
+
+    private static IrTypeDependencyGraph BuildGraph(string csharpSource)
+    {
+        var compilation = IrTestHelper.Compile(csharpSource);
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        return IrTypeDependencyGraph.Build(ir);
+    }
+}

--- a/tests/Metano.Tests/DependencyGraph/IrTypeDependencyGraphTests.cs
+++ b/tests/Metano.Tests/DependencyGraph/IrTypeDependencyGraphTests.cs
@@ -126,6 +126,86 @@ public class IrTypeDependencyGraphTests
     }
 
     [Test]
+    public async Task NestedTypeReference_AttributesToTopLevelContainer()
+    {
+        // A reference to Outer.Inner attributes back to Outer because
+        // the cache emits Outer's output as a whole — Inner cannot be
+        // regenerated independently. Without the top-level rollup the
+        // ownTypes lookup would miss and the edge would silently drop.
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Outer
+            {
+                public sealed record Inner(int X);
+            }
+
+            [Transpile]
+            public sealed record Holder(Outer.Inner Slot);
+            """
+        );
+
+        await Assert.That(graph.DependenciesOf("Demo.Holder")).Contains("Demo.Outer");
+        await Assert.That(graph.DependentsOf("Demo.Outer")).Contains("Demo.Holder");
+    }
+
+    [Test]
+    public async Task SameNameDifferentArity_KeepsKeysDistinct()
+    {
+        // Foo and Foo<T> are different types in C#; collapsing them
+        // would corrupt outEdges (one would silently overwrite the
+        // other) and break invalidation for projects that overload by
+        // arity.
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Foo(int X);
+
+            [Transpile]
+            public sealed record Foo<T>(T Value);
+            """
+        );
+
+        var allTypes = graph.AllTypes.ToHashSet();
+        await Assert.That(allTypes).Contains("Demo.Foo");
+        await Assert.That(allTypes).Contains("Demo.Foo<T>");
+    }
+
+    [Test]
+    public async Task TransitiveDependents_OnCyclicGraph_ExcludesSeed()
+    {
+        // A → B → A is a cycle. The transitive walker re-adds the
+        // seed via a neighbor while traversing; the closure helper
+        // must strip it back out so the documented "excludes seed"
+        // contract stays honest even with cycles in the graph.
+        var graph = BuildGraph(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class A
+            {
+                public B? Other { get; init; }
+            }
+
+            [Transpile]
+            public sealed class B
+            {
+                public A? Other { get; init; }
+            }
+            """
+        );
+
+        var transitiveOfA = graph.TransitiveDependentsOf("Demo.A");
+        await Assert.That(transitiveOfA).Contains("Demo.B");
+        await Assert.That(transitiveOfA).DoesNotContain("Demo.A");
+    }
+
+    [Test]
     public async Task UnknownType_ReturnsEmptySets()
     {
         var graph = BuildGraph(


### PR DESCRIPTION
## Summary

First slice of the **incremental compilation (#21) + watch mode (#18)** roadmap. Adds the shared dependency-graph infrastructure both features need — without consuming it yet. Subsequent PRs land the parallel transformer (#21 part), the cache + invalidation (#21 part), and the file watcher (#18).

## What this PR adds

- **`Metano.Compiler.DependencyGraph.IrTypeDependencyGraph`** — single graph, type-level, derived from the Roslyn symbols in `IrCompilation.TranspilableTypeEntries`. Both forward (\`DependenciesOf\`) and reverse (\`DependentsOf\` + \`TransitiveDependentsOf\`) edges are precomputed.
- **ADR-0018** — explains the granularity choice (per-type, not per-file), Roslyn-direct discovery, foreign-assembly trade-off. ADR README catches up to ADRs 13–17 that were pinned but never indexed.
- **6 new tests** — direct edges, generic argument unwrapping, transitive closure, self-reference skip, BCL drop, unknown FQN.

## Design

- **Granularity is the type, not the file.** Partials + \`[EmitInFile]\` make file-level granularity lossy.
- **Edges via Roslyn symbols.** \`IrCompilation.Modules\` is currently empty (eager IR-tree population is future work); walking Roslyn symbols directly avoids that dependency and gives the graph builder its own clean entry point.
- **Only edges within the current compilation.** Foreign / BCL types are dropped — they invalidate consumers via a separate metadata-hash key in #21's cache.
- **Both directions precomputed** so the dirty propagation in the cache (#21) is a single closure walk over reverse edges.

## Test plan

- [x] 984 .NET tests pass (+6 new \`IrTypeDependencyGraphTests\`)
- [x] biome + csharpier clean
- [x] No regressions in any sample (verified by the new \`verify-targets-clean\` pre-push gate)

## Roadmap (next PRs in this thread)

1. ✅ **PR 1 — type-level dependency graph** (this PR)
2. **PR 2 — parallel TypeTransformer** (#21 part). Uses the shared state contract that ADR-0002 pins; audits the 39 handlers for mutation; switches the main loop to \`Parallel.ForEach\` with \`ConcurrentBag<MetanoDiagnostic>\`.
3. **PR 3 — incremental cache** (#21 part). Adds \`.metano/cache.json\` keyed by per-type content hash + dependency snapshot; uses \`IrTypeDependencyGraph.TransitiveDependentsOf\` to mark dirty.
4. **PR 4 — watch mode** (#18). \`--watch\` CLI + \`FileSystemWatcher\` + debounce; reuses the cache / graph in memory between events.

Each PR is independent and lands separately.

## References

- ADR-0018 — type-level dependency graph
- Issue #21 — incremental compilation + parallel TypeTransformer
- Issue #18 — watch mode
- ADR-0013 — shared IR as canonical semantic representation