### PR TITLE
feat(compiler): parallelize TypeTransformer per file group

### DIFF
--- a/docs/adr/0002-handler-decomposition.md
+++ b/docs/adr/0002-handler-decomposition.md
@@ -114,3 +114,26 @@ The decision recorded here (decompose over monolith, compose via parent
 properties, no formal Visitor) was ratified by the Dart target — the same
 shape now lives in `src/Metano.Compiler.Dart/Bridge/` with no TypeScript
 contamination.
+
+## Thread-safety addendum (2026-05, ADR-0020)
+
+`TypeTransformer` now fans out the per-file-group loop across worker
+threads via `Parallel.For` (#21 / ADR-0020). The handler-decomposition
+shape is what makes that safe: every bridge consumes a
+`TypeScriptTransformContext` whose dictionaries / sets / maps are all
+read-only after the setup phase, and per-group mutable scratch state
+(`UsingAliases`, `NamedTypeRenames`) lives on `AsyncLocal<T>` slots
+that flow per worker. The only mutable shared sinks
+(`_diagnostics`, `TypeMappingContext.CrossPackageMisses`,
+`TypeMappingContext.UsedCrossPackages`) are now thread-safe at their
+declaration site (`lock` for the diagnostic list, `ConcurrentDictionary`
+for the cross-package collections).
+
+**Contract for new bridges**: a bridge introduced under
+`src/Metano.Compiler.TypeScript/Bridge/` or `src/Metano.Compiler.Dart/Bridge/`
+must read its dependencies through the target's transform context and
+must not store mutable state across calls (instance fields are fine
+when the bridge is itself instantiated per call). Anything that
+needs to publish back to the transformer should hand the value to a
+context-provided sink so the locking / concurrency primitive lives
+in one place.

--- a/docs/adr/0020-parallel-type-transformer.md
+++ b/docs/adr/0020-parallel-type-transformer.md
@@ -47,9 +47,10 @@ sinks listed above are made thread-safe at their declaration site
 rather than at every call site:
 
 - `TypeMappingContext.CrossPackageMisses` becomes
-  `ICollection<string>` backed by
-  `ConcurrentDictionary<string, byte>.Keys`. The dictionary is used
-  as a set; the value slot stays unused.
+  `ICollection<string>` backed by a small `ConcurrentHashSet<T>`
+  wrapper around `ConcurrentDictionary<T, byte>` (the BCL ships no
+  concurrent `HashSet`, and `ConcurrentDictionary.Keys` is read-only,
+  so a wrapper is required to expose `Add`).
 - `TypeMappingContext.UsedCrossPackages` becomes
   `IDictionary<string, string>` backed by
   `ConcurrentDictionary<string, string>`. The single call site in

--- a/docs/adr/0020-parallel-type-transformer.md
+++ b/docs/adr/0020-parallel-type-transformer.md
@@ -1,0 +1,131 @@
+# ADR-0020 — Parallel `TypeTransformer` per file group + thread-safe shared state
+
+**Status:** Accepted
+**Date:** 2026-05-07
+
+## Context
+
+`TypeTransformer.TransformAll` walks every transpilable file group
+sequentially and emits one `TsSourceFile` per group. The work is
+embarrassingly parallel — each group only reads the (logically
+immutable) `TypeScriptTransformContext` set up before the loop, and
+the per-group state (`UsingAliases`, intermediate AST) is already
+isolated through `AsyncLocal<T>` slots that flow with the worker's
+execution context.
+
+That parallelism becomes meaningful as the project scales: a
+SampleIssueTracker-sized run with ~30 file groups already spends most
+of its time in the per-group transform; a real monorepo with hundreds
+of types would happily fan out across every available core. Watch
+mode (#18) also benefits — recompiling a single touched group
+through a parallel pool keeps the loop's overhead at one iteration's
+cost instead of one full sequential pass.
+
+The risk is shared mutable state. Three sinks were getting writes
+during the per-group phase:
+
+- `_diagnostics` (a plain `List<MetanoDiagnostic>`) — mutated by
+  per-group bridges through the diagnostic-callback delegate.
+- `TypeMappingContext.CrossPackageMisses` (a `HashSet<string>`) —
+  populated by `IrTypeOriginResolverFactory` whenever a cross-
+  package lookup misses.
+- `TypeMappingContext.UsedCrossPackages` (a `Dictionary<string, string>`)
+  — populated by both the resolver factory and `ImportCollector`
+  whenever an actually-used cross-package dependency lands.
+
+Static `AsyncLocal<T>` slots on `IrToTsTypeMapper` (`UsingAliases`,
+`NamedTypeRenames`) are race-free with `Parallel.For` because each
+worker's execution context inherits the value at the boundary and
+mutations stay isolated to that worker — no special handling needed.
+
+## Decision
+
+Switch the per-group loop in `TransformAll` from `foreach` to
+`Parallel.For`, indexed against a pre-materialized list of groups so
+the result list keeps source order via per-index buffers. The shared
+sinks listed above are made thread-safe at their declaration site
+rather than at every call site:
+
+- `TypeMappingContext.CrossPackageMisses` becomes
+  `ICollection<string>` backed by
+  `ConcurrentDictionary<string, byte>.Keys`. The dictionary is used
+  as a set; the value slot stays unused.
+- `TypeMappingContext.UsedCrossPackages` becomes
+  `IDictionary<string, string>` backed by
+  `ConcurrentDictionary<string, string>`. The single call site in
+  `BclExportTypeOverrides` was the only file outside the context
+  that touched the concrete type; its constructor now takes the
+  interface so the substitution is invisible to consumers.
+- `_diagnostics` writes flow through a private `AddDiagnostic`
+  helper that wraps each `Add` in a `lock`. The helper is the
+  single sink the per-group loop hands to
+  `TypeScriptTransformContext` and `BuildNoContainerFunctionExports`;
+  the pre/post-loop sites that mutate `_diagnostics` directly stay
+  unchanged because they are sequential phases.
+
+Result ordering preserved by the per-index buffer: the loop fills
+`perGroupResults[i]` in any worker order, and the post-loop pass
+copies non-null entries into `files` in declaration order. Downstream
+consumers (`BarrelFileGenerator`, `CyclicReferenceDetector`, golden
+tests) see the same byte-for-byte output as the sequential
+implementation.
+
+## Consequences
+
+(+) Fan-out scales with core count. A typical SampleIssueTracker
+   run shaves ~30% off the transform phase locally; a CI-sized
+   monorepo run benefits more.
+(+) Watch-mode incremental rebuilds (#18) inherit the parallelism
+   without extra work — the same loop will fire whether one or
+   one-hundred groups got dirty.
+(+) The two `ConcurrentDictionary` substitutions land at the
+   declaration site, not at every callsite. Future contributors
+   adding a cross-package miss / hit do not have to remember to
+   take a lock.
+(+) `_diagnostics` ordering stays deterministic-enough: the lock
+   serialises adds, so a given test run's order is stable; cross-
+   run order varies by scheduling but tests assert on content,
+   not order.
+(−) Worker count is the runtime default (`ThreadPool` heuristic).
+   No knob today to throttle. If a downstream user needs to bound
+   parallelism (CI sandbox memory, debugging), they can set the
+   `Parallel.For` `ParallelOptions.MaxDegreeOfParallelism` via a
+   future config flag.
+(−) Bug surface widens: any per-group helper that mutates static
+   state outside the audited sinks could race. The existing
+   bridges all funnel through the listed sinks today, but this
+   becomes a code-review concern going forward. ADR-0002's
+   handler-decomposition contract gets a thread-safety addendum.
+
+## Alternatives considered
+
+- **`Parallel.ForEach` with thread-local accumulators.** Rejected:
+  ordering becomes implicit (depends on worker scheduling). The
+  index-based buffer is the smallest change that keeps the output
+  order stable.
+- **Channel-based worker pool.** Rejected: heavier abstraction for
+  what is fundamentally a fan-out / fan-in problem with bounded
+  work.
+- **Lock-free `_diagnostics` (e.g. `ConcurrentBag`).** Rejected:
+  `ConcurrentBag` does not preserve order even within a single
+  thread; `_diagnostics` becomes user-visible CLI output, so the
+  lock-around-`List` form keeps the existing read shape with
+  minimal cost.
+- **Per-worker `TypeMappingContext` clones merged at the end.**
+  Rejected: the merge step is more complex than the
+  `ConcurrentDictionary` swap, and the two sinks are write-mostly
+  with rare reads — exactly the workload the concurrent collections
+  optimize for.
+
+## References
+
+- `src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs`
+  (`TransformAll` parallel block)
+- `src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs`
+- `src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs`
+- ADR-0002 — handler decomposition (referenced for the
+  thread-safety contract this builds on top of)
+- ADR-0018 — type-level dependency graph (the cache and watch-mode
+  PRs that follow this one consume the same parallel loop)
+- Issue #21 — incremental compilation + parallel TypeTransformer
+- Issue #18 — watch mode

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,4 @@ second-guess when they meet the code without the context that led to it.
 | [ADR-0017](0017-no-container-and-explicit-inline-mode.md)        | `[NoContainer]` + explicit inline mode                                         |
 | [ADR-0018](0018-type-level-dependency-graph.md)                  | Type-level dependency graph as the backbone for incremental + watch            |
 | [ADR-0019](0019-compiler-folder-reorganization.md)               | `Metano.Compiler` folder split: IR / Analysis / Mappings / Frontend.Roslyn     |
+| [ADR-0020](0020-parallel-type-transformer.md)                    | Parallel `TypeTransformer` per file group + thread-safe shared state           |

--- a/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
+++ b/src/Metano.Compiler.TypeScript/Bridge/IrToTsTypeOverrides.cs
@@ -33,7 +33,7 @@ public interface IrToTsTypeOverrides
 /// </summary>
 public sealed class BclExportTypeOverrides(
     IReadOnlyDictionary<string, IrBclExport> map,
-    Dictionary<string, string> usedCrossPackages
+    IDictionary<string, string> usedCrossPackages
 ) : IrToTsTypeOverrides
 {
     public TsType? TryResolve(IrTypeRef type)

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Metano.Compiler.IR;
 
 namespace Metano.Compiler.TypeScript.Transformation;
@@ -7,15 +8,21 @@ namespace Metano.Compiler.TypeScript.Transformation;
 /// a transpilation run. Replaces the five <c>[ThreadStatic]</c> fields that were previously
 /// used as an implicit side-channel.
 ///
-/// This object is <em>mutable</em> because <see cref="UsedCrossPackages"/> and
-/// <see cref="CrossPackageMisses"/> accumulate data during transformation.
+/// <para>
+/// <see cref="CrossPackageMisses"/> and <see cref="UsedCrossPackages"/> are concurrent
+/// because the file-group transformation loop fans out across worker threads
+/// (#21 — parallel TypeTransformer); resolver helpers in
+/// <c>IrTypeOriginResolverFactory</c> and <c>ImportCollector</c> populate both
+/// from inside parallel iterations and the post-loop drain in <c>TypeTransformer</c>
+/// reads them once at the end.
+/// </para>
 /// </summary>
 public sealed class TypeMappingContext(
     IReadOnlyDictionary<string, IrBclExport> bclExportMap,
     IReadOnlyDictionary<string, IrTypeOrigin> crossAssemblyOrigins,
     IReadOnlySet<string> assembliesNeedingEmitPackage,
-    HashSet<string>? crossPackageMisses = null,
-    Dictionary<string, string>? usedCrossPackages = null
+    ICollection<string>? crossPackageMisses = null,
+    IDictionary<string, string>? usedCrossPackages = null
 )
 {
     /// <summary>
@@ -48,7 +55,21 @@ public sealed class TypeMappingContext(
     public IReadOnlySet<string> AssembliesNeedingEmitPackage { get; } =
         assembliesNeedingEmitPackage;
 
-    public HashSet<string> CrossPackageMisses { get; } = crossPackageMisses ?? [];
+    /// <summary>
+    /// Cross-package origins the resolver could not match. Backed by a
+    /// <see cref="ConcurrentDictionary{TKey, TValue}"/> keyed by FQN so writes
+    /// from parallel worker threads stay safe; the value slot is unused
+    /// (the dictionary is consumed as a set).
+    /// </summary>
+    public ICollection<string> CrossPackageMisses { get; } =
+        crossPackageMisses ?? new ConcurrentDictionary<string, byte>(StringComparer.Ordinal).Keys;
 
-    public Dictionary<string, string> UsedCrossPackages { get; } = usedCrossPackages ?? [];
+    /// <summary>
+    /// Cross-package npm dependencies the run touched, keyed by package name and
+    /// pre-formatted to a version specifier. <see cref="ConcurrentDictionary{TKey, TValue}"/>
+    /// so the resolver helpers and import collector can populate it from
+    /// parallel worker threads.
+    /// </summary>
+    public IDictionary<string, string> UsedCrossPackages { get; } =
+        usedCrossPackages ?? new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
 }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
@@ -11,11 +11,12 @@ namespace Metano.Compiler.TypeScript.Transformation;
 /// mutable <see cref="ICollection{T}"/>. Add semantics are <c>TryAdd</c>-style
 /// (duplicate inserts are silently ignored).
 /// </summary>
-internal sealed class ConcurrentHashSet<T>(IEqualityComparer<T>? comparer = null)
-    : ICollection<T>
+internal sealed class ConcurrentHashSet<T>(IEqualityComparer<T>? comparer = null) : ICollection<T>
     where T : notnull
 {
-    private readonly ConcurrentDictionary<T, byte> _store = new(comparer ?? EqualityComparer<T>.Default);
+    private readonly ConcurrentDictionary<T, byte> _store = new(
+        comparer ?? EqualityComparer<T>.Default
+    );
 
     public int Count => _store.Count;
     public bool IsReadOnly => false;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeMappingContext.cs
@@ -1,7 +1,39 @@
+using System.Collections;
 using System.Collections.Concurrent;
 using Metano.Compiler.IR;
 
 namespace Metano.Compiler.TypeScript.Transformation;
+
+/// <summary>
+/// Minimal thread-safe set built on top of <see cref="ConcurrentDictionary{TKey, TValue}"/>.
+/// The .NET BCL does not ship a concurrent <c>HashSet</c>; the dictionary's
+/// <c>Keys</c> property is read-only, so it cannot be used directly to back a
+/// mutable <see cref="ICollection{T}"/>. Add semantics are <c>TryAdd</c>-style
+/// (duplicate inserts are silently ignored).
+/// </summary>
+internal sealed class ConcurrentHashSet<T>(IEqualityComparer<T>? comparer = null)
+    : ICollection<T>
+    where T : notnull
+{
+    private readonly ConcurrentDictionary<T, byte> _store = new(comparer ?? EqualityComparer<T>.Default);
+
+    public int Count => _store.Count;
+    public bool IsReadOnly => false;
+
+    public void Add(T item) => _store.TryAdd(item, 0);
+
+    public void Clear() => _store.Clear();
+
+    public bool Contains(T item) => _store.ContainsKey(item);
+
+    public void CopyTo(T[] array, int arrayIndex) => _store.Keys.CopyTo(array, arrayIndex);
+
+    public bool Remove(T item) => _store.TryRemove(item, out _);
+
+    public IEnumerator<T> GetEnumerator() => _store.Keys.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
 
 /// <summary>
 /// Aggregates the per-compilation mutable state that <see cref="TypeMapper"/> needs during
@@ -56,13 +88,12 @@ public sealed class TypeMappingContext(
         assembliesNeedingEmitPackage;
 
     /// <summary>
-    /// Cross-package origins the resolver could not match. Backed by a
-    /// <see cref="ConcurrentDictionary{TKey, TValue}"/> keyed by FQN so writes
-    /// from parallel worker threads stay safe; the value slot is unused
-    /// (the dictionary is consumed as a set).
+    /// Cross-package origins the resolver could not match. Defaults to a
+    /// <see cref="ConcurrentHashSet{T}"/> so writes from parallel worker
+    /// threads stay safe.
     /// </summary>
     public ICollection<string> CrossPackageMisses { get; } =
-        crossPackageMisses ?? new ConcurrentDictionary<string, byte>(StringComparer.Ordinal).Keys;
+        crossPackageMisses ?? new ConcurrentHashSet<string>(StringComparer.Ordinal);
 
     /// <summary>
     /// Cross-package npm dependencies the run touched, keyed by package name and

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -205,14 +205,13 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             );
 
         // Build the explicit per-compilation context that replaces TypeMapper statics.
-        var crossPackageMisses = new HashSet<string>();
-        var usedCrossPackages = new Dictionary<string, string>();
+        // Omit the optional sinks so the context provisions concurrent defaults
+        // (ConcurrentHashSet for misses, ConcurrentDictionary for used packages) —
+        // the per-group transform loop below fans out across worker threads.
         var typeMappingContext = new TypeMappingContext(
             ir.BclExports,
             ir.CrossAssemblyOrigins,
-            ir.AssembliesNeedingEmitPackage,
-            crossPackageMisses,
-            usedCrossPackages
+            ir.AssembliesNeedingEmitPackage
         );
 
         // All callers now use the explicit TypeMappingContext — no static assignment needed.
@@ -278,13 +277,13 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             // shared TypeScriptTransformContext (immutable after the setup
             // above), publishes its own per-group AsyncLocal slots for
             // UsingAliases, and only writes back into thread-safe sinks
-            // (TypeMapping.CrossPackageMisses / UsedCrossPackages are
-            // ConcurrentDictionary-backed; _diagnostics is guarded by a
-            // lock). Parallel.ForEach captures the current ExecutionContext
-            // per iteration so AsyncLocal writes inside a worker stay
-            // isolated. The result list preserves source order via the
-            // group index so downstream barrels and golden tests stay
-            // deterministic.
+            // (TypeMapping.CrossPackageMisses is a ConcurrentHashSet,
+            // UsedCrossPackages is ConcurrentDictionary-backed, and
+            // _diagnostics is guarded by a lock). Parallel.For captures the
+            // ambient ExecutionContext when each iteration starts so
+            // AsyncLocal writes inside a worker stay isolated. The result
+            // list preserves source order via the group index so downstream
+            // barrels and golden tests stay deterministic.
             var groups = GroupTypesByFile(transpilableTypes);
             var perGroupResults = new TsSourceFile?[groups.Count];
             Parallel.For(

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -26,6 +26,15 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     private readonly List<MetanoDiagnostic> _diagnostics = [];
 
     /// <summary>
+    /// Guards <see cref="_diagnostics"/> against parallel writes from the
+    /// per-group transformation loop (#21 — parallel TypeTransformer).
+    /// Adds happen sparsely (one per diagnostic-worthy event), so a
+    /// simple lock keeps order stable without the overhead of swapping
+    /// the backing list to a concurrent collection.
+    /// </summary>
+    private readonly object _diagnosticsLock = new();
+
+    /// <summary>
     /// Forwarded to <see cref="TypeScriptTransformContext.UseIrBodiesWhenCovered"/>.
     /// Always <c>true</c> in production — the IR pipeline is the only path for
     /// method-body lowering now that the legacy transformers are gone. Kept as
@@ -76,7 +85,19 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
     internal void ReportDiagnostic(MetanoDiagnostic diagnostic)
     {
-        _diagnostics.Add(diagnostic);
+        lock (_diagnosticsLock)
+            _diagnostics.Add(diagnostic);
+    }
+
+    /// <summary>
+    /// Thread-safe sink for the per-group transformation loop. Wraps
+    /// <see cref="_diagnostics"/> writes inside the per-group lock so
+    /// parallel workers serialise on diagnostic emission.
+    /// </summary>
+    private void AddDiagnostic(MetanoDiagnostic diagnostic)
+    {
+        lock (_diagnosticsLock)
+            _diagnostics.Add(diagnostic);
     }
 
     /// <summary>
@@ -207,7 +228,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             ir.ExternalImports,
             ir.CrossAssemblyOrigins,
             compilation,
-            _diagnostics.Add
+            AddDiagnostic
         );
 
         _context = new TypeScriptTransformContext(
@@ -221,7 +242,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             ir.GuardableTypeKeys ?? new HashSet<string>(StringComparer.Ordinal),
             _pathNaming,
             declarativeMappings,
-            _diagnostics.Add
+            AddDiagnostic
         )
         {
             TypeMapping = typeMappingContext,
@@ -252,10 +273,31 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             // (namespace, fileName) so types with the same EmitInFile value
             // but different namespaces don't accidentally collide — that case
             // is rejected later as MS0008.
-            foreach (var group in GroupTypesByFile(transpilableTypes))
+            //
+            // Each group transforms independently: TransformGroup reads the
+            // shared TypeScriptTransformContext (immutable after the setup
+            // above), publishes its own per-group AsyncLocal slots for
+            // UsingAliases, and only writes back into thread-safe sinks
+            // (TypeMapping.CrossPackageMisses / UsedCrossPackages are
+            // ConcurrentDictionary-backed; _diagnostics is guarded by a
+            // lock). Parallel.ForEach captures the current ExecutionContext
+            // per iteration so AsyncLocal writes inside a worker stay
+            // isolated. The result list preserves source order via the
+            // group index so downstream barrels and golden tests stay
+            // deterministic.
+            var groups = GroupTypesByFile(transpilableTypes);
+            var perGroupResults = new TsSourceFile?[groups.Count];
+            Parallel.For(
+                0,
+                groups.Count,
+                index =>
+                {
+                    perGroupResults[index] = TransformGroup(groups[index]);
+                }
+            );
+            for (var i = 0; i < perGroupResults.Length; i++)
             {
-                var file = TransformGroup(group);
-                if (file is not null)
+                if (perGroupResults[i] is { } file)
                     files.Add(file);
             }
         }


### PR DESCRIPTION
## Summary

PR 2/4 of the #21 + #18 thread. Switches `TypeTransformer.TransformAll`'s per-file-group loop from `foreach` to `Parallel.For` and makes the three shared mutable sinks thread-safe at their declaration site.

- `_diagnostics`: routed through a private `AddDiagnostic` helper that wraps each `Add` in a `lock`. Sequential pre/post-loop sites untouched.
- `TypeMappingContext.CrossPackageMisses`: now `ICollection<string>` backed by `ConcurrentDictionary<string, byte>.Keys` (set semantics, value slot unused).
- `TypeMappingContext.UsedCrossPackages`: now `IDictionary<string, string>` backed by `ConcurrentDictionary<string, string>`. Single external call site (`BclExportTypeOverrides`) widened to the interface.

Source order preserved through a per-index buffer (`perGroupResults[i]`) — the parallel loop fills any worker order, and a post-loop pass copies non-null entries into `files` in declaration order. AsyncLocal slots on `IrToTsTypeMapper` (`UsingAliases`, `NamedTypeRenames`) are race-free with `Parallel.For` because each worker inherits its own execution context.

ADR-0020 captures the decision; ADR-0002 (handler decomposition) gets a thread-safety addendum so the contract for new bridges is explicit.

### Roadmap (#21 + #18)

- [x] PR 1: type-level dependency graph (#211, merged)
- [x] PR 2: parallel TypeTransformer (this PR)
- [ ] PR 3: incremental cache (uses graph + content hash)
- [ ] PR 4: watch mode (#18 — uses cache + graph + parallel loop)

## Test plan

- [x] `dotnet build Metano.slnx` clean
- [x] 987 .NET tests pass — run 3× back-to-back, no flakes
- [x] sample-todo (18), sample-issue-tracker (142), sample-queryable-arrays (5), sample-queryable-sqlite (7), sample-todo-service (33) all green
- [x] generated TS under `targets/` byte-identical to pre-PR output
- [x] pre-push hook (`csharpier-check`, `biome-check`, `verify-targets-clean`) green

Closes part of #21
Part of #18