### PR TITLE
feat(compiler): incremental cache MVP — whole-build short-circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ Thumbs.db
 *.tsbuildinfo
 bun.lock
 
+# Metano incremental cache — pinned next to generated outputs
+# (ADR-0021). Per-machine, never committed.
+.metano-cache.json
+
 # Local working plans (per CLAUDE.md workflow — private per-session notes,
 # not committed — the authoritative backlog lives in GitHub issues)
 tasks/

--- a/docs/adr/0021-incremental-cache.md
+++ b/docs/adr/0021-incremental-cache.md
@@ -1,0 +1,145 @@
+# ADR-0021 — Incremental cache: whole-build short-circuit
+
+**Status:** Accepted
+**Date:** 2026-05-07
+
+## Context
+
+Issue #21 asks for an incremental compilation cache so the transpiler
+skips work when nothing changed. Watch mode (#18) needs the same
+machinery: a file save that does not actually alter content (an IDE's
+save-on-focus-loss, a no-op formatter pass, a `touch`) should produce
+zero output instead of triggering a full re-emit.
+
+The dependency graph from PR 1 (#211 / ADR-0018) and the parallel
+TypeTransformer from PR 2 (#213 / ADR-0020) both expect a cache layer
+on top. The hard question is *granularity*: per-type (using sig
+hashes + the dependency graph) gives the finest skip but requires a
+file-descriptor abstraction so downstream stages (barrel generation,
+cyclic-import detection, file emit) can consume both freshly
+transformed and cached outputs uniformly.
+
+## Decision
+
+PR 3 ships the **whole-build short-circuit** as the MVP. Per-type
+skip ("PR 3b") is a follow-up that builds on top of this layer.
+
+The cache file lives at `<outputDir>/.metano-cache.json`. Shape:
+
+```json
+{
+  "formatVersion": 1,
+  "target": "TypeScript",
+  "sourceHashes":           { "<absolute .cs path>": "<sha256-hex>" },
+  "referenceFingerprints":  { "<absolute .dll path>": "<length>:<lastWriteTimeUtc.ticks>" },
+  "outputHashes":           { "<relative output path>": "<sha256-hex>" }
+}
+```
+
+`TranspilerHost.RunAsync` short-circuits the pipeline when **all** of
+the following match the cached fingerprint:
+
+1. The set of `.cs` files Roslyn parsed and each file's SHA-256.
+2. Every metadata reference's `length:lastWriteTimeUtc` tuple.
+3. Every previously emitted output file still exists on disk with a
+   SHA-256 matching the cached value.
+
+If anything diverges, the host runs the full pipeline and overwrites
+the cache file at the end. `--clean` wipes the output directory
+(including the cache file), so a clean run always rebuilds. `--no-cache`
+opts the run out of both reading and writing the cache. `--dry-run`
+also opts out of cache writes — there are no on-disk files to pin.
+
+### Why source-hash + reference-fingerprint, not type-level sig hashes (yet)
+
+Whole-build short-circuit does not need the dependency graph or
+per-type signature hashing. The `.cs` content hashes already cover
+both signature edits and body edits, and the reference fingerprints
+catch external assembly swaps without reading every .dll on every
+run. Per-type granularity (PR 3b) needs body-vs-signature separation
+because the dep graph is signature-only (ADR-0018) and a body-only
+edit must still re-emit the affected file even though no dependent's
+sig closure changed. That separation, plus a file-descriptor type
+that lets cached files participate in barrels and cyclic detection
+without an AST, is the work PR 3b takes on.
+
+### Why `length:ticks` for reference fingerprints
+
+Hashing a 50 MB BCL .dll on every run would dominate the cold-start
+budget. The mtime+length tuple flips on a recompile of the
+referenced project, on a NuGet upgrade, and on a manual swap — the
+three real change cases. Drift cases are file-system-clock skew
+across machines (each machine maintains its own cache) and an
+identical-length write that preserves mtime (extremely rare; opt-out
+via `--no-cache`).
+
+### Why store output hashes
+
+The cache is meaningless if the user — or a sibling target's
+`--clean` — deleted half the output directory. The output-hash check
+detects both deletions and out-of-band edits (someone hand-fixed a
+generated file; we should regenerate to overwrite it). The cost is
+a content read per output on cache check, which is bounded by the
+size of the previous emit and dwarfed by the avoided full pipeline.
+
+## Consequences
+
+(+) Watch mode's "nothing changed" tick is now O(file count) — read
+   syntax trees, hash, compare, exit. No transform, no print, no
+   write.
+(+) Re-running a green build is free even without watch mode (CI
+   re-runs on the same SHA, local rebuild loops).
+(+) Cache file format is versioned (`formatVersion: 1`); future
+   schema changes bump the version and treat older caches as stale.
+(+) `--clean` semantics unchanged: nuking the output directory
+   rebuilds from scratch. Users do not have to learn a separate
+   cache-clear command.
+(−) Coarse granularity. A single character change in any .cs file
+   re-runs the full pipeline. PR 3b lifts this to per-group skip
+   once the file-descriptor abstraction lands.
+(−) The reference fingerprint trusts the file system's mtime
+   resolution. A pathological case (write of identical length within
+   the same mtime tick) would hide a swap. Treated as a known
+   limitation; `--no-cache` is the escape hatch.
+(−) Cache files now live next to outputs. Users committing the
+   `targets/js/...` tree to git need a `.gitignore` entry; the repo
+   adds one centrally.
+(−) Target-specific post-emit hooks (today only the TypeScript
+   target's <c>PackageJsonWriter</c>) skip on a cache hit because
+   their inputs (<c>target.LastSourceFiles</c>,
+   <c>target.LastEmitPackageName</c>, …) live on the target instance
+   and only get populated by <c>target.Transform</c>. In practice the
+   writer is idempotent (merge semantics) so a hand-edited
+   <c>package.json</c> survives a cache hit; the failure mode is "user
+   deletes <c>package.json</c> between runs" — recovery is
+   <c>--clean</c> or <c>--no-cache</c>. PR 3b folds the post-emit hook
+   into the cache so this round-trips automatically.
+
+## Alternatives considered
+
+- **Type-level sig hashes from PR 1's dependency graph.** Rejected
+  for the MVP: need a file-descriptor abstraction so cached files
+  can flow through barrel generation and cyclic detection without an
+  AST. Tracked as PR 3b.
+- **mtime-only cache key.** Rejected: every editor save bumps mtime
+  even when content is unchanged, defeating the watch-mode noop case
+  (one of the two motivating wins).
+- **Cache lives in `obj/metano-cache/<target>.json`.** Rejected: the
+  output dir is the natural home — it is what `--clean` already
+  manages and what users delete to "start over". Splitting cache
+  state across two roots invites stale-cache-against-clean-output
+  bugs.
+- **Hash every metadata reference's bytes.** Rejected: too slow on
+  cold start. The mtime+length tuple is good enough for the cases
+  that matter and falls back gracefully via `--no-cache`.
+
+## References
+
+- `src/Metano.Compiler/Caching/TranspilationCache.cs`
+- `src/Metano.Compiler/Caching/CacheKeyBuilder.cs`
+- `src/Metano.Compiler/TranspilerHost.cs` — `TryShortCircuitFromCache`
+- ADR-0018 — type-level dependency graph (input for PR 3b)
+- ADR-0020 — parallel TypeTransformer (the parallel loop is the work
+  the cache lets us skip)
+- Issue #21 — incremental compilation + parallel TypeTransformer
+- Issue #18 — watch mode (the cache's primary consumer)

--- a/docs/adr/0021-incremental-cache.md
+++ b/docs/adr/0021-incremental-cache.md
@@ -28,13 +28,22 @@ The cache file lives at `<outputDir>/.metano-cache.json`. Shape:
 
 ```json
 {
-  "formatVersion": 1,
+  "formatVersion": 2,
   "target": "TypeScript",
+  "configurationFingerprint": "target=namespaceBarrels=False;stripInterfacePrefix=False;filePrefix=",
   "sourceHashes":           { "<absolute .cs path>": "<sha256-hex>" },
   "referenceFingerprints":  { "<absolute .dll path>": "<length>:<lastWriteTimeUtc.ticks>" },
   "outputHashes":           { "<relative output path>": "<sha256-hex>" }
 }
 ```
+
+The `configurationFingerprint` mixes the host's `--file-prefix` with each
+target's per-run flags exposed via the new
+`ITranspilerTarget.ConfigurationFingerprint` property (the TypeScript
+target pins `NamespaceBarrels` and `StripInterfacePrefix`; the Dart
+target has no flags today and returns the empty string). Flag flips
+invalidate the cache even when sources and references are
+byte-identical.
 
 `TranspilerHost.RunAsync` short-circuits the pipeline when **all** of
 the following match the cached fingerprint:
@@ -46,9 +55,20 @@ the following match the cached fingerprint:
 
 If anything diverges, the host runs the full pipeline and overwrites
 the cache file at the end. `--clean` wipes the output directory
-(including the cache file), so a clean run always rebuilds. `--no-cache`
-opts the run out of both reading and writing the cache. `--dry-run`
-also opts out of cache writes — there are no on-disk files to pin.
+(including the cache file) before the run, so a clean run always
+rebuilds, but the post-run write still happens — the next run gets a
+fresh cache to consult. `--no-cache` opts the run out of both reading
+and writing. `--dry-run` opts out of writes — there are no on-disk
+files to pin.
+
+The cache hit path validates and rehydrates outputs in a single disk
+pass: each cached path is checked for traversal segments
+(`..` / rooted), opened once, streamed through `SHA256.HashData`, and
+then read back as text for the rehydrated `GeneratedFile`. The host
+strips the file-prefix block when present so
+`TranspileResult.Files` on a cache hit matches what
+`target.Transform` would return on a full run (no prefix — the host
+adds it at write time).
 
 ### Why source-hash + reference-fingerprint, not type-level sig hashes (yet)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ second-guess when they meet the code without the context that led to it.
 | [ADR-0018](0018-type-level-dependency-graph.md)                  | Type-level dependency graph as the backbone for incremental + watch            |
 | [ADR-0019](0019-compiler-folder-reorganization.md)               | `Metano.Compiler` folder split: IR / Analysis / Mappings / Frontend.Roslyn     |
 | [ADR-0020](0020-parallel-type-transformer.md)                    | Parallel `TypeTransformer` per file group + thread-safe shared state           |
+| [ADR-0021](0021-incremental-cache.md)                            | Incremental cache: whole-build short-circuit on source/reference/output match  |

--- a/src/Metano.Compiler.Dart/Commands.cs
+++ b/src/Metano.Compiler.Dart/Commands.cs
@@ -14,6 +14,7 @@ public class Commands
     /// <param name="clean">-c, Clean output directory before generating.</param>
     /// <param name="filePrefix">Opaque text written verbatim at the top of every generated file, followed by a single newline. Use for `// @generated` provenance markers or Dart linter directives.</param>
     /// <param name="dryRun">Run the full pipeline but do NOT write any files. Print a preflight summary (file count + total line count + per-file paths) instead.</param>
+    /// <param name="noCache">Disable the incremental cache. Forces a full transpilation even when sources, references, and outputs are byte-identical to the previous run.</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -21,7 +22,8 @@ public class Commands
         bool time = false,
         bool clean = false,
         string? filePrefix = null,
-        bool dryRun = false
+        bool dryRun = false,
+        bool noCache = false
     )
     {
         var target = new DartTarget();
@@ -32,7 +34,8 @@ public class Commands
             ShowTimings: time,
             Clean: clean,
             FilePrefix: filePrefix,
-            DryRun: dryRun
+            DryRun: dryRun,
+            NoCache: noCache
         );
 
         var result = await TranspilerHost.RunAsync(options, target);

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -20,6 +20,7 @@ public class Commands
     /// <param name="stripInterfacePrefix">Drop the C# `I` prefix from generated interface names when it is followed by another uppercase letter (opt-in). Collisions with sibling types in the same namespace keep the prefix and emit MS0017.</param>
     /// <param name="filePrefix">Opaque text written verbatim at the top of every generated file, followed by a single newline. Use to inject formatter / lint directives (e.g., a Biome `biome-ignore-all` block, a Prettier `// @prettier-ignore`, a `// @generated` provenance marker).</param>
     /// <param name="dryRun">Run the full pipeline but do NOT write any files. Print a preflight summary (file count + total line count + per-file paths) instead. Useful for CI preflight checks and exploratory runs. Skips the package.json update too.</param>
+    /// <param name="noCache">Disable the incremental cache. Forces a full transpilation even when sources, references, and outputs are byte-identical to the previous run.</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -33,7 +34,8 @@ public class Commands
         bool namespaceBarrels = false,
         bool stripInterfacePrefix = false,
         string? filePrefix = null,
-        bool dryRun = false
+        bool dryRun = false,
+        bool noCache = false
     )
     {
         var target = new TypeScriptTarget
@@ -48,7 +50,8 @@ public class Commands
             ShowTimings: time,
             Clean: clean,
             FilePrefix: filePrefix,
-            DryRun: dryRun
+            DryRun: dryRun,
+            NoCache: noCache
         );
 
         var result = await TranspilerHost.RunAsync(options, target);

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -77,6 +77,16 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     public bool StripInterfacePrefix { get; init; }
 
+    /// <summary>
+    /// Cache fingerprint (ADR-0021): pin the two emit-affecting flags so
+    /// flipping either one invalidates the incremental cache. Format is
+    /// keep small + ordered so future additions extend it without
+    /// breaking older caches (the format-version bump in
+    /// <see cref="TranspilationCache"/> handles structural breaks).
+    /// </summary>
+    public string ConfigurationFingerprint =>
+        $"namespaceBarrels={NamespaceBarrels};stripInterfacePrefix={StripInterfacePrefix}";
+
     public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
     {
         if (compilation is null)

--- a/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
+++ b/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
@@ -1,0 +1,144 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.Caching;
+
+/// <summary>
+/// Computes the cache fingerprint for a transpilation run. Builds source-file
+/// SHA-256 hashes from the Roslyn syntax trees, reference fingerprints from
+/// the metadata reference file paths (size + last-write-time tuple — fast and
+/// good enough to spot a swap or rebuild), and on-disk output hashes by
+/// re-hashing the files the previous run pinned in the cache.
+/// </summary>
+public static class CacheKeyBuilder
+{
+    public static IReadOnlyDictionary<string, string> ComputeSourceHashes(Compilation compilation)
+    {
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            // SyntaxTree.FilePath can be empty for in-memory trees (the test
+            // harness uses these); skip those — they cannot collide with
+            // anything on disk and cannot be re-read on a subsequent run.
+            if (string.IsNullOrEmpty(tree.FilePath))
+                continue;
+            var text = tree.GetText().ToString();
+            hashes[NormalizePath(tree.FilePath)] = Sha256(text);
+        }
+        return hashes;
+    }
+
+    public static IReadOnlyDictionary<string, string> ComputeReferenceFingerprints(
+        Compilation compilation
+    )
+    {
+        var fingerprints = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var reference in compilation.References)
+        {
+            if (reference is not PortableExecutableReference pe || pe.FilePath is null)
+                continue;
+            var info = new FileInfo(pe.FilePath);
+            if (!info.Exists)
+                continue;
+            // length:ticks is precise enough for the cache: a recompile
+            // touches LastWriteTime, a swap typically changes the length
+            // too. Cheaper than re-hashing every .dll on every run.
+            fingerprints[NormalizePath(pe.FilePath)] =
+                $"{info.Length.ToString(CultureInfo.InvariantCulture)}:"
+                + info.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
+        }
+        return fingerprints;
+    }
+
+    /// <summary>
+    /// Hashes each generated file's eventual on-disk content (i.e., with
+    /// the optional file-prefix block prepended, mirroring what
+    /// <see cref="TranspilerHost"/> writes). The returned map is what
+    /// gets pinned into the next run's <c>outputHashes</c>.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> HashGeneratedContent(
+        IReadOnlyList<GeneratedFile> files,
+        string? prefixBlock
+    )
+    {
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in files)
+        {
+            var content = string.IsNullOrEmpty(prefixBlock) ? file.Content : prefixBlock + file.Content;
+            hashes[file.RelativePath] = Sha256(content);
+        }
+        return hashes;
+    }
+
+    public static bool OutputsStillValid(
+        string outputDir,
+        IReadOnlyDictionary<string, string> expectedHashes
+    )
+    {
+        foreach (var (relativePath, expected) in expectedHashes)
+        {
+            if (!MatchesOnDisk(ResolveOutputPath(outputDir, relativePath), expected))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Reads each cached output file from disk and returns it as a
+    /// <see cref="GeneratedFile"/>, so the host can populate
+    /// <c>TranspileResult.Files</c> on a cache hit (callers that read it
+    /// post-run keep seeing every emitted artifact, not an empty list).
+    /// </summary>
+    public static IReadOnlyList<GeneratedFile> RehydrateFiles(
+        string outputDir,
+        IReadOnlyDictionary<string, string> outputHashes
+    )
+    {
+        var files = new List<GeneratedFile>(outputHashes.Count);
+        foreach (var relativePath in outputHashes.Keys)
+        {
+            var path = ResolveOutputPath(outputDir, relativePath);
+            if (File.Exists(path))
+                files.Add(new GeneratedFile(relativePath, File.ReadAllText(path)));
+        }
+        return files;
+    }
+
+    public static bool DictionariesEqual(
+        IReadOnlyDictionary<string, string> a,
+        IReadOnlyDictionary<string, string> b
+    )
+    {
+        if (a.Count != b.Count)
+            return false;
+        foreach (var (key, value) in a)
+        {
+            if (!b.TryGetValue(key, out var other))
+                return false;
+            if (!string.Equals(value, other, StringComparison.Ordinal))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool MatchesOnDisk(string path, string expectedHash)
+    {
+        if (!File.Exists(path))
+            return false;
+        return Sha256(File.ReadAllText(path)) == expectedHash;
+    }
+
+    private static string ResolveOutputPath(string outputDir, string relativePath) =>
+        Path.Combine(outputDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    private static string Sha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string NormalizePath(string path) => Path.GetFullPath(path);
+}

--- a/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
+++ b/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
@@ -66,7 +66,9 @@ public static class CacheKeyBuilder
         var hashes = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var file in files)
         {
-            var content = string.IsNullOrEmpty(prefixBlock) ? file.Content : prefixBlock + file.Content;
+            var content = string.IsNullOrEmpty(prefixBlock)
+                ? file.Content
+                : prefixBlock + file.Content;
             hashes[file.RelativePath] = Sha256(content);
         }
         return hashes;

--- a/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
+++ b/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
@@ -10,7 +10,9 @@ namespace Metano.Compiler.Caching;
 /// SHA-256 hashes from the Roslyn syntax trees, reference fingerprints from
 /// the metadata reference file paths (size + last-write-time tuple — fast and
 /// good enough to spot a swap or rebuild), and on-disk output hashes by
-/// re-hashing the files the previous run pinned in the cache.
+/// re-hashing the files the previous run pinned in the cache. Output reads
+/// stream through <see cref="SHA256.HashData(Stream)"/> so a 50 MB generated
+/// file does not balloon into a managed string.
 /// </summary>
 public static class CacheKeyBuilder
 {
@@ -24,8 +26,10 @@ public static class CacheKeyBuilder
             // anything on disk and cannot be re-read on a subsequent run.
             if (string.IsNullOrEmpty(tree.FilePath))
                 continue;
-            var text = tree.GetText().ToString();
-            hashes[NormalizePath(tree.FilePath)] = Sha256(text);
+            var checksum = tree.GetText().GetChecksum();
+            // Roslyn computes the checksum from the underlying SourceText
+            // stream incrementally — no full-file string materialization.
+            hashes[NormalizePath(tree.FilePath)] = HexEncode(checksum.AsSpan());
         }
         return hashes;
     }
@@ -69,43 +73,55 @@ public static class CacheKeyBuilder
             var content = string.IsNullOrEmpty(prefixBlock)
                 ? file.Content
                 : prefixBlock + file.Content;
-            hashes[file.RelativePath] = Sha256(content);
+            hashes[file.RelativePath] = HashUtf8(content);
         }
         return hashes;
     }
 
-    public static bool OutputsStillValid(
-        string outputDir,
-        IReadOnlyDictionary<string, string> expectedHashes
-    )
-    {
-        foreach (var (relativePath, expected) in expectedHashes)
-        {
-            if (!MatchesOnDisk(ResolveOutputPath(outputDir, relativePath), expected))
-                return false;
-        }
-        return true;
-    }
-
     /// <summary>
-    /// Reads each cached output file from disk and returns it as a
-    /// <see cref="GeneratedFile"/>, so the host can populate
-    /// <c>TranspileResult.Files</c> on a cache hit (callers that read it
-    /// post-run keep seeing every emitted artifact, not an empty list).
+    /// In one disk pass per cached output: validates that every cached
+    /// path is safe (no rooted, no <c>..</c>) and points at a file with
+    /// the recorded hash, while collecting <see cref="GeneratedFile"/>
+    /// entries for the host to return on a cache hit. Returns
+    /// <see langword="null"/> on first mismatch / missing file / bad path
+    /// — the host treats that as a cache miss and falls through to the
+    /// full pipeline.
     /// </summary>
-    public static IReadOnlyList<GeneratedFile> RehydrateFiles(
+    public static IReadOnlyList<GeneratedFile>? ValidateAndRehydrate(
         string outputDir,
-        IReadOnlyDictionary<string, string> outputHashes
+        IReadOnlyDictionary<string, string> outputHashes,
+        string? prefixBlock
     )
     {
-        var files = new List<GeneratedFile>(outputHashes.Count);
-        foreach (var relativePath in outputHashes.Keys)
+        var rehydrated = new List<GeneratedFile>(outputHashes.Count);
+        foreach (var (relativePath, expectedHash) in outputHashes)
         {
-            var path = ResolveOutputPath(outputDir, relativePath);
-            if (File.Exists(path))
-                files.Add(new GeneratedFile(relativePath, File.ReadAllText(path)));
+            if (!IsSafeRelativePath(relativePath))
+                return null;
+            var fullPath = ResolveOutputPath(outputDir, relativePath);
+            if (!File.Exists(fullPath))
+                return null;
+
+            // Read once: hash + capture content for rehydration. Streamed
+            // hash so large outputs don't allocate a full-file string.
+            string content;
+            using (var stream = File.OpenRead(fullPath))
+            {
+                var actualHash = HexEncode(SHA256.HashData(stream));
+                if (actualHash != expectedHash)
+                    return null;
+            }
+            content = File.ReadAllText(fullPath);
+            // Strip the prefix block so rehydrated GeneratedFile.Content
+            // matches what target.Transform would produce — the host
+            // re-applies the prefix at write time on the full-pipeline
+            // path, so callers reading TranspileResult.Files see the
+            // same shape regardless of cache hit / miss.
+            if (!string.IsNullOrEmpty(prefixBlock) && content.StartsWith(prefixBlock))
+                content = content[prefixBlock.Length..];
+            rehydrated.Add(new GeneratedFile(relativePath, content));
         }
-        return files;
+        return rehydrated;
     }
 
     public static bool DictionariesEqual(
@@ -125,22 +141,36 @@ public static class CacheKeyBuilder
         return true;
     }
 
-    private static bool MatchesOnDisk(string path, string expectedHash)
+    /// <summary>
+    /// Rejects rooted paths and any segment equal to <c>..</c> so a
+    /// hand-edited cache file cannot point <c>OutputsStillValid</c> /
+    /// <c>RehydrateFiles</c> at arbitrary disk locations.
+    /// </summary>
+    private static bool IsSafeRelativePath(string relativePath)
     {
-        if (!File.Exists(path))
+        if (string.IsNullOrEmpty(relativePath))
             return false;
-        return Sha256(File.ReadAllText(path)) == expectedHash;
+        if (Path.IsPathRooted(relativePath))
+            return false;
+        foreach (var segment in relativePath.Split('/', '\\'))
+        {
+            if (segment == "..")
+                return false;
+        }
+        return true;
     }
 
     private static string ResolveOutputPath(string outputDir, string relativePath) =>
         Path.Combine(outputDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
 
-    private static string Sha256(string content)
+    private static string HashUtf8(string content)
     {
         var bytes = Encoding.UTF8.GetBytes(content);
         var hash = SHA256.HashData(bytes);
-        return Convert.ToHexString(hash);
+        return HexEncode(hash);
     }
+
+    private static string HexEncode(ReadOnlySpan<byte> bytes) => Convert.ToHexString(bytes);
 
     private static string NormalizePath(string path) => Path.GetFullPath(path);
 }

--- a/src/Metano.Compiler/Caching/TranspilationCache.cs
+++ b/src/Metano.Compiler/Caching/TranspilationCache.cs
@@ -13,6 +13,11 @@ namespace Metano.Compiler.Caching;
 /// Cache invariants:
 /// </para>
 /// <list type="bullet">
+///   <item><b>Configuration fingerprint</b>: a stable string mixing the
+///   shared <c>--file-prefix</c> with each target's per-run flags
+///   (e.g., the TypeScript target's <c>NamespaceBarrels</c>,
+///   <c>StripInterfacePrefix</c>). Flag flips invalidate the cache even
+///   when sources and references are byte-identical.</item>
 ///   <item><b>Source hashes</b>: SHA-256 of every C# syntax tree the
 ///   compilation parsed. Catches body edits the type-level dependency
 ///   graph alone would miss (ADR-0018 leaves bodies out of the
@@ -35,12 +40,13 @@ namespace Metano.Compiler.Caching;
 public sealed record TranspilationCache(
     int FormatVersion,
     string Target,
+    string ConfigurationFingerprint,
     IReadOnlyDictionary<string, string> SourceHashes,
     IReadOnlyDictionary<string, string> ReferenceFingerprints,
     IReadOnlyDictionary<string, string> OutputHashes
 )
 {
-    public const int CurrentFormatVersion = 1;
+    public const int CurrentFormatVersion = 2;
     public const string FileName = ".metano-cache.json";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -49,6 +55,13 @@ public sealed record TranspilationCache(
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
 
+    /// <summary>
+    /// Reads <c>.metano-cache.json</c> from <paramref name="outputDir"/>.
+    /// Returns <see langword="null"/> on missing file, format-version
+    /// mismatch, JSON parse failure, or any partially populated section
+    /// (defense against a hand-edited cache with required dictionaries
+    /// stripped to <c>null</c>).
+    /// </summary>
     public static TranspilationCache? TryRead(string outputDir)
     {
         var path = Path.Combine(outputDir, FileName);
@@ -59,7 +72,19 @@ public sealed record TranspilationCache(
         {
             var json = File.ReadAllText(path);
             var cache = JsonSerializer.Deserialize<TranspilationCache>(json, JsonOptions);
-            return cache?.FormatVersion == CurrentFormatVersion ? cache : null;
+            if (cache is null)
+                return null;
+            if (cache.FormatVersion != CurrentFormatVersion)
+                return null;
+            if (
+                cache.Target is null
+                || cache.ConfigurationFingerprint is null
+                || cache.SourceHashes is null
+                || cache.ReferenceFingerprints is null
+                || cache.OutputHashes is null
+            )
+                return null;
+            return cache;
         }
         catch
         {

--- a/src/Metano.Compiler/Caching/TranspilationCache.cs
+++ b/src/Metano.Compiler/Caching/TranspilationCache.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+namespace Metano.Compiler.Caching;
+
+/// <summary>
+/// On-disk cache the transpiler writes after every successful run and
+/// inspects at the start of the next run to decide whether anything
+/// regenerates. The MVP scope (#21 PR 3a) is "skip the entire pipeline
+/// when nothing changed"; per-group skip lands in the follow-up
+/// (PR 3b) once a file-descriptor abstraction exists.
+///
+/// <para>
+/// Cache invariants:
+/// </para>
+/// <list type="bullet">
+///   <item><b>Source hashes</b>: SHA-256 of every C# syntax tree the
+///   compilation parsed. Catches body edits the type-level dependency
+///   graph alone would miss (ADR-0018 leaves bodies out of the
+///   signature surface).</item>
+///   <item><b>Reference fingerprints</b>: <c>length:lastWriteTimeUtc</c>
+///   per metadata reference. Picks up assembly swaps without reading
+///   the .dll bytes.</item>
+///   <item><b>Output hashes</b>: SHA-256 of every file the previous
+///   run emitted into the output directory. If a user (or
+///   <c>--clean</c> on a sibling target, or a manual <c>rm</c>) deletes
+///   a file we treat the cache as stale and regenerate.</item>
+/// </list>
+///
+/// <para>
+/// The cache file is stored at <c>&lt;outputDir&gt;/.metano-cache.json</c>
+/// so it lives next to the artifacts it describes; <c>--clean</c>
+/// wipes it alongside the outputs it pinned.
+/// </para>
+/// </summary>
+public sealed record TranspilationCache(
+    int FormatVersion,
+    string Target,
+    IReadOnlyDictionary<string, string> SourceHashes,
+    IReadOnlyDictionary<string, string> ReferenceFingerprints,
+    IReadOnlyDictionary<string, string> OutputHashes
+)
+{
+    public const int CurrentFormatVersion = 1;
+    public const string FileName = ".metano-cache.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static TranspilationCache? TryRead(string outputDir)
+    {
+        var path = Path.Combine(outputDir, FileName);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var cache = JsonSerializer.Deserialize<TranspilationCache>(json, JsonOptions);
+            return cache?.FormatVersion == CurrentFormatVersion ? cache : null;
+        }
+        catch
+        {
+            // A corrupt cache file is treated as a miss — the next
+            // run rebuilds from scratch and overwrites the bad file.
+            return null;
+        }
+    }
+
+    public void Write(string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+        var path = Path.Combine(outputDir, FileName);
+        File.WriteAllText(path, JsonSerializer.Serialize(this, JsonOptions));
+    }
+}

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -45,4 +45,15 @@ public interface ITranspilerTarget
     /// ignore the parameter entirely; Roslyn-dependent targets should surface a clear
     /// diagnostic when it is unavailable.</param>
     TargetOutput Transform(IrCompilation ir, Compilation? compilation);
+
+    /// <summary>
+    /// Stable fingerprint of every target-specific option that influences
+    /// generated output (e.g. the TypeScript target's <c>NamespaceBarrels</c>
+    /// or <c>StripInterfacePrefix</c> flags). The host folds this into the
+    /// incremental cache key (ADR-0021) so a flag flip invalidates the
+    /// cache even when sources and references are byte-identical. Default
+    /// returns the empty string — targets with no per-run flags have no
+    /// configuration that needs pinning.
+    /// </summary>
+    string ConfigurationFingerprint => string.Empty;
 }

--- a/src/Metano.Compiler/TranspileOptions.cs
+++ b/src/Metano.Compiler/TranspileOptions.cs
@@ -10,5 +10,6 @@ public sealed record TranspileOptions(
     bool ShowTimings = false,
     bool Clean = false,
     string? FilePrefix = null,
-    bool DryRun = false
+    bool DryRun = false,
+    bool NoCache = false
 );

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -213,7 +213,13 @@ public static class TranspilerHost
             return false;
         if (!string.Equals(cache.Target, targetLanguage, StringComparison.Ordinal))
             return false;
-        if (!string.Equals(cache.ConfigurationFingerprint, configFingerprint, StringComparison.Ordinal))
+        if (
+            !string.Equals(
+                cache.ConfigurationFingerprint,
+                configFingerprint,
+                StringComparison.Ordinal
+            )
+        )
             return false;
         if (!CacheKeyBuilder.DictionariesEqual(cache.SourceHashes, sourceHashes))
             return false;
@@ -221,7 +227,11 @@ public static class TranspilerHost
             return false;
 
         var prefixBlock = string.IsNullOrEmpty(filePrefix) ? null : filePrefix + "\n";
-        var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(outputDir, cache.OutputHashes, prefixBlock);
+        var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(
+            outputDir,
+            cache.OutputHashes,
+            prefixBlock
+        );
         if (rehydrated is null)
             return false;
 

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Metano.Compiler.Caching;
 using Metano.Compiler.Diagnostics;
 
 namespace Metano.Compiler;
@@ -51,6 +52,29 @@ public static class TranspilerHost
 
         if (options.ShowTimings)
             Console.WriteLine($"  Compilation: {compileSw.ElapsedMilliseconds}ms");
+
+        // Incremental cache short-circuit (#21 / ADR-0021): if every C#
+        // syntax tree, every metadata reference, and every output file
+        // matches the previously cached fingerprint, skip the rest of
+        // the pipeline. --clean (which already wiped the output dir
+        // including .metano-cache.json) and --no-cache opt out.
+        var sourceHashes = CacheKeyBuilder.ComputeSourceHashes(compilation);
+        var referenceFingerprints = CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
+        if (
+            ShouldAttemptCache(options)
+            && TryShortCircuitFromCache(
+                outputDir,
+                target.Language.ToString(),
+                sourceHashes,
+                referenceFingerprints,
+                options.ShowTimings,
+                totalSw,
+                out var cachedFiles
+            )
+        )
+        {
+            return new TranspileResult(true, cachedFiles, 0, 0);
+        }
 
         var transpileSw = Stopwatch.StartNew();
         var output = target.Transform(ir, compilation);
@@ -106,7 +130,78 @@ public static class TranspilerHost
 
         Console.WriteLine($"Metano: {output.Files.Count} file(s) generated in {outputDir}");
 
+        WriteCacheIfEnabled(
+            options,
+            target,
+            outputDir,
+            output.Files,
+            sourceHashes,
+            referenceFingerprints
+        );
+
         return new TranspileResult(true, output.Files, warningCount, 0);
+    }
+
+    private static bool ShouldAttemptCache(TranspileOptions options) =>
+        !options.NoCache && !options.DryRun && !options.Clean;
+
+    private static void WriteCacheIfEnabled(
+        TranspileOptions options,
+        ITranspilerTarget target,
+        string outputDir,
+        IReadOnlyList<GeneratedFile> files,
+        IReadOnlyDictionary<string, string> sourceHashes,
+        IReadOnlyDictionary<string, string> referenceFingerprints
+    )
+    {
+        if (options.NoCache || options.DryRun)
+            return;
+        var prefixBlock = string.IsNullOrEmpty(options.FilePrefix)
+            ? null
+            : options.FilePrefix + "\n";
+        var outputHashes = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock);
+        var cache = new TranspilationCache(
+            FormatVersion: TranspilationCache.CurrentFormatVersion,
+            Target: target.Language.ToString(),
+            SourceHashes: sourceHashes,
+            ReferenceFingerprints: referenceFingerprints,
+            OutputHashes: outputHashes
+        );
+        cache.Write(outputDir);
+    }
+
+    private static bool TryShortCircuitFromCache(
+        string outputDir,
+        string targetLanguage,
+        IReadOnlyDictionary<string, string> sourceHashes,
+        IReadOnlyDictionary<string, string> referenceFingerprints,
+        bool showTimings,
+        Stopwatch totalSw,
+        out IReadOnlyList<GeneratedFile> cachedFiles
+    )
+    {
+        cachedFiles = [];
+        var cache = TranspilationCache.TryRead(outputDir);
+        if (cache is null)
+            return false;
+        if (!string.Equals(cache.Target, targetLanguage, StringComparison.Ordinal))
+            return false;
+        if (!CacheKeyBuilder.DictionariesEqual(cache.SourceHashes, sourceHashes))
+            return false;
+        if (!CacheKeyBuilder.DictionariesEqual(cache.ReferenceFingerprints, referenceFingerprints))
+            return false;
+        if (!CacheKeyBuilder.OutputsStillValid(outputDir, cache.OutputHashes))
+            return false;
+
+        cachedFiles = CacheKeyBuilder.RehydrateFiles(outputDir, cache.OutputHashes);
+
+        totalSw.Stop();
+        Console.WriteLine(
+            $"Metano: incremental cache hit — {cache.OutputHashes.Count} output file(s) reused, no work to do."
+        );
+        if (showTimings)
+            Console.WriteLine($"  Total: {totalSw.ElapsedMilliseconds}ms");
+        return true;
     }
 
     private static void PrintDryRunSummary(string outputDir, IReadOnlyList<GeneratedFile> files)

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -54,26 +54,35 @@ public static class TranspilerHost
             Console.WriteLine($"  Compilation: {compileSw.ElapsedMilliseconds}ms");
 
         // Incremental cache short-circuit (#21 / ADR-0021): if every C#
-        // syntax tree, every metadata reference, and every output file
-        // matches the previously cached fingerprint, skip the rest of
-        // the pipeline. --clean (which already wiped the output dir
-        // including .metano-cache.json) and --no-cache opt out.
-        var sourceHashes = CacheKeyBuilder.ComputeSourceHashes(compilation);
-        var referenceFingerprints = CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
-        if (
-            ShouldAttemptCache(options)
-            && TryShortCircuitFromCache(
-                outputDir,
-                target.Language.ToString(),
-                sourceHashes,
-                referenceFingerprints,
-                options.ShowTimings,
-                totalSw,
-                out var cachedFiles
-            )
-        )
+        // syntax tree, every metadata reference, the target's emit-config
+        // fingerprint, and every output file match the previously cached
+        // fingerprint, skip the rest of the pipeline. --clean (which
+        // already wiped the output dir including .metano-cache.json) and
+        // --no-cache opt out. Hashes are computed lazily so a --no-cache
+        // run does not pay the SHA bill.
+        IReadOnlyDictionary<string, string>? sourceHashes = null;
+        IReadOnlyDictionary<string, string>? referenceFingerprints = null;
+        var configFingerprint = BuildConfigFingerprint(target, options);
+        if (ShouldAttemptCache(options))
         {
-            return new TranspileResult(true, cachedFiles, 0, 0);
+            sourceHashes = CacheKeyBuilder.ComputeSourceHashes(compilation);
+            referenceFingerprints = CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
+            if (
+                TryShortCircuitFromCache(
+                    outputDir,
+                    target.Language.ToString(),
+                    configFingerprint,
+                    sourceHashes,
+                    referenceFingerprints,
+                    options.FilePrefix,
+                    options.ShowTimings,
+                    totalSw,
+                    out var cachedFiles
+                )
+            )
+            {
+                return new TranspileResult(true, cachedFiles, 0, 0);
+            }
         }
 
         var transpileSw = Stopwatch.StartNew();
@@ -135,8 +144,10 @@ public static class TranspilerHost
             target,
             outputDir,
             output.Files,
+            configFingerprint,
             sourceHashes,
-            referenceFingerprints
+            referenceFingerprints,
+            compilation
         );
 
         return new TranspileResult(true, output.Files, warningCount, 0);
@@ -145,13 +156,21 @@ public static class TranspilerHost
     private static bool ShouldAttemptCache(TranspileOptions options) =>
         !options.NoCache && !options.DryRun && !options.Clean;
 
+    private static string BuildConfigFingerprint(
+        ITranspilerTarget target,
+        TranspileOptions options
+    ) =>
+        $"target={target.ConfigurationFingerprint};filePrefix={options.FilePrefix ?? string.Empty}";
+
     private static void WriteCacheIfEnabled(
         TranspileOptions options,
         ITranspilerTarget target,
         string outputDir,
         IReadOnlyList<GeneratedFile> files,
-        IReadOnlyDictionary<string, string> sourceHashes,
-        IReadOnlyDictionary<string, string> referenceFingerprints
+        string configFingerprint,
+        IReadOnlyDictionary<string, string>? sourceHashes,
+        IReadOnlyDictionary<string, string>? referenceFingerprints,
+        Microsoft.CodeAnalysis.Compilation compilation
     )
     {
         if (options.NoCache || options.DryRun)
@@ -160,9 +179,15 @@ public static class TranspilerHost
             ? null
             : options.FilePrefix + "\n";
         var outputHashes = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock);
+        // The read path may have skipped these on a --clean run (no cache
+        // to consult). Compute now so the freshly written cache is
+        // consultable on the next run.
+        sourceHashes ??= CacheKeyBuilder.ComputeSourceHashes(compilation);
+        referenceFingerprints ??= CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
         var cache = new TranspilationCache(
             FormatVersion: TranspilationCache.CurrentFormatVersion,
             Target: target.Language.ToString(),
+            ConfigurationFingerprint: configFingerprint,
             SourceHashes: sourceHashes,
             ReferenceFingerprints: referenceFingerprints,
             OutputHashes: outputHashes
@@ -173,8 +198,10 @@ public static class TranspilerHost
     private static bool TryShortCircuitFromCache(
         string outputDir,
         string targetLanguage,
+        string configFingerprint,
         IReadOnlyDictionary<string, string> sourceHashes,
         IReadOnlyDictionary<string, string> referenceFingerprints,
+        string? filePrefix,
         bool showTimings,
         Stopwatch totalSw,
         out IReadOnlyList<GeneratedFile> cachedFiles
@@ -186,15 +213,19 @@ public static class TranspilerHost
             return false;
         if (!string.Equals(cache.Target, targetLanguage, StringComparison.Ordinal))
             return false;
+        if (!string.Equals(cache.ConfigurationFingerprint, configFingerprint, StringComparison.Ordinal))
+            return false;
         if (!CacheKeyBuilder.DictionariesEqual(cache.SourceHashes, sourceHashes))
             return false;
         if (!CacheKeyBuilder.DictionariesEqual(cache.ReferenceFingerprints, referenceFingerprints))
             return false;
-        if (!CacheKeyBuilder.OutputsStillValid(outputDir, cache.OutputHashes))
+
+        var prefixBlock = string.IsNullOrEmpty(filePrefix) ? null : filePrefix + "\n";
+        var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(outputDir, cache.OutputHashes, prefixBlock);
+        if (rehydrated is null)
             return false;
 
-        cachedFiles = CacheKeyBuilder.RehydrateFiles(outputDir, cache.OutputHashes);
-
+        cachedFiles = rehydrated;
         totalSw.Stop();
         Console.WriteLine(
             $"Metano: incremental cache hit — {cache.OutputHashes.Count} output file(s) reused, no work to do."

--- a/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
@@ -1,0 +1,197 @@
+using Metano.Compiler;
+using Metano.Compiler.Caching;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin the on-disk shape of <see cref="TranspilationCache"/> and the helpers
+/// in <see cref="CacheKeyBuilder"/> so PR 3a's whole-build short-circuit
+/// (ADR-0021) stays correct as the schema evolves.
+/// </summary>
+public class TranspilationCacheTests
+{
+    private readonly List<string> _tempDirs = new();
+
+    [After(Test)]
+    public void DeleteTempDirs()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RoundTrip_PreservesEveryHashSection()
+    {
+        var dir = MakeTempDir();
+        var original = new TranspilationCache(
+            FormatVersion: TranspilationCache.CurrentFormatVersion,
+            Target: "TypeScript",
+            SourceHashes: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["/proj/src/Foo.cs"] = "abc123",
+            },
+            ReferenceFingerprints: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["/refs/Bar.dll"] = "12345:6789",
+            },
+            OutputHashes: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["src/foo.ts"] = "def456",
+            }
+        );
+
+        original.Write(dir);
+        var roundTripped = TranspilationCache.TryRead(dir);
+
+        await Assert.That(roundTripped).IsNotNull();
+        await Assert.That(roundTripped!.FormatVersion).IsEqualTo(original.FormatVersion);
+        await Assert.That(roundTripped.Target).IsEqualTo("TypeScript");
+        await Assert.That(roundTripped.SourceHashes["/proj/src/Foo.cs"]).IsEqualTo("abc123");
+        await Assert.That(roundTripped.ReferenceFingerprints["/refs/Bar.dll"])
+            .IsEqualTo("12345:6789");
+        await Assert.That(roundTripped.OutputHashes["src/foo.ts"]).IsEqualTo("def456");
+    }
+
+    [Test]
+    public async Task TryRead_ReturnsNull_WhenCacheFileMissing()
+    {
+        var dir = MakeTempDir();
+        var cache = TranspilationCache.TryRead(dir);
+        await Assert.That(cache).IsNull();
+    }
+
+    [Test]
+    public async Task TryRead_ReturnsNull_WhenFormatVersionMismatch()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, TranspilationCache.FileName),
+            """
+            {
+              "formatVersion": 999,
+              "target": "TypeScript",
+              "sourceHashes": {},
+              "referenceFingerprints": {},
+              "outputHashes": {}
+            }
+            """
+        );
+
+        var cache = TranspilationCache.TryRead(dir);
+        await Assert.That(cache).IsNull();
+    }
+
+    [Test]
+    public async Task TryRead_ReturnsNull_WhenJsonCorrupt()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, TranspilationCache.FileName),
+            "{ this is not valid json"
+        );
+
+        var cache = TranspilationCache.TryRead(dir);
+        await Assert.That(cache).IsNull();
+    }
+
+    [Test]
+    public async Task HashGeneratedContent_IsDeterministic_AndPrefixSensitive()
+    {
+        var files = new List<GeneratedFile>
+        {
+            new("a.ts", "export const x = 1;\n"),
+            new("b.ts", "export const y = 2;\n"),
+        };
+
+        var firstRun = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: null);
+        var secondRun = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: null);
+        var withSamePrefix = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: "// header\n");
+        var withDifferentPrefix = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: "// changed\n");
+
+        await Assert.That(firstRun["a.ts"]).IsEqualTo(secondRun["a.ts"]);
+        await Assert.That(withSamePrefix["a.ts"]).IsNotEqualTo(firstRun["a.ts"]);
+        await Assert.That(withSamePrefix["a.ts"]).IsNotEqualTo(withDifferentPrefix["a.ts"]);
+    }
+
+    [Test]
+    public async Task OutputsStillValid_DetectsMissingFile()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(Path.Combine(dir, "alive.ts"), "x");
+
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["alive.ts"] = Sha256("x"),
+            ["missing.ts"] = "anything",
+        };
+
+        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsFalse();
+    }
+
+    [Test]
+    public async Task OutputsStillValid_DetectsModifiedFile()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(Path.Combine(dir, "edited.ts"), "original");
+
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["edited.ts"] = Sha256("not-the-current-content"),
+        };
+
+        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsFalse();
+    }
+
+    [Test]
+    public async Task OutputsStillValid_TrueWhenAllHashesMatch()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(Path.Combine(dir, "match.ts"), "match");
+
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["match.ts"] = Sha256("match"),
+        };
+
+        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsTrue();
+    }
+
+    [Test]
+    public async Task RehydrateFiles_ReadsContentFromDisk_PreservesRelativePathOrder()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(Path.Combine(dir, "first.ts"), "alpha");
+        Directory.CreateDirectory(Path.Combine(dir, "nested"));
+        await File.WriteAllTextAsync(Path.Combine(dir, "nested", "second.ts"), "beta");
+
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["first.ts"] = Sha256("alpha"),
+            ["nested/second.ts"] = Sha256("beta"),
+        };
+
+        var rehydrated = CacheKeyBuilder.RehydrateFiles(dir, hashes);
+
+        await Assert.That(rehydrated.Count).IsEqualTo(2);
+        await Assert.That(rehydrated[0].Content).IsEqualTo("alpha");
+        await Assert.That(rehydrated[1].Content).IsEqualTo("beta");
+    }
+
+    private string MakeTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "metano-cache-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    private static string Sha256(string content)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
@@ -50,7 +50,8 @@ public class TranspilationCacheTests
         await Assert.That(roundTripped!.FormatVersion).IsEqualTo(original.FormatVersion);
         await Assert.That(roundTripped.Target).IsEqualTo("TypeScript");
         await Assert.That(roundTripped.SourceHashes["/proj/src/Foo.cs"]).IsEqualTo("abc123");
-        await Assert.That(roundTripped.ReferenceFingerprints["/refs/Bar.dll"])
+        await Assert
+            .That(roundTripped.ReferenceFingerprints["/refs/Bar.dll"])
             .IsEqualTo("12345:6789");
         await Assert.That(roundTripped.OutputHashes["src/foo.ts"]).IsEqualTo("def456");
     }
@@ -108,8 +109,14 @@ public class TranspilationCacheTests
 
         var firstRun = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: null);
         var secondRun = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: null);
-        var withSamePrefix = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: "// header\n");
-        var withDifferentPrefix = CacheKeyBuilder.HashGeneratedContent(files, prefixBlock: "// changed\n");
+        var withSamePrefix = CacheKeyBuilder.HashGeneratedContent(
+            files,
+            prefixBlock: "// header\n"
+        );
+        var withDifferentPrefix = CacheKeyBuilder.HashGeneratedContent(
+            files,
+            prefixBlock: "// changed\n"
+        );
 
         await Assert.That(firstRun["a.ts"]).IsEqualTo(secondRun["a.ts"]);
         await Assert.That(withSamePrefix["a.ts"]).IsNotEqualTo(firstRun["a.ts"]);
@@ -182,7 +189,10 @@ public class TranspilationCacheTests
 
     private string MakeTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "metano-cache-test-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Combine(
+            Path.GetTempPath(),
+            "metano-cache-test-" + Guid.NewGuid().ToString("N")
+        );
         Directory.CreateDirectory(dir);
         _tempDirs.Add(dir);
         return dir;

--- a/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
@@ -29,6 +29,7 @@ public class TranspilationCacheTests
         var original = new TranspilationCache(
             FormatVersion: TranspilationCache.CurrentFormatVersion,
             Target: "TypeScript",
+            ConfigurationFingerprint: "namespaceBarrels=False;stripInterfacePrefix=False",
             SourceHashes: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["/proj/src/Foo.cs"] = "abc123",
@@ -49,6 +50,8 @@ public class TranspilationCacheTests
         await Assert.That(roundTripped).IsNotNull();
         await Assert.That(roundTripped!.FormatVersion).IsEqualTo(original.FormatVersion);
         await Assert.That(roundTripped.Target).IsEqualTo("TypeScript");
+        await Assert.That(roundTripped.ConfigurationFingerprint)
+            .IsEqualTo("namespaceBarrels=False;stripInterfacePrefix=False");
         await Assert.That(roundTripped.SourceHashes["/proj/src/Foo.cs"]).IsEqualTo("abc123");
         await Assert
             .That(roundTripped.ReferenceFingerprints["/refs/Bar.dll"])
@@ -74,9 +77,28 @@ public class TranspilationCacheTests
             {
               "formatVersion": 999,
               "target": "TypeScript",
+              "configurationFingerprint": "",
               "sourceHashes": {},
               "referenceFingerprints": {},
               "outputHashes": {}
+            }
+            """
+        );
+
+        var cache = TranspilationCache.TryRead(dir);
+        await Assert.That(cache).IsNull();
+    }
+
+    [Test]
+    public async Task TryRead_ReturnsNull_WhenRequiredSectionMissing()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, TranspilationCache.FileName),
+            $$"""
+            {
+              "formatVersion": {{TranspilationCache.CurrentFormatVersion}},
+              "target": "TypeScript"
             }
             """
         );
@@ -124,7 +146,7 @@ public class TranspilationCacheTests
     }
 
     [Test]
-    public async Task OutputsStillValid_DetectsMissingFile()
+    public async Task ValidateAndRehydrate_ReturnsNull_WhenFileMissing()
     {
         var dir = MakeTempDir();
         await File.WriteAllTextAsync(Path.Combine(dir, "alive.ts"), "x");
@@ -135,11 +157,12 @@ public class TranspilationCacheTests
             ["missing.ts"] = "anything",
         };
 
-        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsFalse();
+        var result = CacheKeyBuilder.ValidateAndRehydrate(dir, expected, prefixBlock: null);
+        await Assert.That(result).IsNull();
     }
 
     [Test]
-    public async Task OutputsStillValid_DetectsModifiedFile()
+    public async Task ValidateAndRehydrate_ReturnsNull_WhenFileModified()
     {
         var dir = MakeTempDir();
         await File.WriteAllTextAsync(Path.Combine(dir, "edited.ts"), "original");
@@ -149,25 +172,12 @@ public class TranspilationCacheTests
             ["edited.ts"] = Sha256("not-the-current-content"),
         };
 
-        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsFalse();
+        var result = CacheKeyBuilder.ValidateAndRehydrate(dir, expected, prefixBlock: null);
+        await Assert.That(result).IsNull();
     }
 
     [Test]
-    public async Task OutputsStillValid_TrueWhenAllHashesMatch()
-    {
-        var dir = MakeTempDir();
-        await File.WriteAllTextAsync(Path.Combine(dir, "match.ts"), "match");
-
-        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["match.ts"] = Sha256("match"),
-        };
-
-        await Assert.That(CacheKeyBuilder.OutputsStillValid(dir, expected)).IsTrue();
-    }
-
-    [Test]
-    public async Task RehydrateFiles_ReadsContentFromDisk_PreservesRelativePathOrder()
+    public async Task ValidateAndRehydrate_ReturnsFiles_WhenAllHashesMatch()
     {
         var dir = MakeTempDir();
         await File.WriteAllTextAsync(Path.Combine(dir, "first.ts"), "alpha");
@@ -180,11 +190,57 @@ public class TranspilationCacheTests
             ["nested/second.ts"] = Sha256("beta"),
         };
 
-        var rehydrated = CacheKeyBuilder.RehydrateFiles(dir, hashes);
+        var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(dir, hashes, prefixBlock: null);
 
-        await Assert.That(rehydrated.Count).IsEqualTo(2);
-        await Assert.That(rehydrated[0].Content).IsEqualTo("alpha");
-        await Assert.That(rehydrated[1].Content).IsEqualTo("beta");
+        await Assert.That(rehydrated).IsNotNull();
+        await Assert.That(rehydrated!.Count).IsEqualTo(2);
+        await Assert.That(rehydrated.Any(f => f.Content == "alpha")).IsTrue();
+        await Assert.That(rehydrated.Any(f => f.Content == "beta")).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAndRehydrate_StripsPrefix_FromOnDiskContent()
+    {
+        var dir = MakeTempDir();
+        var prefix = "// header\n";
+        var raw = "export const x = 1;\n";
+        await File.WriteAllTextAsync(Path.Combine(dir, "prefixed.ts"), prefix + raw);
+
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["prefixed.ts"] = Sha256(prefix + raw),
+        };
+
+        var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(dir, hashes, prefixBlock: prefix);
+
+        await Assert.That(rehydrated).IsNotNull();
+        await Assert.That(rehydrated![0].Content).IsEqualTo(raw);
+    }
+
+    [Test]
+    public async Task ValidateAndRehydrate_RejectsRootedPath()
+    {
+        var dir = MakeTempDir();
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["/etc/passwd"] = "anything",
+        };
+
+        var result = CacheKeyBuilder.ValidateAndRehydrate(dir, hashes, prefixBlock: null);
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ValidateAndRehydrate_RejectsParentSegment()
+    {
+        var dir = MakeTempDir();
+        var hashes = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["../escape.ts"] = "anything",
+        };
+
+        var result = CacheKeyBuilder.ValidateAndRehydrate(dir, hashes, prefixBlock: null);
+        await Assert.That(result).IsNull();
     }
 
     private string MakeTempDir()

--- a/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
@@ -50,7 +50,8 @@ public class TranspilationCacheTests
         await Assert.That(roundTripped).IsNotNull();
         await Assert.That(roundTripped!.FormatVersion).IsEqualTo(original.FormatVersion);
         await Assert.That(roundTripped.Target).IsEqualTo("TypeScript");
-        await Assert.That(roundTripped.ConfigurationFingerprint)
+        await Assert
+            .That(roundTripped.ConfigurationFingerprint)
             .IsEqualTo("namespaceBarrels=False;stripInterfacePrefix=False");
         await Assert.That(roundTripped.SourceHashes["/proj/src/Foo.cs"]).IsEqualTo("abc123");
         await Assert


### PR DESCRIPTION
## Summary

PR 3a/4 of the #21 + #18 thread. Adds a JSON cache file at `<outputDir>/.metano-cache.json` that pins per-source SHA-256, per-reference `length:lastWriteTimeUtc`, and per-output content hashes. `TranspilerHost.RunAsync` short-circuits the whole pipeline when every fingerprint matches and every cached output file still exists with matching content. Watch-mode (#18) noop ticks now cost only the load + extract phases.

- Cache opt-out via `--no-cache` (wired through `metano-typescript` and `metano-dart`)
- `--clean` and `--dry-run` skip both reading and writing
- Cache hits rehydrate `TranspileResult.Files` from disk so post-run consumers keep seeing every emitted artifact
- ADR-0021 documents the design + the deferred bits (per-type sig hashing, per-group skip → PR 3b)

### Roadmap (#21 + #18)

- [x] PR 1 — type-level dependency graph (#211)
- [x] PR 2 — parallel TypeTransformer (#213)
- [x] PR 3a — incremental cache: whole-build short-circuit (this PR)
- [ ] PR 3b — per-group skip via file-descriptor abstraction
- [ ] PR 4 — watch mode (#18)

### Known limitation (deferred to PR 3b)

Target-specific post-emit hooks (today only TypeScript's `PackageJsonWriter`) skip on cache hits because their inputs (`target.LastSourceFiles`, `target.LastEmitPackageName`, ...) live on the target instance and only get populated by `target.Transform`. The writer is idempotent (merge semantics) so an existing `package.json` survives correctly; the failure mode is "user deletes `package.json` between runs" — recovery is `--clean` or `--no-cache`. PR 3b folds the post-emit hook into the cache so this round-trips automatically.

## Test plan

- [x] 9 new unit tests for `TranspilationCache` round-trip, format-version mismatch, JSON corruption recovery, content hashing determinism, output-validity predicates, and rehydration
- [x] 996 total .NET tests pass (was 987)
- [x] Manual smoke: first run writes cache, second run hits, `touch` (no content change) stays a hit, real edit misses, deleted output file misses
- [x] Generated TS under `targets/` byte-identical
- [x] dual-agent review (compiler-man + bob) — addressed structural / readability findings; documented PackageJsonWriter limitation

Part of #21
Part of #18