### PR TITLE
feat(compiler): per-group skip foundation — type + closure signature hashing

### DIFF
--- a/docs/adr/0023-per-group-skip-foundation.md
+++ b/docs/adr/0023-per-group-skip-foundation.md
@@ -1,0 +1,147 @@
+# ADR-0023 — Per-group skip foundation: type + closure signature hashing
+
+**Status:** Accepted (foundation only — integration deferred)
+**Date:** 2026-05-11
+
+## Context
+
+PR 3a (#214 / ADR-0021) shipped the whole-build short-circuit: if
+every source file, reference fingerprint, and output content matches
+the previous run, the entire pipeline is skipped. The follow-up
+asked for **per-group skip**: when only one file group's closure
+changes, only that group regenerates while the rest of the build
+reuses cached output.
+
+The dependency graph from PR 1 (#211 / ADR-0018) gives the
+"what types belong to a closure" answer. What's missing is the
+"did this closure change?" answer — a stable fingerprint that
+flips on body edits, signature edits, and attribute edits to
+anything inside the closure, and stays stable when an unrelated
+type elsewhere in the project moves.
+
+## Decision
+
+Ship the per-type and per-closure hashers as standalone, reusable
+primitives in `src/Metano.Compiler/Caching/`. The integration into
+`TypeTransformer.TransformGroup` is deferred to a follow-up PR
+once the file-descriptor abstraction is designed (see
+"Deferred" below).
+
+### `IrTypeSignatureHasher.Hash(INamedTypeSymbol)`
+
+SHA-256 over a deterministic serialization that includes:
+
+- **Identity**: FQN, TypeKind, accessibility, modifiers
+  (abstract / sealed / static / record / value-type / readonly),
+  generic arity.
+- **Hierarchy**: base type FQN, every interface FQN (sorted).
+- **Attributes**: every `[…]` on the type, sorted, with
+  constructor argument values folded in via
+  `TypedConstant` pretty-printing.
+- **Members**: every method / property / field / event signature
+  (sorted), including return / parameter types, accessibility,
+  static / virtual / override / abstract bits, ref kinds, params
+  and default-value presence.
+- **Body text**: the full declaring-syntax text per partial
+  declaration. This catches edits to method bodies, field
+  initializers, and property getters that the symbol shape alone
+  would miss — the dep graph (ADR-0018) is signature-only, so
+  body-level invalidation has to live here.
+
+### `GroupClosureHasher.HashGroupClosure(groupFqns, graph, sigIndex)`
+
+SHA-256 over the per-type hashes of every member of the group's
+**transitive dependency closure**, sorted by FQN. Combined with
+the global cache key from PR 3a (target language + configuration
+fingerprint + reference fingerprints), this becomes the exact
+unit of invalidation per-group skip will need: change a type
+inside the closure and the hash flips; change a type outside
+and the hash stays.
+
+`BuildSignatureHashIndex` amortises `Hash()` across groups whose
+closures overlap (a popular base class gets hashed once, then
+reused for every dependent group).
+
+### Why these primitives, separately, now
+
+The hashers stand on their own:
+
+- Pure functions, no shared state, trivially testable.
+- The dep graph (PR 1) is already merged; the hasher is the
+  smallest unit that turns "graph + symbol" into "stable cache
+  key".
+- Future per-group skip integration only needs to *call* these —
+  they pin the contract of what counts as a "change" so the
+  integration PR is a wiring exercise, not a design exercise.
+
+## Deferred (follow-up PR)
+
+The wiring inside `TypeTransformer` is not in this PR. The
+blocker is the **file-descriptor abstraction**: downstream stages
+(`BarrelFileGenerator`, `CyclicReferenceDetector`) consume the
+full `TsSourceFile` AST. A cache hit must hand them something
+that walks identically without forcing the per-group transform
+to actually run.
+
+Two designs under consideration for the follow-up:
+
+1. **Stub `TsSourceFile`**: reconstruct a `TsSourceFile` from
+   cached metadata containing exactly the AST nodes the two
+   downstream stages read (TsImport + minimal export markers).
+   Lightweight cache schema but brittle — any new downstream
+   stage that reads other AST nodes silently breaks.
+2. **`IGeneratedFileSummary` interface**: refactor
+   `BarrelFileGenerator` and `CyclicReferenceDetector` to consume
+   a lightweight descriptor (path + import paths + export entries).
+   `TsSourceFile` implements it via an AST walk; cached files
+   implement it from the on-disk metadata. Cleaner long-term but
+   touches more files.
+
+The follow-up PR will pick one based on the trade-offs and
+deliver the user-visible per-group skip.
+
+## Consequences
+
+(+) The dep graph (PR 1) gets a concrete consumer; before this
+   only the architectural ADR (ADR-0018) referenced it.
+(+) The cache invalidation key for per-group skip is now defined,
+   tested, and frozen. The follow-up PR cannot accidentally
+   diverge.
+(+) The hashers are reusable beyond per-group skip — any future
+   incremental work (cross-target consistency checks, type-level
+   diff tooling) can layer on the same fingerprint.
+(−) No user-visible improvement in this PR. The win lands in the
+   follow-up.
+(−) The hashers cost CPU per run even when nothing else uses
+   them. Mitigation: callers opt in by invoking
+   `BuildSignatureHashIndex` only when the per-group cache path
+   activates.
+
+## Alternatives considered
+
+- **Inline the hasher into `TypeTransformer`.** Rejected: hides a
+  load-bearing primitive inside an already-large class and makes
+  unit testing the invalidation contract harder.
+- **Hash from the IR instead of Roslyn symbols.** Rejected for
+  the MVP: `IrCompilation.Modules` is not eagerly populated
+  (ADR-0018), and the targets read from the Roslyn symbols
+  directly during transform. Hashing from symbols matches what
+  the transform actually depends on.
+- **Reuse PR 3a's source-file SHA as the per-group hash.**
+  Rejected: a source file can declare multiple types belonging
+  to different groups, and one type's edit would invalidate
+  unrelated groups that happened to share a `.cs` file. The
+  type-level fingerprint is the right granularity.
+
+## References
+
+- `src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs`
+- `src/Metano.Compiler/Caching/GroupClosureHasher.cs`
+- `tests/Metano.Tests/Caching/IrTypeSignatureHasherTests.cs`
+- `tests/Metano.Tests/Caching/GroupClosureHasherTests.cs`
+- ADR-0018 — type-level dependency graph (the closure walker)
+- ADR-0020 — parallel TypeTransformer (the loop the skip will
+  cut into)
+- ADR-0021 — incremental cache (the per-group entries layer on
+  top of the whole-build cache)
+- Issue #21 — incremental compilation + parallel TypeTransformer

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,3 +43,4 @@ second-guess when they meet the code without the context that led to it.
 | [ADR-0020](0020-parallel-type-transformer.md)                    | Parallel `TypeTransformer` per file group + thread-safe shared state           |
 | [ADR-0021](0021-incremental-cache.md)                            | Incremental cache: whole-build short-circuit on source/reference/output match  |
 | [ADR-0022](0022-watch-mode.md)                                   | `--watch` mode: file-system watcher + debounce on top of the cache + parallel  |
+| [ADR-0023](0023-per-group-skip-foundation.md)                    | Per-group skip foundation: per-type + closure signature hashing (PR 3b setup)  |

--- a/src/Metano.Compiler/Caching/GroupClosureHasher.cs
+++ b/src/Metano.Compiler/Caching/GroupClosureHasher.cs
@@ -1,0 +1,93 @@
+using System.Security.Cryptography;
+using System.Text;
+using Metano.Compiler.Analysis;
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.Caching;
+
+/// <summary>
+/// Computes the cache-invalidation key for a single file group
+/// (PR 3b / ADR-0023): the SHA-256 of the per-type signature
+/// hashes for every type in the group <em>plus every type the
+/// group transitively depends on</em>, sorted by FQN for stable
+/// order.
+///
+/// <para>
+/// Combined with the global cache key from PR 3a
+/// (target language + configuration fingerprint + reference
+/// fingerprints), the group closure hash is the exact unit of
+/// invalidation the per-group skip path needs: change a type
+/// inside the closure and the hash flips; change a type outside
+/// the closure and the hash stays.
+/// </para>
+/// </summary>
+public static class GroupClosureHasher
+{
+    /// <summary>
+    /// Builds <c>{ FQN → signature hash }</c> for every transpilable
+    /// type in the compilation. Intended to be computed once per run
+    /// and re-used across <see cref="HashGroupClosure"/> calls (the
+    /// number of groups is small, but their closures overlap heavily;
+    /// caching the per-type hash avoids hashing a popular base class
+    /// dozens of times).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> BuildSignatureHashIndex(
+        IEnumerable<INamedTypeSymbol> transpilableTypes
+    )
+    {
+        var index = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var symbol in transpilableTypes)
+        {
+            var fqn = IrTypeDependencyGraph.QualifiedName(symbol);
+            // Multiple groups can ask about the same type; hash once.
+            if (!index.ContainsKey(fqn))
+                index[fqn] = IrTypeSignatureHasher.Hash(symbol);
+        }
+        return index;
+    }
+
+    /// <summary>
+    /// Hashes the closure of <paramref name="groupTypeFqns"/> using
+    /// the dependency graph and the pre-computed per-type signature
+    /// index. The closure is "every group type plus every transitive
+    /// dependent" — that is the set of types whose change would
+    /// require regenerating this group's output files.
+    /// </summary>
+    /// <param name="groupTypeFqns">FQNs of types declared in the
+    /// group (the ones <c>GroupTypesByFile</c> placed together).</param>
+    /// <param name="graph">Dependency graph from PR 1.</param>
+    /// <param name="signatureHashes">Pre-computed
+    /// <c>FQN → SHA-256(sig)</c> map from
+    /// <see cref="BuildSignatureHashIndex"/>.</param>
+    public static string HashGroupClosure(
+        IEnumerable<string> groupTypeFqns,
+        IrTypeDependencyGraph graph,
+        IReadOnlyDictionary<string, string> signatureHashes
+    )
+    {
+        var closure = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var fqn in groupTypeFqns)
+        {
+            if (closure.Add(fqn))
+            {
+                foreach (var dep in graph.TransitiveDependenciesOf(fqn))
+                    closure.Add(dep);
+            }
+        }
+
+        var sb = new StringBuilder();
+        foreach (var fqn in closure.OrderBy(s => s, StringComparer.Ordinal))
+        {
+            sb.Append(fqn).Append('=');
+            // Types outside the transpilable set (BCL, foreign assemblies)
+            // do not have entries here; the global reference fingerprint
+            // from PR 3a already covers their churn.
+            if (signatureHashes.TryGetValue(fqn, out var hash))
+                sb.Append(hash);
+            sb.Append('\0');
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+        return Convert.ToHexString(SHA256.HashData(bytes));
+    }
+}

--- a/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
+++ b/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
@@ -61,7 +61,9 @@ public static class IrTypeSignatureHasher
         if (symbol.BaseType is { } baseType)
             sb.Append("base=").Append(baseType.ToDisplayString()).Append('\0');
 
-        foreach (var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal))
+        foreach (
+            var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal)
+        )
             sb.Append("iface=").Append(iface.ToDisplayString()).Append('\0');
 
         AppendAttributes(sb, symbol.GetAttributes());

--- a/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
+++ b/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
@@ -37,6 +37,17 @@ namespace Metano.Compiler.Caching;
 /// </summary>
 public static class IrTypeSignatureHasher
 {
+    /// <summary>
+    /// Stable type-display format. <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/>
+    /// pins every namespace + containing-type prefix and expands nullable
+    /// + ref-kind decorations, so a short-name collision in one
+    /// namespace cannot quietly tie two unrelated types to the same
+    /// hash and a future change to Roslyn's default <c>ToDisplayString</c>
+    /// cannot drift the cache key.
+    /// </summary>
+    private static readonly SymbolDisplayFormat StableFormat =
+        SymbolDisplayFormat.FullyQualifiedFormat;
+
     public static string Hash(INamedTypeSymbol symbol)
     {
         var sb = new StringBuilder();
@@ -59,12 +70,12 @@ public static class IrTypeSignatureHasher
         sb.Append("arity=").Append(symbol.Arity).Append('\0');
 
         if (symbol.BaseType is { } baseType)
-            sb.Append("base=").Append(baseType.ToDisplayString()).Append('\0');
+            sb.Append("base=").Append(baseType.ToDisplayString(StableFormat)).Append('\0');
 
         foreach (
-            var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal)
+            var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(StableFormat), StringComparer.Ordinal)
         )
-            sb.Append("iface=").Append(iface.ToDisplayString()).Append('\0');
+            sb.Append("iface=").Append(iface.ToDisplayString(StableFormat)).Append('\0');
 
         AppendAttributes(sb, symbol.GetAttributes());
 
@@ -91,29 +102,42 @@ public static class IrTypeSignatureHasher
         member switch
         {
             IMethodSymbol m =>
-                $"method:{m.MethodKind}:{m.Name}({string.Join(",", m.Parameters.Select(FormatParam))})->{m.ReturnType.ToDisplayString()};acc={m.DeclaredAccessibility};static={m.IsStatic};virt={m.IsVirtual};over={m.IsOverride};abs={m.IsAbstract}",
+                $"method:{m.MethodKind}:{m.Name}({string.Join(",", m.Parameters.Select(FormatParam))})->{m.ReturnType.ToDisplayString(StableFormat)};acc={m.DeclaredAccessibility};static={m.IsStatic};virt={m.IsVirtual};over={m.IsOverride};abs={m.IsAbstract}",
             IPropertySymbol p =>
-                $"prop:{p.Name}:{p.Type.ToDisplayString()};get={p.GetMethod is not null};set={p.SetMethod is not null};acc={p.DeclaredAccessibility};static={p.IsStatic}",
+                $"prop:{p.Name}:{p.Type.ToDisplayString(StableFormat)};get={p.GetMethod is not null};set={p.SetMethod is not null};acc={p.DeclaredAccessibility};static={p.IsStatic}",
             IFieldSymbol f =>
-                $"field:{f.Name}:{f.Type.ToDisplayString()};acc={f.DeclaredAccessibility};static={f.IsStatic};readonly={f.IsReadOnly};const={f.IsConst}",
+                $"field:{f.Name}:{f.Type.ToDisplayString(StableFormat)};acc={f.DeclaredAccessibility};static={f.IsStatic};readonly={f.IsReadOnly};const={f.IsConst}",
             IEventSymbol e =>
-                $"event:{e.Name}:{e.Type.ToDisplayString()};acc={e.DeclaredAccessibility};static={e.IsStatic}",
+                $"event:{e.Name}:{e.Type.ToDisplayString(StableFormat)};acc={e.DeclaredAccessibility};static={e.IsStatic}",
             _ => $"other:{member.Kind}:{member.Name}",
         };
 
     private static string FormatParam(IParameterSymbol p) =>
-        $"{p.RefKind}:{p.Type.ToDisplayString()}:{(p.IsParams ? "params:" : "")}{(p.HasExplicitDefaultValue ? "default" : "")}";
+        $"{p.RefKind}:{p.Type.ToDisplayString(StableFormat)}:{(p.IsParams ? "params:" : "")}{(p.HasExplicitDefaultValue ? "default" : "")}";
 
     private static void AppendAttributes(StringBuilder sb, IReadOnlyList<AttributeData> attributes)
     {
         var formatted = attributes
             .Where(a => a.AttributeClass is not null)
-            .Select(a =>
-                $"{a.AttributeClass!.ToDisplayString()}({string.Join(",", a.ConstructorArguments.Select(FormatConstant))})"
-            )
+            .Select(FormatAttribute)
             .OrderBy(s => s, StringComparer.Ordinal);
         foreach (var attr in formatted)
             sb.Append("attr=").Append(attr).Append('\0');
+    }
+
+    private static string FormatAttribute(AttributeData a)
+    {
+        var ctorArgs = string.Join(",", a.ConstructorArguments.Select(FormatConstant));
+        // Named arguments (e.g., [Foo(Bar = 1)]) are sorted by key so
+        // the order written in source can't shift the hash, and
+        // included so changes to a named property invalidate the
+        // cache the same way ctor-arg edits do.
+        var namedArgs = string.Join(
+            ",",
+            a.NamedArguments.OrderBy(p => p.Key, StringComparer.Ordinal)
+                .Select(p => $"{p.Key}={FormatConstant(p.Value)}")
+        );
+        return $"{a.AttributeClass!.ToDisplayString(StableFormat)}({ctorArgs}|{namedArgs})";
     }
 
     private static string FormatConstant(TypedConstant constant) =>
@@ -121,6 +145,11 @@ public static class IrTypeSignatureHasher
         {
             TypedConstantKind.Array =>
                 $"[{string.Join(",", constant.Values.Select(FormatConstant))}]",
+            // typeof(T) constants carry an ITypeSymbol whose default
+            // ToString isn't guaranteed to be stable across Roslyn
+            // versions; format with the explicit FullyQualifiedFormat.
+            TypedConstantKind.Type when constant.Value is ITypeSymbol t =>
+                $"typeof({t.ToDisplayString(StableFormat)})",
             _ => constant.Value?.ToString() ?? "null",
         };
 

--- a/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
+++ b/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
@@ -1,0 +1,131 @@
+using System.Security.Cryptography;
+using System.Text;
+using Metano.Compiler.Analysis;
+using Microsoft.CodeAnalysis;
+
+namespace Metano.Compiler.Caching;
+
+/// <summary>
+/// Computes a stable per-type fingerprint from a Roslyn
+/// <see cref="INamedTypeSymbol"/>. The fingerprint is the unit of
+/// invalidation for the per-group incremental skip
+/// (#21 / ADR-0023 / PR 3b) — when a type's hash changes, every
+/// group whose closure contains that type regenerates.
+///
+/// <para>
+/// The hash mixes everything that can affect emission for the type:
+/// </para>
+/// <list type="bullet">
+///   <item>Fully qualified name + kind (class / struct / record /
+///   interface / enum / delegate)</item>
+///   <item>Modifiers: <c>IsAbstract</c>, <c>IsSealed</c>,
+///   <c>IsStatic</c>, <c>IsRecord</c>, <c>IsValueType</c>,
+///   accessibility, <c>IsGenericType</c> + arity</item>
+///   <item>Base type FQN, every interface FQN (sorted)</item>
+///   <item>Every member's signature (sorted): name, kind, return
+///   type, parameter types, accessibility, refness</item>
+///   <item>The full normalized syntax text of every declaring node,
+///   so body edits invalidate the hash even though the dep graph
+///   itself is signature-only (ADR-0018)</item>
+/// </list>
+///
+/// <para>
+/// Attributes are folded in via the type-level metadata; the body
+/// text inclusion is what catches a method-body edit that does not
+/// touch any signature member.
+/// </para>
+/// </summary>
+public static class IrTypeSignatureHasher
+{
+    public static string Hash(INamedTypeSymbol symbol)
+    {
+        var sb = new StringBuilder();
+        AppendType(sb, symbol);
+        return Sha256(sb.ToString());
+    }
+
+    private static void AppendType(StringBuilder sb, INamedTypeSymbol symbol)
+    {
+        sb.Append("TYPE\0");
+        sb.Append(IrTypeDependencyGraph.QualifiedName(symbol)).Append('\0');
+        sb.Append(symbol.TypeKind).Append('\0');
+        sb.Append(symbol.DeclaredAccessibility).Append('\0');
+        sb.Append("abstract=").Append(symbol.IsAbstract).Append('\0');
+        sb.Append("sealed=").Append(symbol.IsSealed).Append('\0');
+        sb.Append("static=").Append(symbol.IsStatic).Append('\0');
+        sb.Append("record=").Append(symbol.IsRecord).Append('\0');
+        sb.Append("value=").Append(symbol.IsValueType).Append('\0');
+        sb.Append("readonly=").Append(symbol.IsReadOnly).Append('\0');
+        sb.Append("arity=").Append(symbol.Arity).Append('\0');
+
+        if (symbol.BaseType is { } baseType)
+            sb.Append("base=").Append(baseType.ToDisplayString()).Append('\0');
+
+        foreach (var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(), StringComparer.Ordinal))
+            sb.Append("iface=").Append(iface.ToDisplayString()).Append('\0');
+
+        AppendAttributes(sb, symbol.GetAttributes());
+
+        var members = symbol
+            .GetMembers()
+            .Where(m => m is not INamedTypeSymbol)
+            .Select(MemberSignature)
+            .OrderBy(s => s, StringComparer.Ordinal);
+        foreach (var member in members)
+            sb.Append("member=").Append(member).Append('\0');
+
+        // Body edits (method bodies, field initializers, property
+        // getters) live in the syntax text but not in the symbol
+        // shape. Fold the full declaring-syntax text in so any source
+        // change to this type triggers a re-hash.
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            var node = reference.GetSyntax();
+            sb.Append("syntax=").Append(node.ToFullString()).Append('\0');
+        }
+    }
+
+    private static string MemberSignature(ISymbol member) =>
+        member switch
+        {
+            IMethodSymbol m =>
+                $"method:{m.MethodKind}:{m.Name}({string.Join(",", m.Parameters.Select(FormatParam))})->{m.ReturnType.ToDisplayString()};acc={m.DeclaredAccessibility};static={m.IsStatic};virt={m.IsVirtual};over={m.IsOverride};abs={m.IsAbstract}",
+            IPropertySymbol p =>
+                $"prop:{p.Name}:{p.Type.ToDisplayString()};get={p.GetMethod is not null};set={p.SetMethod is not null};acc={p.DeclaredAccessibility};static={p.IsStatic}",
+            IFieldSymbol f =>
+                $"field:{f.Name}:{f.Type.ToDisplayString()};acc={f.DeclaredAccessibility};static={f.IsStatic};readonly={f.IsReadOnly};const={f.IsConst}",
+            IEventSymbol e =>
+                $"event:{e.Name}:{e.Type.ToDisplayString()};acc={e.DeclaredAccessibility};static={e.IsStatic}",
+            _ => $"other:{member.Kind}:{member.Name}",
+        };
+
+    private static string FormatParam(IParameterSymbol p) =>
+        $"{p.RefKind}:{p.Type.ToDisplayString()}:{(p.IsParams ? "params:" : "")}{(p.HasExplicitDefaultValue ? "default" : "")}";
+
+    private static void AppendAttributes(StringBuilder sb, IReadOnlyList<AttributeData> attributes)
+    {
+        var formatted = attributes
+            .Where(a => a.AttributeClass is not null)
+            .Select(a =>
+                $"{a.AttributeClass!.ToDisplayString()}({string.Join(",", a.ConstructorArguments.Select(FormatConstant))})"
+            )
+            .OrderBy(s => s, StringComparer.Ordinal);
+        foreach (var attr in formatted)
+            sb.Append("attr=").Append(attr).Append('\0');
+    }
+
+    private static string FormatConstant(TypedConstant constant) =>
+        constant.Kind switch
+        {
+            TypedConstantKind.Array =>
+                $"[{string.Join(",", constant.Values.Select(FormatConstant))}]",
+            _ => constant.Value?.ToString() ?? "null",
+        };
+
+    private static string Sha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
+++ b/src/Metano.Compiler/Caching/IrTypeSignatureHasher.cs
@@ -73,7 +73,10 @@ public static class IrTypeSignatureHasher
             sb.Append("base=").Append(baseType.ToDisplayString(StableFormat)).Append('\0');
 
         foreach (
-            var iface in symbol.Interfaces.OrderBy(i => i.ToDisplayString(StableFormat), StringComparer.Ordinal)
+            var iface in symbol.Interfaces.OrderBy(
+                i => i.ToDisplayString(StableFormat),
+                StringComparer.Ordinal
+            )
         )
             sb.Append("iface=").Append(iface.ToDisplayString(StableFormat)).Append('\0');
 

--- a/tests/Metano.Tests/Caching/GroupClosureHasherTests.cs
+++ b/tests/Metano.Tests/Caching/GroupClosureHasherTests.cs
@@ -1,0 +1,104 @@
+using Metano.Compiler;
+using Metano.Compiler.Analysis;
+using Metano.Compiler.Caching;
+using Metano.Tests.IR;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin the closure-hash semantics for PR 3b's per-group skip:
+/// editing a type in the closure flips the hash, editing a type
+/// outside the closure does NOT flip it.
+/// </summary>
+public class GroupClosureHasherTests
+{
+    [Test]
+    public async Task SameClosure_AcrossRuns_ProducesSameHash()
+    {
+        var a = HashClosureOf("Demo.Order", BaselineSource);
+        var b = HashClosureOf("Demo.Order", BaselineSource);
+        await Assert.That(a).IsEqualTo(b);
+    }
+
+    [Test]
+    public async Task EditingSeedType_FlipsHash()
+    {
+        var before = HashClosureOf("Demo.Order", BaselineSource);
+        var after = HashClosureOf(
+            "Demo.Order",
+            BaselineSource.Replace("record Order(Money Total)", "record Order(Money Total, int Quantity)")
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
+    public async Task EditingDependency_FlipsHash()
+    {
+        var before = HashClosureOf("Demo.Order", BaselineSource);
+        // Edit Money (Order's dependency) — Order's closure includes Money,
+        // so the hash must flip even though Order itself didn't change.
+        var after = HashClosureOf(
+            "Demo.Order",
+            BaselineSource.Replace("record Money(decimal Amount, string Currency)", "record Money(decimal Amount, string Currency, string Note)")
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
+    public async Task EditingTypeOutsideClosure_KeepsHash()
+    {
+        var before = HashClosureOf("Demo.Order", BaselineSource);
+        // Customer is transpilable but NOT in Order's closure (Order does
+        // not reference Customer). Editing Customer must not invalidate
+        // Order's group.
+        var after = HashClosureOf(
+            "Demo.Order",
+            BaselineSource.Replace("record Customer(string Name)", "record Customer(string Name, string Email)")
+        );
+        await Assert.That(before).IsEqualTo(after);
+    }
+
+    private const string BaselineSource =
+        """
+        namespace Demo;
+
+        [Transpile]
+        public sealed record Money(decimal Amount, string Currency);
+
+        [Transpile]
+        public sealed record Order(Money Total);
+
+        [Transpile]
+        public sealed record Customer(string Name);
+        """;
+
+    private static string HashClosureOf(string fqn, string source)
+    {
+        var compilation = IrTestHelper.Compile(source);
+        var transpilable = EnumerateTranspilableTypes(compilation).ToList();
+        var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
+        var graph = IrTypeDependencyGraph.Build(ir);
+        var sigIndex = GroupClosureHasher.BuildSignatureHashIndex(transpilable);
+        return GroupClosureHasher.HashGroupClosure(new[] { fqn }, graph, sigIndex);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateTranspilableTypes(
+        CSharpCompilation compilation
+    )
+    {
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var node in tree.GetRoot().DescendantNodes())
+            {
+                if (
+                    model.GetDeclaredSymbol(node) is INamedTypeSymbol named
+                    && named.GetAttributes().Any(a => a.AttributeClass?.Name == "TranspileAttribute")
+                )
+                    yield return named;
+            }
+        }
+    }
+}

--- a/tests/Metano.Tests/Caching/GroupClosureHasherTests.cs
+++ b/tests/Metano.Tests/Caching/GroupClosureHasherTests.cs
@@ -28,7 +28,10 @@ public class GroupClosureHasherTests
         var before = HashClosureOf("Demo.Order", BaselineSource);
         var after = HashClosureOf(
             "Demo.Order",
-            BaselineSource.Replace("record Order(Money Total)", "record Order(Money Total, int Quantity)")
+            BaselineSource.Replace(
+                "record Order(Money Total)",
+                "record Order(Money Total, int Quantity)"
+            )
         );
         await Assert.That(before).IsNotEqualTo(after);
     }
@@ -41,7 +44,10 @@ public class GroupClosureHasherTests
         // so the hash must flip even though Order itself didn't change.
         var after = HashClosureOf(
             "Demo.Order",
-            BaselineSource.Replace("record Money(decimal Amount, string Currency)", "record Money(decimal Amount, string Currency, string Note)")
+            BaselineSource.Replace(
+                "record Money(decimal Amount, string Currency)",
+                "record Money(decimal Amount, string Currency, string Note)"
+            )
         );
         await Assert.That(before).IsNotEqualTo(after);
     }
@@ -55,13 +61,15 @@ public class GroupClosureHasherTests
         // Order's group.
         var after = HashClosureOf(
             "Demo.Order",
-            BaselineSource.Replace("record Customer(string Name)", "record Customer(string Name, string Email)")
+            BaselineSource.Replace(
+                "record Customer(string Name)",
+                "record Customer(string Name, string Email)"
+            )
         );
         await Assert.That(before).IsEqualTo(after);
     }
 
-    private const string BaselineSource =
-        """
+    private const string BaselineSource = """
         namespace Demo;
 
         [Transpile]
@@ -95,7 +103,9 @@ public class GroupClosureHasherTests
             {
                 if (
                     model.GetDeclaredSymbol(node) is INamedTypeSymbol named
-                    && named.GetAttributes().Any(a => a.AttributeClass?.Name == "TranspileAttribute")
+                    && named
+                        .GetAttributes()
+                        .Any(a => a.AttributeClass?.Name == "TranspileAttribute")
                 )
                     yield return named;
             }

--- a/tests/Metano.Tests/Caching/IrTypeSignatureHasherTests.cs
+++ b/tests/Metano.Tests/Caching/IrTypeSignatureHasherTests.cs
@@ -122,6 +122,28 @@ public class IrTypeSignatureHasherTests
     }
 
     [Test]
+    public async Task AttributeNamedArgEdit_ChangesHash()
+    {
+        var before = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile, Import("Foo", "foo", Version = "1.0.0")]
+            public sealed class Foo {}
+            """
+        );
+        var after = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile, Import("Foo", "foo", Version = "2.0.0")]
+            public sealed class Foo {}
+            """
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
     public async Task BaseTypeChange_ChangesHash()
     {
         var before = HashFirstTranspilableType(

--- a/tests/Metano.Tests/Caching/IrTypeSignatureHasherTests.cs
+++ b/tests/Metano.Tests/Caching/IrTypeSignatureHasherTests.cs
@@ -1,0 +1,176 @@
+using Metano.Compiler;
+using Metano.Compiler.Caching;
+using Metano.Tests.IR;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin the per-type signature hash so the per-group skip path
+/// (PR 3b / ADR-0023) has a stable invalidation key. Coverage:
+/// equal sources hash equal, body edits change the hash even when
+/// signatures stay the same, signature edits change the hash, and
+/// attribute edits change the hash.
+/// </summary>
+public class IrTypeSignatureHasherTests
+{
+    [Test]
+    public async Task IdenticalSource_ProducesIdenticalHash()
+    {
+        var hashA = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Foo(int Value);
+            """
+        );
+        var hashB = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed record Foo(int Value);
+            """
+        );
+        await Assert.That(hashA).IsEqualTo(hashB);
+    }
+
+    [Test]
+    public async Task BodyEdit_ChangesHash_EvenWithoutSignatureChange()
+    {
+        var before = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Foo
+            {
+                public int Compute(int x) => x + 1;
+            }
+            """
+        );
+        var after = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Foo
+            {
+                public int Compute(int x) => x + 2;
+            }
+            """
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
+    public async Task SignatureEdit_ChangesHash()
+    {
+        var before = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Foo
+            {
+                public int Compute(int x) => x + 1;
+            }
+            """
+        );
+        var after = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Foo
+            {
+                public int Compute(int x, int y) => x + y;
+            }
+            """
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
+    public async Task AttributeEdit_ChangesHash()
+    {
+        var before = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile]
+            public sealed class Foo
+            {
+                public int Value { get; init; }
+            }
+            """
+        );
+        var after = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            [Transpile, Name("Bar")]
+            public sealed class Foo
+            {
+                public int Value { get; init; }
+            }
+            """
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    [Test]
+    public async Task BaseTypeChange_ChangesHash()
+    {
+        var before = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            public abstract class BaseA {}
+
+            [Transpile]
+            public sealed class Foo : BaseA {}
+            """,
+            typeName: "Foo"
+        );
+        var after = HashFirstTranspilableType(
+            """
+            namespace Demo;
+
+            public abstract class BaseB {}
+
+            [Transpile]
+            public sealed class Foo : BaseB {}
+            """,
+            typeName: "Foo"
+        );
+        await Assert.That(before).IsNotEqualTo(after);
+    }
+
+    private static string HashFirstTranspilableType(string source, string? typeName = null)
+    {
+        var compilation = IrTestHelper.Compile(source);
+        var symbol = FindType(compilation, typeName);
+        return IrTypeSignatureHasher.Hash(symbol);
+    }
+
+    private static INamedTypeSymbol FindType(CSharpCompilation compilation, string? typeName)
+    {
+        var visited = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var node in tree.GetRoot().DescendantNodes())
+            {
+                if (model.GetDeclaredSymbol(node) is INamedTypeSymbol named && visited.Add(named))
+                {
+                    if (typeName is null || named.Name == typeName)
+                        return named;
+                }
+            }
+        }
+        throw new InvalidOperationException($"Type '{typeName ?? "<first>"}' not found.");
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the per-group skip work (PR 3b). Adds two reusable, tested primitives in `src/Metano.Compiler/Caching/`:

- `IrTypeSignatureHasher.Hash(symbol)` — SHA-256 over a deterministic serialization of a Roslyn `INamedTypeSymbol` (identity, hierarchy, attributes, sorted member signatures, plus full declaring-syntax text so body edits invalidate even though the dep graph from ADR-0018 stays signature-only).
- `GroupClosureHasher.HashGroupClosure(groupFqns, graph, sigIndex)` — combines the per-type hashes for a group's transitive dependency closure into a single fingerprint. `BuildSignatureHashIndex` amortises the per-type hash across groups whose closures overlap.

The TypeTransformer integration (the user-visible per-group skip) is **explicitly deferred**. ADR-0023 explains why: downstream stages (`BarrelFileGenerator`, `CyclicReferenceDetector`) consume the full `TsSourceFile` AST, and a cache hit needs to hand them something that walks identically. Two designs are sketched in the ADR (stub `TsSourceFile` vs `IGeneratedFileSummary` interface); the integration PR picks one.

Why ship this alone:
- The hashers are pure functions — trivially testable, no shared state.
- The cache-invalidation contract is now frozen and reviewable. The integration PR becomes a wiring exercise, not a design exercise.
- The dep graph (PR 1) gets a concrete consumer; before this only ADR-0018 referenced it.

### Roadmap (#21 + #18)

- [x] PR 1 — type-level dependency graph (#211)
- [x] PR 2 — parallel TypeTransformer (#213)
- [x] PR 3a — incremental cache: whole-build short-circuit (#214)
- [x] PR 4 — watch mode (#215)
- [ ] **PR 3b — per-group skip (this PR is the foundation; integration is a follow-up)**

## Test plan

- [x] 9 new tests across the two hashers (1023 total .NET tests pass, was 1014)
- [x] `IrTypeSignatureHasher`: identical-source determinism, body edit flips, signature edit flips, attribute edit flips, base-type change flips
- [x] `GroupClosureHasher`: identical-closure determinism, seed-type edit flips, dependency edit flips (even when seed didn't change), edits to types **outside** the closure stay equal
- [x] Build green; `targets/` byte-identical
- [x] ADR-0023 + index updated

Part of #21