### PR TITLE
feat(compiler): per-group skip integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,9 @@ Thumbs.db
 bun.lock
 
 # Metano incremental cache — pinned next to generated outputs
-# (ADR-0021). Per-machine, never committed.
+# (ADR-0021, ADR-0024). Per-machine, never committed.
 .metano-cache.json
+.metano-cache-groups-*.json
 
 # Local working plans (per CLAUDE.md workflow — private per-session notes,
 # not committed — the authoritative backlog lives in GitHub issues)

--- a/docs/adr/0024-per-group-skip-integration.md
+++ b/docs/adr/0024-per-group-skip-integration.md
@@ -1,0 +1,170 @@
+# ADR-0024 — Per-group skip integration
+
+**Status:** Accepted
+**Date:** 2026-05-11
+
+## Context
+
+PR 3b (#216 / ADR-0023) shipped the hashers — `IrTypeSignatureHasher`
+for per-type fingerprints and `GroupClosureHasher` for per-group
+closure hashes. PR 3a (#214 / ADR-0021) shipped the whole-build
+short-circuit. Per-type sig hash plus the dep graph from PR 1
+(#211 / ADR-0018) gave us "did this group's closure change?", but
+the question we punted was **how to wire the skip into
+`TypeTransformer` without breaking downstream stages**
+(`BarrelFileGenerator`, `CyclicReferenceDetector`) that consume the
+full `TsSourceFile` AST.
+
+ADR-0023 sketched two designs (stub `TsSourceFile` vs
+`IGeneratedFileSummary` interface). This PR picks the **stub**
+design — surgical, minimal file churn, no abstraction refactor —
+and documents the constraints.
+
+## Decision
+
+### Cache file: `<outputDir>/.metano-cache-groups-typescript.json`
+
+Per-target group cache, keyed by `namespace/fileName`:
+
+```json
+{
+  "formatVersion": 1,
+  "groups": {
+    "Demo.Issues.Domain/issue": {
+      "closureHash": "<sha256>",
+      "files": [
+        {
+          "path": "issues/domain/issue.ts",
+          "imports": [
+            { "names": ["UserId"], "from": "#/shared-kernel/user-id" }
+          ],
+          "exports": [
+            { "name": "Issue", "typeOnly": false }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+The TypeScript target manages this file independently from PR 3a's
+target-agnostic cache; both files coexist next to the generated
+output so a single `--clean` wipes both.
+
+### Stub `TsSourceFile` on cache hit
+
+`FileMetadataExtractor`:
+- `Extract(TsSourceFile)` → builds `CachedFileMetadata` (path,
+  imports preserved with full `TsImport` shape, exports collapsed
+  to `(name, typeOnly)` pairs).
+- `BuildStub(CachedFileMetadata)` → reconstructs a stub
+  `TsSourceFile` with the original `TsImport` records plus minimal
+  export markers (`TsInterface` for type-only, `TsConstObject` for
+  value). Those are exactly the two `TsTopLevel` shapes the
+  downstream stages match on.
+
+The stub flows through `BarrelFileGenerator` and
+`CyclicReferenceDetector` identically to a fresh AST: barrel
+emission picks the right re-export form (value vs type-only),
+cycle detection walks the imports.
+
+### Bypass the Printer for cached files
+
+The stub deliberately does **not** carry the real body. Printing it
+would produce empty TypeScript, overwriting the cached `.ts` file.
+`TypeTransformer.CachedFileContents` exposes the raw on-disk
+content per cache-hit path (with the host's file-prefix block
+stripped so the emit pass can re-apply it without doubling). The
+TypeScript target consults this map before calling `Printer.Print`
+— hits emit the cached content verbatim, misses go through the
+normal printer.
+
+### Skip decision
+
+`TypeTransformer.TransformAll`:
+
+1. Build the dep graph + per-type sig index (`BuildSignatureHashIndex`).
+2. Compute the closure hash for every group (`HashGroupClosure`).
+3. Load the on-disk group cache if `CacheOutputDir` is set.
+4. Per group, inside the existing `Parallel.For`:
+   - **Hit** when the cached entry's closure hash matches AND the
+     on-disk file still exists. Build the stub, store the raw
+     content, increment the skip counter, return.
+   - **Miss** runs `TransformGroup` as before. Extract the
+     metadata for the next run's cache.
+5. After the loop, write the fresh cache (all groups, hits and
+   misses).
+
+A summary line —
+`Per-group cache: 17/18 group(s) reused from cache.` — fires when
+the skip activates.
+
+### Why ITranspilerTarget.Transform now takes outputDir + filePrefix
+
+The TypeScript target needs to know **where** the cache lives and
+**which prefix** to strip from cached content. The host knew both
+all along; we extended `Transform` with two optional parameters
+instead of inventing a side-channel property. Backwards-compatible
+default (`null`) keeps any third-party target compiling.
+
+## Consequences
+
+(+) PR 3a's whole-build path stays as the fast lane; PR 3c wins
+   when PR 3a misses but only one type changed — a single editor
+   save now regenerates one file, the other N-1 reuse the disk
+   content.
+(+) Watch mode (#18 / ADR-0022) inherits the per-group skip
+   automatically — the same `TranspilerHost.RunAsync` runs on
+   every tick.
+(+) No abstraction refactor. `BarrelFileGenerator` and
+   `CyclicReferenceDetector` are unchanged. The stub design's risk
+   (downstream stages start reading other AST nodes) is contained
+   to two callers and easy to revisit if it bites.
+(+) Smoke-verified on SampleIssueTracker: 18 groups, one type
+   edit → 17 reused, 1 regenerated; byte-identical output.
+(−) The stub approach assumes downstream stages only read
+   `TsImport` + the seven export-bearing `TsTopLevel` variants
+   (`TsClass`, `TsFunction`, `TsEnum`, `TsConstObject`,
+   `TsNamespaceDeclaration`, `TsTypeAlias`, `TsInterface`). Any
+   future stage that reads e.g. `TsVariableDeclaration` will
+   silently get an empty list from a cached file. The
+   `FileMetadataExtractor` is the contract point — extend it
+   when adding a new downstream stage.
+(−) Group cache is target-specific (different file name per
+   target). Cross-target reuse is not in scope.
+(−) Per-group cache only invalidates when a closure member's hash
+   changes. Edits to types **outside** every group's closure
+   (orphaned types) leave the cache stale on disk; PR 3a's
+   reference-fingerprint check catches edits to BCL / foreign
+   assemblies, but a truly orphaned source file would not flip
+   the per-group cache. Acceptable today — orphaned types do not
+   emit and so do not appear in any group anyway.
+
+## Alternatives considered
+
+- **`IGeneratedFileSummary` interface refactor.** Cleaner
+  long-term but requires `BarrelFileGenerator` and
+  `CyclicReferenceDetector` to migrate. Out of scope for this PR.
+- **Cache the full `TsSourceFile` AST (JSON or binary).** Would
+  remove the stub fragility but at the cost of writing custom
+  `JsonConverter`s for every `TsTopLevel` subtype. Heavyweight
+  for the marginal win.
+- **Single shared cache file for all targets.** Rejected: the
+  per-group cache schema is target-specific (different AST
+  shapes per target). One file per target keeps the schemas
+  decoupled.
+
+## References
+
+- `src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs`
+- `src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs`
+- `src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs`
+- `src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs`
+  (`TransformAll` per-group skip block + helpers)
+- `src/Metano.Compiler.TypeScript/TypeScriptTarget.cs`
+  (`CachedFileContents` bypass)
+- ADR-0018 — dep graph
+- ADR-0021 — whole-build cache (the layer this builds on top of)
+- ADR-0023 — per-group hashers (PR 3b foundation)
+- Issue #21 — incremental compilation + parallel TypeTransformer

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,3 +44,4 @@ second-guess when they meet the code without the context that led to it.
 | [ADR-0021](0021-incremental-cache.md)                            | Incremental cache: whole-build short-circuit on source/reference/output match  |
 | [ADR-0022](0022-watch-mode.md)                                   | `--watch` mode: file-system watcher + debounce on top of the cache + parallel  |
 | [ADR-0023](0023-per-group-skip-foundation.md)                    | Per-group skip foundation: per-type + closure signature hashing (PR 3b setup)  |
+| [ADR-0024](0024-per-group-skip-integration.md)                   | Per-group skip integration: stub `TsSourceFile` + cache bypass for hit content |

--- a/src/Metano.Compiler.Dart/DartTarget.cs
+++ b/src/Metano.Compiler.Dart/DartTarget.cs
@@ -18,7 +18,12 @@ public sealed class DartTarget : ITranspilerTarget
 
     public IReadOnlyList<DartSourceFile> LastSourceFiles { get; private set; } = [];
 
-    public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
+    public TargetOutput Transform(
+        IrCompilation ir,
+        Compilation? compilation,
+        string? outputDir = null,
+        string? filePrefix = null
+    )
     {
         if (compilation is null)
             throw new NotSupportedException(

--- a/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
@@ -1,0 +1,36 @@
+namespace Metano.Compiler.TypeScript.Caching;
+
+/// <summary>
+/// Per-cached-file shape persisted alongside the per-group closure
+/// hash (ADR-0023 follow-up / PR 3c). On a per-group cache hit the
+/// host reads the file's content from disk and rebuilds a minimal
+/// <see cref="Metano.Compiler.TypeScript.AST.TsSourceFile"/> from
+/// this metadata so the downstream stages
+/// (<c>BarrelFileGenerator</c>, <c>CyclicReferenceDetector</c>) can
+/// walk it identically to a fresh AST.
+///
+/// <para>
+/// Imports preserve every detail of <c>TsImport</c> because both
+/// downstream consumers read the full shape (typeOnly,
+/// per-name typeOnlyNames, default form, namespace form, aliases).
+/// Exports keep only the name + a coarse type-vs-value flag — that
+/// is the only distinction the barrel emitter cares about.
+/// </para>
+/// </summary>
+public sealed record CachedFileMetadata(
+    string Path,
+    IReadOnlyList<CachedImport> Imports,
+    IReadOnlyList<CachedExport> Exports
+);
+
+public sealed record CachedImport(
+    IReadOnlyList<string> Names,
+    string From,
+    bool TypeOnly = false,
+    bool IsDefault = false,
+    IReadOnlyList<string>? TypeOnlyNames = null,
+    bool IsNamespace = false,
+    IReadOnlyDictionary<string, string>? Aliases = null
+);
+
+public sealed record CachedExport(string Name, bool TypeOnly);

--- a/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
@@ -19,6 +19,7 @@ namespace Metano.Compiler.TypeScript.Caching;
 /// </summary>
 public sealed record CachedFileMetadata(
     string Path,
+    string ContentHash,
     IReadOnlyList<CachedImport> Imports,
     IReadOnlyList<CachedExport> Exports
 );

--- a/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
@@ -44,9 +44,7 @@ public static class FileMetadataExtractor
                             import.From,
                             import.TypeOnly,
                             import.IsDefault,
-                            import.TypeOnlyNames is null
-                                ? null
-                                : import.TypeOnlyNames.ToArray(),
+                            import.TypeOnlyNames is null ? null : import.TypeOnlyNames.ToArray(),
                             import.IsNamespace,
                             import.Aliases
                         )

--- a/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
@@ -1,0 +1,113 @@
+using Metano.Compiler.TypeScript.AST;
+
+namespace Metano.Compiler.TypeScript.Caching;
+
+/// <summary>
+/// Extracts <see cref="CachedFileMetadata"/> from a freshly
+/// transformed <see cref="TsSourceFile"/> and rebuilds a stub
+/// <see cref="TsSourceFile"/> from cached metadata on a per-group
+/// hit (PR 3c). The stub contains exactly the AST nodes the
+/// barrel emitter and cyclic detector look at — every other
+/// statement is omitted, which is safe because the cached
+/// on-disk content is what actually gets written.
+///
+/// <para>
+/// Imports go through unchanged. Exports collapse to the
+/// minimum shape each downstream stage reads:
+/// </para>
+/// <list type="bullet">
+///   <item>Value exports → <see cref="TsConstObject"/> with the
+///   same <see cref="TsTopLevel"/>-level name. <c>BarrelFileGenerator</c>
+///   matches <c>TsConstObject { Exported: true }</c> in its
+///   <c>GetExportedName</c> switch and treats it as a value
+///   re-export.</item>
+///   <item>Type-only exports → <see cref="TsInterface"/>, which the
+///   barrel emitter treats as type-only. The empty
+///   property list keeps the stub minimal.</item>
+/// </list>
+/// </summary>
+public static class FileMetadataExtractor
+{
+    public static CachedFileMetadata Extract(TsSourceFile file)
+    {
+        var imports = new List<CachedImport>();
+        var exports = new List<CachedExport>();
+
+        foreach (var stmt in file.Statements)
+        {
+            switch (stmt)
+            {
+                case TsImport import:
+                    imports.Add(
+                        new CachedImport(
+                            import.Names,
+                            import.From,
+                            import.TypeOnly,
+                            import.IsDefault,
+                            import.TypeOnlyNames is null
+                                ? null
+                                : import.TypeOnlyNames.ToArray(),
+                            import.IsNamespace,
+                            import.Aliases
+                        )
+                    );
+                    break;
+                case TsClass { Exported: true } c:
+                    exports.Add(new CachedExport(c.Name, TypeOnly: false));
+                    break;
+                case TsFunction { Exported: true } f:
+                    exports.Add(new CachedExport(f.Name, TypeOnly: false));
+                    break;
+                case TsEnum { Exported: true } e:
+                    exports.Add(new CachedExport(e.Name, TypeOnly: false));
+                    break;
+                case TsConstObject { Exported: true } co:
+                    exports.Add(new CachedExport(co.Name, TypeOnly: false));
+                    break;
+                case TsNamespaceDeclaration { Exported: true } ns:
+                    exports.Add(new CachedExport(ns.Name, TypeOnly: false));
+                    break;
+                case TsTypeAlias { Exported: true } ta:
+                    exports.Add(new CachedExport(ta.Name, TypeOnly: true));
+                    break;
+                case TsInterface { Exported: true } i:
+                    exports.Add(new CachedExport(i.Name, TypeOnly: true));
+                    break;
+            }
+        }
+
+        return new CachedFileMetadata(file.FileName, imports, exports);
+    }
+
+    public static TsSourceFile BuildStub(CachedFileMetadata metadata)
+    {
+        var statements = new List<TsTopLevel>(metadata.Imports.Count + metadata.Exports.Count);
+
+        foreach (var import in metadata.Imports)
+        {
+            statements.Add(
+                new TsImport(
+                    import.Names.ToArray(),
+                    import.From,
+                    import.TypeOnly,
+                    import.IsDefault,
+                    import.TypeOnlyNames is null
+                        ? null
+                        : new HashSet<string>(import.TypeOnlyNames, StringComparer.Ordinal),
+                    import.IsNamespace,
+                    import.Aliases
+                )
+            );
+        }
+
+        foreach (var export in metadata.Exports)
+        {
+            if (export.TypeOnly)
+                statements.Add(new TsInterface(export.Name, []));
+            else
+                statements.Add(new TsConstObject(export.Name, []));
+        }
+
+        return new TsSourceFile(metadata.Path, statements);
+    }
+}

--- a/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Metano.Compiler.TypeScript.AST;
 
 namespace Metano.Compiler.TypeScript.Caching;
@@ -28,7 +30,7 @@ namespace Metano.Compiler.TypeScript.Caching;
 /// </summary>
 public static class FileMetadataExtractor
 {
-    public static CachedFileMetadata Extract(TsSourceFile file)
+    public static CachedFileMetadata Extract(TsSourceFile file, string content)
     {
         var imports = new List<CachedImport>();
         var exports = new List<CachedExport>();
@@ -74,7 +76,18 @@ public static class FileMetadataExtractor
             }
         }
 
-        return new CachedFileMetadata(file.FileName, imports, exports);
+        return new CachedFileMetadata(file.FileName, Sha256(content), imports, exports);
+    }
+
+    /// <summary>
+    /// Hex SHA-256 of UTF-8 <paramref name="content"/>. Used by the
+    /// per-group cache to fingerprint each emitted file so a stale
+    /// entry whose on-disk content has been edited gets rejected.
+    /// </summary>
+    public static string Sha256(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        return Convert.ToHexString(SHA256.HashData(bytes));
     }
 
     public static TsSourceFile BuildStub(CachedFileMetadata metadata)
@@ -107,5 +120,26 @@ public static class FileMetadataExtractor
         }
 
         return new TsSourceFile(metadata.Path, statements);
+    }
+
+    /// <summary>
+    /// Rejects rooted paths and any segment equal to <c>..</c> so a
+    /// hand-edited <c>.metano-cache-groups-typescript.json</c> cannot
+    /// redirect <c>File.ReadAllText</c> to an arbitrary disk
+    /// location (mirrors the safety check the host-level cache from
+    /// PR 3a applies in <c>CacheKeyBuilder</c>).
+    /// </summary>
+    public static bool IsSafeRelativePath(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+            return false;
+        if (Path.IsPathRooted(relativePath))
+            return false;
+        foreach (var segment in relativePath.Split('/', '\\'))
+        {
+            if (segment == "..")
+                return false;
+        }
+        return true;
     }
 }

--- a/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+namespace Metano.Compiler.TypeScript.Caching;
+
+/// <summary>
+/// Per-target persistence for the per-group skip cache (PR 3c).
+/// Lives next to <c>TranspilationCache</c>'s <c>.metano-cache.json</c>
+/// at <c>&lt;outputDir&gt;/.metano-cache-groups-typescript.json</c>;
+/// shape is keyed by the group key the
+/// <c>TypeScript</c> transformer uses for grouping
+/// (<c>namespace + fileName</c>).
+///
+/// <para>
+/// A group entry is valid for re-use when every output file it
+/// declares still matches the global <c>outputHashes</c> map kept
+/// by <see cref="Metano.Compiler.Caching.TranspilationCache"/> —
+/// the whole-build cache (PR 3a) verifies that map at the host
+/// layer before <c>target.Transform</c> ever runs, so the per-group
+/// hit path can trust it here.
+/// </para>
+/// </summary>
+public sealed record GroupCacheFile(
+    int FormatVersion,
+    IReadOnlyDictionary<string, GroupCacheEntry> Groups
+)
+{
+    public const int CurrentFormatVersion = 1;
+    public const string FileName = ".metano-cache-groups-typescript.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static GroupCacheFile? TryRead(string outputDir)
+    {
+        var path = Path.Combine(outputDir, FileName);
+        if (!File.Exists(path))
+            return null;
+        try
+        {
+            var json = File.ReadAllText(path);
+            var cache = JsonSerializer.Deserialize<GroupCacheFile>(json, JsonOptions);
+            if (cache is null)
+                return null;
+            if (cache.FormatVersion != CurrentFormatVersion)
+                return null;
+            if (cache.Groups is null)
+                return null;
+            return cache;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Write(string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+        var path = Path.Combine(outputDir, FileName);
+        File.WriteAllText(path, JsonSerializer.Serialize(this, JsonOptions));
+    }
+}
+
+public sealed record GroupCacheEntry(string ClosureHash, IReadOnlyList<CachedFileMetadata> Files);

--- a/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
@@ -11,20 +11,25 @@ namespace Metano.Compiler.TypeScript.Caching;
 /// (<c>namespace + fileName</c>).
 ///
 /// <para>
-/// A group entry is valid for re-use when every output file it
-/// declares still matches the global <c>outputHashes</c> map kept
-/// by <see cref="Metano.Compiler.Caching.TranspilationCache"/> —
-/// the whole-build cache (PR 3a) verifies that map at the host
-/// layer before <c>target.Transform</c> ever runs, so the per-group
-/// hit path can trust it here.
+/// A group entry is valid for re-use only when ALL of the
+/// following hold: (a) the cached <c>ConfigurationFingerprint</c>
+/// matches the active run's, (b) the cached closure hash matches
+/// the closure currently computed from the dep graph, and (c) the
+/// disk content's SHA-256 matches the cached
+/// <see cref="CachedFileMetadata.ContentHash"/>. The whole-build
+/// cache (PR 3a) verifies disk content on the short-circuit
+/// path, but on a normal transform run it does not — so this
+/// layer hashes the disk content itself before trusting the
+/// cached metadata.
 /// </para>
 /// </summary>
 public sealed record GroupCacheFile(
     int FormatVersion,
+    string ConfigurationFingerprint,
     IReadOnlyDictionary<string, GroupCacheEntry> Groups
 )
 {
-    public const int CurrentFormatVersion = 1;
+    public const int CurrentFormatVersion = 2;
     public const string FileName = ".metano-cache-groups-typescript.json";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -46,7 +51,7 @@ public sealed record GroupCacheFile(
                 return null;
             if (cache.FormatVersion != CurrentFormatVersion)
                 return null;
-            if (cache.Groups is null)
+            if (cache.Groups is null || cache.ConfigurationFingerprint is null)
                 return null;
             return cache;
         }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -92,8 +92,10 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// real file with the stub's empty body.
     /// </summary>
     public IReadOnlyDictionary<string, string> CachedFileContents => _cachedFileContents;
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _cachedFileContents =
-        new(StringComparer.Ordinal);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<
+        string,
+        string
+    > _cachedFileContents = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Diagnostics collected during transformation. Includes warnings about unsupported

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -92,7 +92,8 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// real file with the stub's empty body.
     /// </summary>
     public IReadOnlyDictionary<string, string> CachedFileContents => _cachedFileContents;
-    private readonly Dictionary<string, string> _cachedFileContents = new(StringComparer.Ordinal);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _cachedFileContents =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Diagnostics collected during transformation. Includes warnings about unsupported
@@ -372,10 +373,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                                 {
                                     diskContent = diskContent[prefixBlock.Length..];
                                 }
-                                lock (_cachedFileContents)
-                                {
-                                    _cachedFileContents[fileMeta.Path] = diskContent;
-                                }
+                                _cachedFileContents[fileMeta.Path] = diskContent;
                                 Interlocked.Increment(ref skippedGroupCount);
                                 return;
                             }

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -768,8 +768,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         List<INamedTypeSymbol> Types
     );
 
-    private static string GroupKey(TypeFileGroup group) =>
-        $"{group.Namespace}/{group.FileName}";
+    private static string GroupKey(TypeFileGroup group) => $"{group.Namespace}/{group.FileName}";
 
     /// <summary>
     /// Builds the per-group closure hash map (PR 3c). The signature
@@ -781,7 +780,10 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         IReadOnlyList<TypeFileGroup> groups
     )
     {
-        var allTypes = groups.SelectMany(g => g.Types).Distinct(SymbolEqualityComparer.Default).Cast<INamedTypeSymbol>();
+        var allTypes = groups
+            .SelectMany(g => g.Types)
+            .Distinct(SymbolEqualityComparer.Default)
+            .Cast<INamedTypeSymbol>();
         var sigIndex = GroupClosureHasher.BuildSignatureHashIndex(allTypes);
         var graph = IrTypeDependencyGraph.Build(ir);
 

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -1,6 +1,7 @@
 using Metano.Annotations;
 using Metano.Compiler;
 using Metano.Compiler.Analysis;
+using Metano.Compiler.Caching;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.Extraction;
 using Metano.Compiler.Frontend.Roslyn;
@@ -8,6 +9,7 @@ using Metano.Compiler.IR;
 using Metano.Compiler.Mappings;
 using Metano.Compiler.TypeScript.AST;
 using Metano.Compiler.TypeScript.Bridge;
+using Metano.Compiler.TypeScript.Caching;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -63,6 +65,34 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     /// Opt-in via <c>--strip-interface-prefix</c>.
     /// </summary>
     public bool StripInterfacePrefix { get; init; }
+
+    /// <summary>
+    /// Output directory for the active run, supplied by the host
+    /// (<see cref="Metano.Compiler.TranspilerHost"/>) so the per-group
+    /// cache (PR 3c) can live next to the generated <c>.ts</c> files.
+    /// <c>null</c> disables the per-group skip path — useful for unit
+    /// tests that drive the transformer with no on-disk side effects.
+    /// </summary>
+    public string? CacheOutputDir { get; init; }
+
+    /// <summary>
+    /// File-prefix block applied by the host at emit time. When set,
+    /// per-group cache hits strip it from the disk content before
+    /// re-publishing — the host re-applies the prefix on the next
+    /// write so storing the prefixed form would double it.
+    /// </summary>
+    public string? CacheFilePrefix { get; init; }
+
+    /// <summary>
+    /// On a per-group cache hit (PR 3c) the transformer reuses the
+    /// content already on disk: stub <c>TsSourceFile</c>s flow
+    /// through barrel + cyclic detection, but the printed output for
+    /// those paths comes straight from disk so the next emit
+    /// pass writes the same bytes back instead of corrupting the
+    /// real file with the stub's empty body.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> CachedFileContents => _cachedFileContents;
+    private readonly Dictionary<string, string> _cachedFileContents = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Diagnostics collected during transformation. Includes warnings about unsupported
@@ -251,6 +281,9 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         };
 
         var files = new List<TsSourceFile>();
+        var groups = new List<TypeFileGroup>();
+        var perGroupClosure = new Dictionary<string, string>(StringComparer.Ordinal);
+        var perGroupMetadata = Array.Empty<CachedFileMetadata[]>();
 
         // Publish the interface-prefix rename dict for the duration
         // of this transform so `IrToTsTypeMapper.MapNamed` rewrites
@@ -284,20 +317,88 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             // AsyncLocal writes inside a worker stay isolated. The result
             // list preserves source order via the group index so downstream
             // barrels and golden tests stay deterministic.
-            var groups = GroupTypesByFile(transpilableTypes);
+            groups = GroupTypesByFile(transpilableTypes);
+
+            // Per-group skip decision (PR 3c): for every group whose
+            // closure hash matches the cached entry, reuse the stub
+            // built from cached metadata and skip TransformGroup
+            // entirely. Misses run the full transform as before. The
+            // closure-hash index amortises per-type hashing across
+            // groups whose closures overlap.
+            perGroupClosure = ComputePerGroupClosure(ir, groups);
+            var cachedGroups = LoadGroupCache();
             var perGroupResults = new TsSourceFile?[groups.Count];
+            perGroupMetadata = new CachedFileMetadata[groups.Count][];
+            var skippedGroupCount = 0;
             Parallel.For(
                 0,
                 groups.Count,
                 index =>
                 {
-                    perGroupResults[index] = TransformGroup(groups[index]);
+                    var group = groups[index];
+                    var groupKey = GroupKey(group);
+                    if (
+                        cachedGroups is not null
+                        && perGroupClosure.TryGetValue(groupKey, out var closure)
+                        && cachedGroups.Groups.TryGetValue(groupKey, out var entry)
+                        && string.Equals(entry.ClosureHash, closure, StringComparison.Ordinal)
+                    )
+                    {
+                        // Hit: rebuild a stub TsSourceFile from cached
+                        // metadata. The host has already verified each
+                        // output file exists with matching content via
+                        // PR 3a's OutputsStillValid gate; if we got
+                        // here it means PR 3a missed for some other
+                        // reason but this group's slice is still good.
+                        if (entry.Files.Count == 1 && CacheOutputDir is not null)
+                        {
+                            var fileMeta = entry.Files[0];
+                            var diskPath = Path.Combine(
+                                CacheOutputDir,
+                                fileMeta.Path.Replace('/', Path.DirectorySeparatorChar)
+                            );
+                            if (File.Exists(diskPath))
+                            {
+                                perGroupResults[index] = FileMetadataExtractor.BuildStub(fileMeta);
+                                perGroupMetadata[index] = [fileMeta];
+                                var diskContent = File.ReadAllText(diskPath);
+                                var prefixBlock = string.IsNullOrEmpty(CacheFilePrefix)
+                                    ? null
+                                    : CacheFilePrefix + "\n";
+                                if (
+                                    prefixBlock is not null
+                                    && diskContent.StartsWith(prefixBlock, StringComparison.Ordinal)
+                                )
+                                {
+                                    diskContent = diskContent[prefixBlock.Length..];
+                                }
+                                lock (_cachedFileContents)
+                                {
+                                    _cachedFileContents[fileMeta.Path] = diskContent;
+                                }
+                                Interlocked.Increment(ref skippedGroupCount);
+                                return;
+                            }
+                        }
+                    }
+
+                    var produced = TransformGroup(group);
+                    perGroupResults[index] = produced;
+                    perGroupMetadata[index] = produced is null
+                        ? []
+                        : [FileMetadataExtractor.Extract(produced)];
                 }
             );
             for (var i = 0; i < perGroupResults.Length; i++)
             {
                 if (perGroupResults[i] is { } file)
                     files.Add(file);
+            }
+            if (skippedGroupCount > 0)
+            {
+                Console.WriteLine(
+                    $"  Per-group cache: {skippedGroupCount}/{groups.Count} group(s) reused from cache."
+                );
             }
         }
         finally
@@ -346,6 +447,8 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         {
             _crossPackageDependencies[packageName] = version;
         }
+
+        WriteGroupCache(groups, perGroupClosure, perGroupMetadata);
 
         return files;
     }
@@ -664,6 +767,58 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         string FileName,
         List<INamedTypeSymbol> Types
     );
+
+    private static string GroupKey(TypeFileGroup group) =>
+        $"{group.Namespace}/{group.FileName}";
+
+    /// <summary>
+    /// Builds the per-group closure hash map (PR 3c). The signature
+    /// hash index is amortised: a type appearing in N groups gets
+    /// hashed once.
+    /// </summary>
+    private static Dictionary<string, string> ComputePerGroupClosure(
+        IrCompilation ir,
+        IReadOnlyList<TypeFileGroup> groups
+    )
+    {
+        var allTypes = groups.SelectMany(g => g.Types).Distinct(SymbolEqualityComparer.Default).Cast<INamedTypeSymbol>();
+        var sigIndex = GroupClosureHasher.BuildSignatureHashIndex(allTypes);
+        var graph = IrTypeDependencyGraph.Build(ir);
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var group in groups)
+        {
+            var fqns = group.Types.Select(IrTypeDependencyGraph.QualifiedName);
+            result[GroupKey(group)] = GroupClosureHasher.HashGroupClosure(fqns, graph, sigIndex);
+        }
+        return result;
+    }
+
+    private GroupCacheFile? LoadGroupCache() =>
+        CacheOutputDir is null ? null : GroupCacheFile.TryRead(CacheOutputDir);
+
+    private void WriteGroupCache(
+        IReadOnlyList<TypeFileGroup> groups,
+        IReadOnlyDictionary<string, string> closures,
+        IReadOnlyList<CachedFileMetadata[]> metadata
+    )
+    {
+        if (CacheOutputDir is null)
+            return;
+        var entries = new Dictionary<string, GroupCacheEntry>(StringComparer.Ordinal);
+        for (var i = 0; i < groups.Count; i++)
+        {
+            var key = GroupKey(groups[i]);
+            if (!closures.TryGetValue(key, out var closure))
+                continue;
+            var files = metadata[i] ?? [];
+            if (files.Length == 0)
+                continue;
+            entries[key] = new GroupCacheEntry(closure, files);
+        }
+        var cache = new GroupCacheFile(GroupCacheFile.CurrentFormatVersion, entries);
+        cache.Write(CacheOutputDir);
+    }
 
     /// <summary>
     /// Rewrites every top-level transpilable interface whose C# name

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -861,12 +861,21 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         var diskContent = File.ReadAllText(diskPath);
         var prefixBlock = string.IsNullOrEmpty(CacheFilePrefix) ? null : CacheFilePrefix + "\n";
-        if (prefixBlock is not null && diskContent.StartsWith(prefixBlock, StringComparison.Ordinal))
+        if (
+            prefixBlock is not null
+            && diskContent.StartsWith(prefixBlock, StringComparison.Ordinal)
+        )
             diskContent = diskContent[prefixBlock.Length..];
 
         // Content-hash gate: a hand-edited output file (or any
         // out-of-band change) flips the hash and forces a miss.
-        if (!string.Equals(FileMetadataExtractor.Sha256(diskContent), meta.ContentHash, StringComparison.Ordinal))
+        if (
+            !string.Equals(
+                FileMetadataExtractor.Sha256(diskContent),
+                meta.ContentHash,
+                StringComparison.Ordinal
+            )
+        )
             return false;
 
         _cachedFileContents[meta.Path] = diskContent;

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -84,6 +84,15 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     public string? CacheFilePrefix { get; init; }
 
     /// <summary>
+    /// Target configuration fingerprint that participates in the
+    /// per-group cache key (combines <c>NamespaceBarrels</c>,
+    /// <c>StripInterfacePrefix</c>, and the host's <c>FilePrefix</c>).
+    /// A flag flip invalidates the entire group cache file even when
+    /// individual closure hashes still match.
+    /// </summary>
+    public string? CacheConfigurationFingerprint { get; init; }
+
+    /// <summary>
     /// On a per-group cache hit (PR 3c) the transformer reuses the
     /// content already on disk: stub <c>TsSourceFile</c>s flow
     /// through barrel + cyclic detection, but the printed output for
@@ -323,13 +332,24 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
             groups = GroupTypesByFile(transpilableTypes);
 
             // Per-group skip decision (PR 3c): for every group whose
-            // closure hash matches the cached entry, reuse the stub
-            // built from cached metadata and skip TransformGroup
-            // entirely. Misses run the full transform as before. The
-            // closure-hash index amortises per-type hashing across
-            // groups whose closures overlap.
-            perGroupClosure = ComputePerGroupClosure(ir, groups);
-            var cachedGroups = LoadGroupCache();
+            // closure hash matches the cached entry AND the on-disk
+            // file's content hash still matches the cached value,
+            // reuse the stub built from cached metadata and skip
+            // TransformGroup entirely. Misses run the full transform
+            // as before. The closure-hash index amortises per-type
+            // hashing across groups whose closures overlap.
+            //
+            // ComputePerGroupClosure + LoadGroupCache run only when
+            // the host enabled the cache path (CacheOutputDir set
+            // AND the configuration fingerprint matches the cache
+            // file's). Otherwise both stay null and every iteration
+            // takes the miss branch.
+            groups = GroupTypesByFile(transpilableTypes);
+            var cachedGroups = LoadGroupCacheIfValid();
+            perGroupClosure =
+                cachedGroups is null && CacheOutputDir is null
+                    ? new Dictionary<string, string>(StringComparer.Ordinal)
+                    : ComputePerGroupClosure(ir, groups);
             var perGroupResults = new TsSourceFile?[groups.Count];
             perGroupMetadata = new CachedFileMetadata[groups.Count][];
             var skippedGroupCount = 0;
@@ -341,52 +361,40 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                     var group = groups[index];
                     var groupKey = GroupKey(group);
                     if (
-                        cachedGroups is not null
-                        && perGroupClosure.TryGetValue(groupKey, out var closure)
-                        && cachedGroups.Groups.TryGetValue(groupKey, out var entry)
-                        && string.Equals(entry.ClosureHash, closure, StringComparison.Ordinal)
+                        TryReuseFromCache(
+                            groupKey,
+                            cachedGroups,
+                            perGroupClosure,
+                            out var stub,
+                            out var fileMeta
+                        )
                     )
                     {
-                        // Hit: rebuild a stub TsSourceFile from cached
-                        // metadata. The host has already verified each
-                        // output file exists with matching content via
-                        // PR 3a's OutputsStillValid gate; if we got
-                        // here it means PR 3a missed for some other
-                        // reason but this group's slice is still good.
-                        if (entry.Files.Count == 1 && CacheOutputDir is not null)
-                        {
-                            var fileMeta = entry.Files[0];
-                            var diskPath = Path.Combine(
-                                CacheOutputDir,
-                                fileMeta.Path.Replace('/', Path.DirectorySeparatorChar)
-                            );
-                            if (File.Exists(diskPath))
-                            {
-                                perGroupResults[index] = FileMetadataExtractor.BuildStub(fileMeta);
-                                perGroupMetadata[index] = [fileMeta];
-                                var diskContent = File.ReadAllText(diskPath);
-                                var prefixBlock = string.IsNullOrEmpty(CacheFilePrefix)
-                                    ? null
-                                    : CacheFilePrefix + "\n";
-                                if (
-                                    prefixBlock is not null
-                                    && diskContent.StartsWith(prefixBlock, StringComparison.Ordinal)
-                                )
-                                {
-                                    diskContent = diskContent[prefixBlock.Length..];
-                                }
-                                _cachedFileContents[fileMeta.Path] = diskContent;
-                                Interlocked.Increment(ref skippedGroupCount);
-                                return;
-                            }
-                        }
+                        perGroupResults[index] = stub;
+                        perGroupMetadata[index] = [fileMeta!];
+                        Interlocked.Increment(ref skippedGroupCount);
+                        return;
                     }
 
                     var produced = TransformGroup(group);
                     perGroupResults[index] = produced;
-                    perGroupMetadata[index] = produced is null
-                        ? []
-                        : [FileMetadataExtractor.Extract(produced)];
+                    if (produced is not null)
+                    {
+                        // Print once: the printed bytes are what the
+                        // target emits AND what the cache fingerprints.
+                        // Stash in _cachedFileContents so the target
+                        // skips its own Printer call for this path.
+                        var printedContent = new Printer().Print(produced);
+                        _cachedFileContents[produced.FileName] = printedContent;
+                        perGroupMetadata[index] =
+                        [
+                            FileMetadataExtractor.Extract(produced, printedContent),
+                        ];
+                    }
+                    else
+                    {
+                        perGroupMetadata[index] = [];
+                    }
                 }
             );
             for (var i = 0; i < perGroupResults.Length; i++)
@@ -796,8 +804,76 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         return result;
     }
 
-    private GroupCacheFile? LoadGroupCache() =>
-        CacheOutputDir is null ? null : GroupCacheFile.TryRead(CacheOutputDir);
+    /// <summary>
+    /// Loads the per-group cache only when the host enabled the
+    /// cache path AND the cached configuration fingerprint matches
+    /// the current run's. A mismatch discards every entry so a
+    /// flag flip (e.g., toggling <c>--strip-interface-prefix</c>) or
+    /// a different <c>--file-prefix</c> never serves stale bytes.
+    /// </summary>
+    private GroupCacheFile? LoadGroupCacheIfValid()
+    {
+        if (CacheOutputDir is null)
+            return null;
+        var cache = GroupCacheFile.TryRead(CacheOutputDir);
+        if (cache is null)
+            return null;
+        if (
+            !string.Equals(
+                cache.ConfigurationFingerprint,
+                CacheConfigurationFingerprint ?? string.Empty,
+                StringComparison.Ordinal
+            )
+        )
+            return null;
+        return cache;
+    }
+
+    private bool TryReuseFromCache(
+        string groupKey,
+        GroupCacheFile? cachedGroups,
+        IReadOnlyDictionary<string, string> closures,
+        out TsSourceFile? stub,
+        out CachedFileMetadata? fileMeta
+    )
+    {
+        stub = null;
+        fileMeta = null;
+        if (CacheOutputDir is null || cachedGroups is null)
+            return false;
+        if (!closures.TryGetValue(groupKey, out var closure))
+            return false;
+        if (!cachedGroups.Groups.TryGetValue(groupKey, out var entry))
+            return false;
+        if (!string.Equals(entry.ClosureHash, closure, StringComparison.Ordinal))
+            return false;
+        if (entry.Files.Count != 1)
+            return false;
+        var meta = entry.Files[0];
+        if (!FileMetadataExtractor.IsSafeRelativePath(meta.Path))
+            return false;
+        var diskPath = Path.Combine(
+            CacheOutputDir,
+            meta.Path.Replace('/', Path.DirectorySeparatorChar)
+        );
+        if (!File.Exists(diskPath))
+            return false;
+
+        var diskContent = File.ReadAllText(diskPath);
+        var prefixBlock = string.IsNullOrEmpty(CacheFilePrefix) ? null : CacheFilePrefix + "\n";
+        if (prefixBlock is not null && diskContent.StartsWith(prefixBlock, StringComparison.Ordinal))
+            diskContent = diskContent[prefixBlock.Length..];
+
+        // Content-hash gate: a hand-edited output file (or any
+        // out-of-band change) flips the hash and forces a miss.
+        if (!string.Equals(FileMetadataExtractor.Sha256(diskContent), meta.ContentHash, StringComparison.Ordinal))
+            return false;
+
+        _cachedFileContents[meta.Path] = diskContent;
+        stub = FileMetadataExtractor.BuildStub(meta);
+        fileMeta = meta;
+        return true;
+    }
 
     private void WriteGroupCache(
         IReadOnlyList<TypeFileGroup> groups,
@@ -806,6 +882,12 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     )
     {
         if (CacheOutputDir is null)
+            return;
+        // Skip the write when the transform produced errors: the
+        // host will abort emit, so persisting entries for files
+        // that were never written would seed stale cache hits on
+        // the next run.
+        if (_diagnostics.Any(d => d.Severity == MetanoDiagnosticSeverity.Error))
             return;
         var entries = new Dictionary<string, GroupCacheEntry>(StringComparer.Ordinal);
         for (var i = 0; i < groups.Count; i++)
@@ -818,7 +900,11 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
                 continue;
             entries[key] = new GroupCacheEntry(closure, files);
         }
-        var cache = new GroupCacheFile(GroupCacheFile.CurrentFormatVersion, entries);
+        var cache = new GroupCacheFile(
+            GroupCacheFile.CurrentFormatVersion,
+            CacheConfigurationFingerprint ?? string.Empty,
+            entries
+        );
         cache.Write(CacheOutputDir);
     }
 

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -87,7 +87,12 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     public string ConfigurationFingerprint =>
         $"namespaceBarrels={NamespaceBarrels};stripInterfacePrefix={StripInterfacePrefix}";
 
-    public TargetOutput Transform(IrCompilation ir, Compilation? compilation)
+    public TargetOutput Transform(
+        IrCompilation ir,
+        Compilation? compilation,
+        string? outputDir = null,
+        string? filePrefix = null
+    )
     {
         if (compilation is null)
             throw new NotSupportedException(
@@ -100,6 +105,8 @@ public sealed class TypeScriptTarget : ITranspilerTarget
         {
             NamespaceBarrels = NamespaceBarrels,
             StripInterfacePrefix = StripInterfacePrefix,
+            CacheOutputDir = outputDir,
+            CacheFilePrefix = filePrefix,
         };
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;
@@ -117,7 +124,18 @@ public sealed class TypeScriptTarget : ITranspilerTarget
         var printer = new Printer();
         var generated = new List<GeneratedFile>(sourceFiles.Count);
         foreach (var file in sourceFiles)
-            generated.Add(new GeneratedFile(file.FileName, printer.Print(file)));
+        {
+            // PR 3c: per-group cache hits surface stub TsSourceFiles
+            // here so the barrel + cyclic stages see the right
+            // imports + exports, but the on-disk bytes already match
+            // the previous emit. Skip Printer for those — reuse the
+            // disk content directly so the host's emit pass writes
+            // the same bytes back.
+            if (transformer.CachedFileContents.TryGetValue(file.FileName, out var cached))
+                generated.Add(new GeneratedFile(file.FileName, cached));
+            else
+                generated.Add(new GeneratedFile(file.FileName, printer.Print(file)));
+        }
 
         return new TargetOutput(generated, transformer.Diagnostics);
     }

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -107,6 +107,8 @@ public sealed class TypeScriptTarget : ITranspilerTarget
             StripInterfacePrefix = StripInterfacePrefix,
             CacheOutputDir = outputDir,
             CacheFilePrefix = filePrefix,
+            CacheConfigurationFingerprint =
+                $"{ConfigurationFingerprint};filePrefix={filePrefix ?? string.Empty}",
         };
         var sourceFiles = transformer.TransformAll();
         LastSourceFiles = sourceFiles;

--- a/src/Metano.Compiler/ITranspilerTarget.cs
+++ b/src/Metano.Compiler/ITranspilerTarget.cs
@@ -44,7 +44,12 @@ public interface ITranspilerTarget
     /// <see langword="null"/> for frontends with no Roslyn backing — IR-only targets can
     /// ignore the parameter entirely; Roslyn-dependent targets should surface a clear
     /// diagnostic when it is unavailable.</param>
-    TargetOutput Transform(IrCompilation ir, Compilation? compilation);
+    TargetOutput Transform(
+        IrCompilation ir,
+        Compilation? compilation,
+        string? outputDir = null,
+        string? filePrefix = null
+    );
 
     /// <summary>
     /// Stable fingerprint of every target-specific option that influences

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -86,7 +86,11 @@ public static class TranspilerHost
         }
 
         var transpileSw = Stopwatch.StartNew();
-        var output = target.Transform(ir, compilation, outputDir, options.FilePrefix);
+        // Pass outputDir to the target only when the run will actually
+        // touch disk — dry-run and --no-cache must not write the
+        // per-target group cache (PR 3c).
+        var targetCacheDir = options.DryRun || options.NoCache ? null : outputDir;
+        var output = target.Transform(ir, compilation, targetCacheDir, options.FilePrefix);
 
         transpileSw.Stop();
 

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -86,7 +86,7 @@ public static class TranspilerHost
         }
 
         var transpileSw = Stopwatch.StartNew();
-        var output = target.Transform(ir, compilation);
+        var output = target.Transform(ir, compilation, outputDir, options.FilePrefix);
 
         transpileSw.Stop();
 

--- a/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
+++ b/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
@@ -1,0 +1,79 @@
+using Metano.Compiler.TypeScript.AST;
+using Metano.Compiler.TypeScript.Caching;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin <see cref="FileMetadataExtractor"/>'s round-trip: extracting
+/// metadata from a fresh <c>TsSourceFile</c> and rebuilding a stub
+/// from it must preserve the exact shape <c>BarrelFileGenerator</c>
+/// and <c>CyclicReferenceDetector</c> read.
+/// </summary>
+public class FileMetadataExtractorTests
+{
+    [Test]
+    public async Task Extract_CapturesImportsAndExports()
+    {
+        var source = new TsSourceFile(
+            "foo/bar.ts",
+            [
+                new TsImport(["UserId"], "#/shared-kernel/user-id"),
+                new TsClass("Bar", null, [], Exported: true),
+                new TsInterface("BarOptions", [], Exported: true),
+            ]
+        );
+
+        var meta = FileMetadataExtractor.Extract(source);
+
+        await Assert.That(meta.Path).IsEqualTo("foo/bar.ts");
+        await Assert.That(meta.Imports.Count).IsEqualTo(1);
+        await Assert.That(meta.Imports[0].From).IsEqualTo("#/shared-kernel/user-id");
+        await Assert.That(meta.Imports[0].Names[0]).IsEqualTo("UserId");
+        await Assert.That(meta.Exports.Count).IsEqualTo(2);
+        await Assert.That(meta.Exports.Any(e => e.Name == "Bar" && !e.TypeOnly)).IsTrue();
+        await Assert.That(meta.Exports.Any(e => e.Name == "BarOptions" && e.TypeOnly)).IsTrue();
+    }
+
+    [Test]
+    public async Task Stub_Roundtrip_HasMatchingImportsAndExportMarkers()
+    {
+        var meta = new CachedFileMetadata(
+            "foo/bar.ts",
+            [new CachedImport(["UserId"], "#/shared-kernel/user-id")],
+            [
+                new CachedExport("Bar", TypeOnly: false),
+                new CachedExport("BarOptions", TypeOnly: true),
+            ]
+        );
+
+        var stub = FileMetadataExtractor.BuildStub(meta);
+
+        await Assert.That(stub.FileName).IsEqualTo("foo/bar.ts");
+        await Assert.That(stub.Statements.OfType<TsImport>().Count()).IsEqualTo(1);
+        // Value export → TsConstObject with matching name.
+        await Assert
+            .That(stub.Statements.OfType<TsConstObject>().Any(c => c.Name == "Bar"))
+            .IsTrue();
+        // Type-only export → TsInterface.
+        await Assert
+            .That(stub.Statements.OfType<TsInterface>().Any(i => i.Name == "BarOptions"))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task NonExportedStatements_AreNotCaptured()
+    {
+        var source = new TsSourceFile(
+            "foo/bar.ts",
+            [
+                new TsImport(["Helper"], "#/util/helper"),
+                new TsClass("Internal", null, [], Exported: false),
+            ]
+        );
+
+        var meta = FileMetadataExtractor.Extract(source);
+
+        await Assert.That(meta.Imports.Count).IsEqualTo(1);
+        await Assert.That(meta.Exports.Count).IsEqualTo(0);
+    }
+}

--- a/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
+++ b/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
@@ -23,7 +23,7 @@ public class FileMetadataExtractorTests
             ]
         );
 
-        var meta = FileMetadataExtractor.Extract(source);
+        var meta = FileMetadataExtractor.Extract(source, "content-placeholder");
 
         await Assert.That(meta.Path).IsEqualTo("foo/bar.ts");
         await Assert.That(meta.Imports.Count).IsEqualTo(1);
@@ -39,6 +39,7 @@ public class FileMetadataExtractorTests
     {
         var meta = new CachedFileMetadata(
             "foo/bar.ts",
+            "deadbeef",
             [new CachedImport(["UserId"], "#/shared-kernel/user-id")],
             [
                 new CachedExport("Bar", TypeOnly: false),
@@ -71,7 +72,7 @@ public class FileMetadataExtractorTests
             ]
         );
 
-        var meta = FileMetadataExtractor.Extract(source);
+        var meta = FileMetadataExtractor.Extract(source, "content-placeholder");
 
         await Assert.That(meta.Imports.Count).IsEqualTo(1);
         await Assert.That(meta.Exports.Count).IsEqualTo(0);


### PR DESCRIPTION
## Summary

Closes the per-group skip work from the #21 + #18 thread. PR 3a (#214) gave us the whole-build short-circuit; PR 3b (#216) gave us the per-type and closure hashers. This PR wires them into `TypeTransformer` so a single editor save regenerates only the affected groups while the rest reuse the disk content.

### Design (ADR-0024)

- **Stub `TsSourceFile` on cache hit**, **bypass the Printer** for cached paths, **skip `TransformGroup`** entirely.
- Cache file is target-specific (`<outputDir>/.metano-cache-groups-typescript.json`) and managed independently from PR 3a's target-agnostic cache. `--clean` wipes both together.
- `FileMetadataExtractor.BuildStub`: imports preserved fully, exports collapsed to `(name, typeOnly)` pairs and rebuilt as `TsConstObject` (value) or `TsInterface` (type-only) — the two `TsTopLevel` shapes `BarrelFileGenerator` matches on.
- `ITranspilerTarget.Transform` extended with optional `outputDir` + `filePrefix` parameters so the host plumbs both through without a side-channel property.

### Flow inside `TransformAll`

1. Compute per-group closure hashes (`BuildSignatureHashIndex` amortises per-type hashing across overlapping closures).
2. Load on-disk group cache.
3. Per group: **hit** → build stub via `FileMetadataExtractor`, capture the disk content (stripped of the host-applied file-prefix), return. **Miss** → run `TransformGroup`, extract metadata.
4. After loop: `Per-group cache: X/Y group(s) reused` summary if hits fired.
5. Write fresh cache.

### Roadmap (#21 + #18) — complete

- [x] PR 1 — type-level dependency graph (#211)
- [x] PR 2 — parallel TypeTransformer (#213)
- [x] PR 3a — incremental cache: whole-build short-circuit (#214)
- [x] PR 4 — watch mode (#215)
- [x] PR 3b — per-group skip foundation (#216)
- [x] PR 3c — per-group skip integration (this PR)

## Test plan

- [x] 1027 .NET tests pass (was 1024; +3 for `FileMetadataExtractor` round-trip)
- [x] Manual smoke on SampleIssueTracker (18 groups): edit one type → `Per-group cache: 17/18 group(s) reused from cache.`, byte-identical output for unchanged groups, regen for the touched group
- [x] All sample suites green; generated TS unchanged after fresh `--clean` rebuild
- [x] `.gitignore` updated for `.metano-cache-groups-*.json`

Closes #21