### PR TITLE
feat(compiler): copy <MetanoAsset> static assets to generated output (#199)

### DIFF
--- a/samples/SampleQueryableSqlite/README.md
+++ b/samples/SampleQueryableSqlite/README.md
@@ -78,8 +78,9 @@ targets/js/sample-queryable-sqlite/
 ```
 
 The C# project sets `MetanoClean=false` so the hand-written TS providers under
-`src/provider/` survive between regenerations. Resource / asset copy from the
-C# project is tracked separately in #199.
+`src/provider/` survive between regenerations. The schema DDL ships as a
+`<MetanoAsset Include="schema.sql" OutputPath="provider/schema.sql" Language="typescript" />`,
+which the transpiler copies next to `provider/db.ts` on every build (FR-048).
 
 ## Running
 
@@ -112,6 +113,6 @@ bun test
 - #197 — `sample-queryable-arrays`, the in-memory provider this sample evolves.
 - #198 — generic visitor API + reusable walker (the natural extraction target
   once a few real providers exist).
-- #199 — copy assembly assets / resources to the generated package output (the
-  schema DDL would normally live as a `schema.sql` resource).
+- #199 — copy assembly assets / resources to the generated package output
+  (closed by this sample's `<MetanoAsset Include="schema.sql" />` wiring).
 - #200 — runtime `LINQ_STAGES` / `getStages` helper that powers introspection.

--- a/samples/SampleQueryableSqlite/SampleQueryableSqlite.csproj
+++ b/samples/SampleQueryableSqlite/SampleQueryableSqlite.csproj
@@ -17,5 +17,13 @@
     <ProjectReference Include="../../src/Metano/Metano.csproj" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Ship the schema next to the generated SQLite provider so db.ts
+         can load it at module init. OutputPath is relative to
+         $(MetanoOutputDir); Language="typescript" keeps the asset out of
+         a future Dart run. -->
+    <MetanoAsset Include="schema.sql" OutputPath="provider/schema.sql" Language="typescript" />
+  </ItemGroup>
+
   <Import Project="../../src/Metano.Build/build/Metano.Build.targets" />
 </Project>

--- a/samples/SampleQueryableSqlite/schema.sql
+++ b/samples/SampleQueryableSqlite/schema.sql
@@ -1,0 +1,13 @@
+-- Schema for the SampleQueryableSqlite product fixture.
+-- Shipped as a <MetanoAsset> so the same DDL is the single source of
+-- truth for both the C# side (if a query analyser ever wants to read
+-- it) and the generated TS bootstrap (provider/db.ts loads this file
+-- at module init).
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  unit_price REAL NOT NULL,
+  stock_count INTEGER NOT NULL,
+  is_active INTEGER NOT NULL
+);

--- a/spec/04-functional-requirements.md
+++ b/spec/04-functional-requirements.md
@@ -115,6 +115,12 @@ requirement uses a stable identifier in the format `FR-XXX`.
   `Metano.Build` as build-only dependencies in .NET projects, so adopting the
   transpiler does not unnecessarily contribute runtime or transitive package
   surface to downstream application outputs.
+- **FR-048** The system shall copy declared static assets (schema files,
+  fixtures, resources) from the source project into the generated package
+  output. Assets are declared via the `<MetanoAsset>` MSBuild item type and
+  support optional output-relative destination override, optional per-target
+  filtering, and participate in the transpiler's incremental cache so
+  unchanged assets do not trigger re-copy.
 
 ## 9. Diagnostic Requirements
 

--- a/spec/08-feature-support-matrix.md
+++ b/spec/08-feature-support-matrix.md
@@ -81,6 +81,7 @@ TypeScript backend — the normative surface of the product today.
 | Validation | Generated type guards | Implemented | Via `[GenerateGuard]` — emits `isT` predicate and `assertT(value, message?)` throwing companion. |
 | Diagnostics | Stable `MS0001`-`MS0008` catalog | Implemented | See diagnostic catalog. |
 | Cycles | Generated TS cyclic import detection | Implemented | Reported as `MS0005`. |
+| Assets | `<MetanoAsset>` static asset copy to generated output | Implemented | Supports optional `OutputPath` destination, optional `Language` filter, cache-aware (FR-048). Missing source / escape attempt / I/O failure raises MS0025. |
 
 ## Explicit Non-Core Guarantees
 

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -105,17 +105,16 @@
 
     <!-- Project @(MetanoAsset) items into asset CLI args.
          Filter by %(Language) against the active transpiler language;
-         items carrying `all` or matching the language survive. Drop
-         items whose source file does not exist so the CLI never sees
-         broken paths (the host would issue MS0025 anyway, but failing
-         fast keeps the fingerprint clean). -->
+         items carrying `all` or matching the language survive. Missing
+         source files are intentionally NOT filtered here — the host
+         must see them so it can raise MS0025 instead of letting a
+         broken manifest pass silently. -->
     <ItemGroup>
       <_MetanoAssetSelected
         Include="@(MetanoAsset)"
         Condition="
-        ('%(MetanoAsset.Language)' == '$(_MetanoTargetLanguage)' or
-          '%(MetanoAsset.Language)' == 'all') and
-        Exists('%(MetanoAsset.FullPath)')"
+        '%(MetanoAsset.Language)' == '$(_MetanoTargetLanguage)' or
+          '%(MetanoAsset.Language)' == 'all'"
       />
     </ItemGroup>
 

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -21,7 +21,39 @@
       MetanoFilePrefix       (optional)  Verbatim text inserted at the top of every generated file, followed by a single newline. Use for formatter / lint directives (Biome `biome-ignore-all`, Prettier `// @prettier-ignore`, `// @generated` markers). Multi-line values are accepted; pass through MSBuild XML escaping.
       MetanoExtraArgs        (optional)  Additional CLI arguments
       MetanoPostBuildCommand (optional)  Shell command to run after transpilation completes. Receives the consumer's choice of formatter / linter / packager. Stays empty by default so the target ships no tool dependency; consumers opt in per project when they want the post-emit pass.
+
+    Asset item type (FR-048):
+
+      <MetanoAsset Include="schema.sql" />
+        Copies the file from the project directory to <MetanoOutputDir>,
+        mirroring the relative path. `schema.sql` lands at
+        $(MetanoOutputDir)/schema.sql; `assets/seed.json` lands at
+        $(MetanoOutputDir)/assets/seed.json.
+
+      Supported per-item metadata:
+        OutputPath (optional)  Output-relative destination path. Overrides
+                               the mirrored default. Use to relocate the
+                               asset without renaming the source file.
+                               `Output` is reserved by MSBuild (MSB4118),
+                               so the metadata name is `OutputPath`.
+        Language   (optional)  Which transpiler this asset applies to.
+                               `typescript`, `dart`, `all`, or empty (=all).
+                               Items not matching the active language are
+                               dropped before the CLI sees them, so they
+                               don't perturb the incremental cache
+                               fingerprint. The metadata name is `Language`
+                               because `Target` is reserved by MSBuild
+                               (MSB4066).
+
+      Declare the same Include twice with different OutputPath values to
+      ship the asset to multiple destinations.
   -->
+
+  <ItemDefinitionGroup>
+    <MetanoAsset>
+      <Language>all</Language>
+    </MetanoAsset>
+  </ItemDefinitionGroup>
 
   <Target Name="MetanoTranspile" AfterTargets="Build" Condition="'$(MetanoOutputDir)' != ''">
     <PropertyGroup>
@@ -32,6 +64,14 @@
       <_MetanoCmd Condition="'$(MetanoCompilerProject)' == ''">dotnet metano-typescript</_MetanoCmd>
       <_MetanoCmd Condition="'$(MetanoCompilerProject)' != ''"
         >dotnet run --project "$(MetanoCompilerProject)" --</_MetanoCmd
+      >
+
+      <!-- Language tag used to filter <MetanoAsset Language="..."> items.
+           The TypeScript build target defaults to "typescript"; downstream
+           Dart-specific MSBuild integrations can override _MetanoTargetLanguage
+           before this target runs to filter accordingly. -->
+      <_MetanoTargetLanguage Condition="'$(_MetanoTargetLanguage)' == ''"
+        >typescript</_MetanoTargetLanguage
       >
 
       <_MetanoArgs>-p "$(MSBuildProjectFullPath)" -o "$(MetanoOutputDir)"</_MetanoArgs>
@@ -60,6 +100,33 @@
       >
       <_MetanoArgs Condition="'$(MetanoExtraArgs)' != ''"
         >$(_MetanoArgs) $(MetanoExtraArgs)</_MetanoArgs
+      >
+    </PropertyGroup>
+
+    <!-- Project @(MetanoAsset) items into asset CLI args.
+         Filter by %(Language) against the active transpiler language;
+         items carrying `all` or matching the language survive. Drop
+         items whose source file does not exist so the CLI never sees
+         broken paths (the host would issue MS0025 anyway, but failing
+         fast keeps the fingerprint clean). -->
+    <ItemGroup>
+      <_MetanoAssetSelected
+        Include="@(MetanoAsset)"
+        Condition="
+        ('%(MetanoAsset.Language)' == '$(_MetanoTargetLanguage)' or
+          '%(MetanoAsset.Language)' == 'all') and
+        Exists('%(MetanoAsset.FullPath)')"
+      />
+    </ItemGroup>
+
+    <!-- Emit one CLI flag per surviving asset. Always include the
+         `=DEST` separator; the host's AssetFlagParser treats an empty
+         tail as a missing override, so a bare <MetanoAsset Include="x" />
+         still mirrors the source path. -->
+    <PropertyGroup>
+      <_MetanoAssetArgs>@(_MetanoAssetSelected -> '--asset &quot;%(FullPath)=%(OutputPath)&quot;', ' ')</_MetanoAssetArgs>
+      <_MetanoArgs Condition="'$(_MetanoAssetArgs)' != ''"
+        >$(_MetanoArgs) $(_MetanoAssetArgs)</_MetanoArgs
       >
     </PropertyGroup>
 

--- a/src/Metano.Compiler.Dart/Commands.cs
+++ b/src/Metano.Compiler.Dart/Commands.cs
@@ -17,6 +17,7 @@ public class Commands
     /// <param name="dryRun">Run the full pipeline but do NOT write any files. Print a preflight summary (file count + total line count + per-file paths) instead.</param>
     /// <param name="noCache">Disable the incremental cache. Forces a full transpilation even when sources, references, and outputs are byte-identical to the previous run.</param>
     /// <param name="watch">Stay running and re-transpile every time a .cs / .csproj / .props / .targets file under the project directory changes.</param>
+    /// <param name="asset">Static asset to copy into the output directory alongside generated files. Repeat the flag for multiple assets. Each value is either an absolute path or `absolutePath=relativeDestination` (destination relative to --output, no rooted paths, no `..` segments). When the destination is omitted, the path relative to the project directory is mirrored under the output tree. Wired from `&lt;MetanoAsset Include="..." OutputPath="..." Language="dart" /&gt;` by the MSBuild target.</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -26,7 +27,8 @@ public class Commands
         string? filePrefix = null,
         bool dryRun = false,
         bool noCache = false,
-        bool watch = false
+        bool watch = false,
+        string[]? asset = null
     )
     {
         var target = new DartTarget();
@@ -38,7 +40,8 @@ public class Commands
             Clean: clean,
             FilePrefix: filePrefix,
             DryRun: dryRun,
-            NoCache: noCache
+            NoCache: noCache,
+            Assets: AssetFlagParser.Parse(asset)
         );
 
         async Task RunOnce()

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -23,6 +23,7 @@ public class Commands
     /// <param name="dryRun">Run the full pipeline but do NOT write any files. Print a preflight summary (file count + total line count + per-file paths) instead. Useful for CI preflight checks and exploratory runs. Skips the package.json update too.</param>
     /// <param name="noCache">Disable the incremental cache. Forces a full transpilation even when sources, references, and outputs are byte-identical to the previous run.</param>
     /// <param name="watch">Stay running and re-transpile every time a .cs / .csproj / .props / .targets file under the project directory changes. Combine with the incremental cache (default) for instant re-runs when nothing actually changed.</param>
+    /// <param name="asset">Static asset to copy into the output directory alongside generated files. Repeat the flag for multiple assets. Each value is either an absolute path or an `absolutePath=relativeDestination` pair where the destination is interpreted relative to --output (no rooted paths, no `..` segments). When the destination is omitted, the asset's path relative to the project directory is mirrored under the output tree. Wired from `&lt;MetanoAsset Include="..." OutputPath="..." /&gt;` by the MSBuild target.</param>
     [Command("")]
     public async Task Transpile(
         string project,
@@ -38,7 +39,8 @@ public class Commands
         string? filePrefix = null,
         bool dryRun = false,
         bool noCache = false,
-        bool watch = false
+        bool watch = false,
+        string[]? asset = null
     )
     {
         var target = new TypeScriptTarget
@@ -54,7 +56,8 @@ public class Commands
             Clean: clean,
             FilePrefix: filePrefix,
             DryRun: dryRun,
-            NoCache: noCache
+            NoCache: noCache,
+            Assets: AssetFlagParser.Parse(asset)
         );
 
         async Task RunOnce()

--- a/src/Metano.Compiler/AssetFlagParser.cs
+++ b/src/Metano.Compiler/AssetFlagParser.cs
@@ -1,0 +1,44 @@
+namespace Metano.Compiler;
+
+/// <summary>
+/// Parses the repeated <c>--asset</c> CLI flag values produced by the
+/// MSBuild target into <see cref="AssetSpec"/> instances. Each value is
+/// either a bare absolute path (<c>SRC</c>) or a <c>SRC=DEST</c> pair
+/// where <c>DEST</c> is interpreted by the host as a path relative to
+/// <see cref="TranspileOptions.OutputDir"/>.
+/// </summary>
+public static class AssetFlagParser
+{
+    public static IReadOnlyList<AssetSpec> Parse(string[]? rawValues)
+    {
+        if (rawValues is null || rawValues.Length == 0)
+            return [];
+
+        var assets = new List<AssetSpec>(rawValues.Length);
+        foreach (var raw in rawValues)
+        {
+            var value = raw?.Trim();
+            if (string.IsNullOrEmpty(value))
+                continue;
+
+            var splitIndex = value.IndexOf('=');
+            if (splitIndex < 0)
+            {
+                assets.Add(new AssetSpec(value));
+                continue;
+            }
+
+            var source = value[..splitIndex].Trim();
+            var destination = value[(splitIndex + 1)..].Trim();
+            if (string.IsNullOrEmpty(source))
+                continue;
+            assets.Add(
+                new AssetSpec(
+                    source,
+                    RelativeDestination: string.IsNullOrEmpty(destination) ? null : destination
+                )
+            );
+        }
+        return assets;
+    }
+}

--- a/src/Metano.Compiler/AssetSpec.cs
+++ b/src/Metano.Compiler/AssetSpec.cs
@@ -1,0 +1,22 @@
+namespace Metano.Compiler;
+
+/// <summary>
+/// Declares a static asset that the transpiler should copy from the source
+/// project into <see cref="TranspileOptions.OutputDir"/> alongside generated
+/// files. Surfaced via the <c>--asset</c> CLI flag (one entry per
+/// occurrence) and ultimately driven by <c>&lt;MetanoAsset Include="..." /&gt;</c>
+/// items in the consumer's csproj.
+/// </summary>
+/// <param name="Source">
+/// Absolute path to the source file on disk. The MSBuild target resolves
+/// this from <c>%(MetanoAsset.FullPath)</c> before invoking the CLI.
+/// </param>
+/// <param name="RelativeDestination">
+/// Output-relative destination path. When <see langword="null"/>, the host
+/// mirrors the source's path relative to the project directory (so
+/// <c>schema.sql</c> at the project root lands at
+/// <c>OutputDir/schema.sql</c>, and <c>assets/seed.json</c> lands at
+/// <c>OutputDir/assets/seed.json</c>). When supplied, this value
+/// replaces the mirrored path entirely.
+/// </param>
+public sealed record AssetSpec(string Source, string? RelativeDestination = null);

--- a/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
+++ b/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
@@ -123,6 +123,44 @@ public static class CacheKeyBuilder
         return rehydrated;
     }
 
+    /// <summary>
+    /// Fingerprints each declared asset by SHA-256 of its on-disk
+    /// source content, keyed by the cache key from
+    /// <see cref="ComputeAssetCacheKey"/>. Missing source files are
+    /// silently omitted — the host surfaces an
+    /// <see cref="DiagnosticCodes.AssetCopyFailure"/> when it tries
+    /// to copy them, and the omitted entry guarantees the next run
+    /// re-attempts the copy instead of short-circuiting on a stale
+    /// fingerprint.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ComputeAssetFingerprints(
+        IReadOnlyList<AssetSpec> assets
+    )
+    {
+        var fingerprints = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var asset in assets)
+        {
+            if (!File.Exists(asset.Source))
+                continue;
+            var bytes = File.ReadAllBytes(asset.Source);
+            fingerprints[ComputeAssetCacheKey(asset)] = HexEncode(SHA256.HashData(bytes));
+        }
+        return fingerprints;
+    }
+
+    /// <summary>
+    /// Cache key shape: <c>NormalizePath(source)</c> for the mirror-
+    /// default, or <c>NormalizePath(source)=&gt;relativeDestination</c>
+    /// for an explicit <c>OutputPath</c> override. The destination
+    /// participates so the same source emitted to two destinations
+    /// produces two distinct rows — invalidating either one triggers
+    /// a re-copy of only the affected destination.
+    /// </summary>
+    private static string ComputeAssetCacheKey(AssetSpec asset) =>
+        asset.RelativeDestination is null
+            ? NormalizePath(asset.Source)
+            : $"{NormalizePath(asset.Source)}=>{asset.RelativeDestination}";
+
     public static bool DictionariesEqual(
         IReadOnlyDictionary<string, string> a,
         IReadOnlyDictionary<string, string> b

--- a/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
+++ b/src/Metano.Compiler/Caching/CacheKeyBuilder.cs
@@ -142,8 +142,8 @@ public static class CacheKeyBuilder
         {
             if (!File.Exists(asset.Source))
                 continue;
-            var bytes = File.ReadAllBytes(asset.Source);
-            fingerprints[ComputeAssetCacheKey(asset)] = HexEncode(SHA256.HashData(bytes));
+            using var stream = File.OpenRead(asset.Source);
+            fingerprints[ComputeAssetCacheKey(asset)] = HexEncode(SHA256.HashData(stream));
         }
         return fingerprints;
     }
@@ -154,12 +154,15 @@ public static class CacheKeyBuilder
     /// for an explicit <c>OutputPath</c> override. The destination
     /// participates so the same source emitted to two destinations
     /// produces two distinct rows — invalidating either one triggers
-    /// a re-copy of only the affected destination.
+    /// a re-copy of only the affected destination. Destination
+    /// separators are normalised to <c>/</c> so a Windows-authored
+    /// <c>provider\schema.sql</c> shares the same row as a Unix
+    /// <c>provider/schema.sql</c>.
     /// </summary>
-    private static string ComputeAssetCacheKey(AssetSpec asset) =>
+    internal static string ComputeAssetCacheKey(AssetSpec asset) =>
         asset.RelativeDestination is null
             ? NormalizePath(asset.Source)
-            : $"{NormalizePath(asset.Source)}=>{asset.RelativeDestination}";
+            : $"{NormalizePath(asset.Source)}=>{asset.RelativeDestination.Replace('\\', '/')}";
 
     public static bool DictionariesEqual(
         IReadOnlyDictionary<string, string> a,

--- a/src/Metano.Compiler/Caching/TranspilationCache.cs
+++ b/src/Metano.Compiler/Caching/TranspilationCache.cs
@@ -26,6 +26,10 @@ namespace Metano.Compiler.Caching;
 ///   <item><b>Reference fingerprints</b>: <c>length:lastWriteTimeUtc</c>
 ///   per metadata reference. Picks up assembly swaps without reading
 ///   the .dll bytes.</item>
+///   <item><b>Asset source hashes</b> (FR-048): SHA-256 of every
+///   <c>&lt;MetanoAsset&gt;</c> source file declared on the run.
+///   Editing an asset (or changing its destination) invalidates the
+///   short-circuit so the file gets re-copied to the output.</item>
 ///   <item><b>Output hashes</b>: SHA-256 of every file the previous
 ///   run emitted into the output directory. If a user (or
 ///   <c>--clean</c> on a sibling target, or a manual <c>rm</c>) deletes
@@ -44,10 +48,11 @@ public sealed record TranspilationCache(
     string ConfigurationFingerprint,
     IReadOnlyDictionary<string, string> SourceHashes,
     IReadOnlyDictionary<string, string> ReferenceFingerprints,
+    IReadOnlyDictionary<string, string> AssetSourceHashes,
     IReadOnlyDictionary<string, string> OutputHashes
 )
 {
-    public const int CurrentFormatVersion = 2;
+    public const int CurrentFormatVersion = 3;
     public const string FileName = ".metano-cache.json";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -96,6 +101,7 @@ public sealed record TranspilationCache(
         && cache.ConfigurationFingerprint is not null
         && cache.SourceHashes is not null
         && cache.ReferenceFingerprints is not null
+        && cache.AssetSourceHashes is not null
         && cache.OutputHashes is not null;
 
     public void Write(string outputDir)

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -241,4 +241,14 @@ public static class DiagnosticCodes
     /// drop the queryable surface so the lambda flows through as an
     /// opaque closure.</summary>
     public const string UnsupportedQueryableBody = "MS0024";
+
+    /// <summary>MS0025 — a <c>&lt;MetanoAsset&gt;</c> declared on the
+    /// consumer csproj could not be copied to the generated output
+    /// directory. Causes include the source file being missing on
+    /// disk, the resolved destination escaping the output tree (via a
+    /// <c>..</c> segment or a rooted <c>Output</c> path), or an I/O
+    /// failure during copy. The transpiler emits the rest of the run
+    /// and surfaces the failure as a warning so the developer can
+    /// fix the manifest without losing the generated TS output.</summary>
+    public const string AssetCopyFailure = "MS0025";
 }

--- a/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
+++ b/src/Metano.Compiler/Diagnostics/MetaSharpDiagnostic.cs
@@ -246,9 +246,9 @@ public static class DiagnosticCodes
     /// consumer csproj could not be copied to the generated output
     /// directory. Causes include the source file being missing on
     /// disk, the resolved destination escaping the output tree (via a
-    /// <c>..</c> segment or a rooted <c>Output</c> path), or an I/O
-    /// failure during copy. The transpiler emits the rest of the run
-    /// and surfaces the failure as a warning so the developer can
-    /// fix the manifest without losing the generated TS output.</summary>
+    /// <c>..</c> segment or a rooted <c>OutputPath</c>), or an I/O
+    /// failure during copy. Surfaced as an error so the build fails
+    /// fast — a broken manifest silently shipping an incomplete
+    /// artifact would be worse than a loud diagnostic.</summary>
     public const string AssetCopyFailure = "MS0025";
 }

--- a/src/Metano.Compiler/TranspileOptions.cs
+++ b/src/Metano.Compiler/TranspileOptions.cs
@@ -11,5 +11,6 @@ public sealed record TranspileOptions(
     bool Clean = false,
     string? FilePrefix = null,
     bool DryRun = false,
-    bool NoCache = false
+    bool NoCache = false,
+    IReadOnlyList<AssetSpec>? Assets = null
 );

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -79,6 +79,8 @@ public static class TranspilerHost
                     sourceHashes,
                     referenceFingerprints,
                     assetSourceHashes,
+                    assets,
+                    projectDir,
                     options.FilePrefix,
                     options.ShowTimings,
                     totalSw,
@@ -114,7 +116,7 @@ public static class TranspilerHost
         if (errorCount > 0)
             return new TranspileResult(false, output.Files, warningCount, errorCount);
 
-        if (output.Files.Count == 0)
+        if (output.Files.Count == 0 && assets.Count == 0)
         {
             Console.WriteLine("Metano: No transpilable types found.");
 
@@ -136,7 +138,8 @@ public static class TranspilerHost
             return new TranspileResult(true, output.Files, warningCount, 0);
         }
 
-        await EmitFilesAsync(outputDir, output.Files, options.Clean, options.FilePrefix);
+        if (output.Files.Count > 0)
+            await EmitFilesAsync(outputDir, output.Files, options.Clean, options.FilePrefix);
         var assetDiagnostics = await CopyAssetsAsync(assets, outputDir, projectDir);
         var (assetWarnings, assetErrors) =
             assetDiagnostics.Count > 0 ? ReportDiagnostics(assetDiagnostics) : (0, 0);
@@ -223,6 +226,8 @@ public static class TranspilerHost
         IReadOnlyDictionary<string, string> sourceHashes,
         IReadOnlyDictionary<string, string> referenceFingerprints,
         IReadOnlyDictionary<string, string> assetSourceHashes,
+        IReadOnlyList<AssetSpec> assets,
+        string projectDir,
         string? filePrefix,
         bool showTimings,
         Stopwatch totalSw,
@@ -249,6 +254,8 @@ public static class TranspilerHost
             return false;
         if (!CacheKeyBuilder.DictionariesEqual(cache.AssetSourceHashes, assetSourceHashes))
             return false;
+        if (!AreAssetCopiesIntact(assets, assetSourceHashes, outputDir, projectDir))
+            return false;
 
         var prefixBlock = string.IsNullOrEmpty(filePrefix) ? null : filePrefix + "\n";
         var rehydrated = CacheKeyBuilder.ValidateAndRehydrate(
@@ -266,6 +273,42 @@ public static class TranspilerHost
         );
         if (showTimings)
             Console.WriteLine($"  Total: {totalSw.ElapsedMilliseconds}ms");
+        return true;
+    }
+
+    /// <summary>
+    /// Validates that every declared asset still exists at its resolved
+    /// destination with content matching the cached source fingerprint.
+    /// Guards against a cache hit when the user (or an external tool)
+    /// has deleted or edited an asset copy out-of-band; without this
+    /// check, the short-circuit would happily report success even
+    /// though the artifact is incomplete.
+    /// </summary>
+    private static bool AreAssetCopiesIntact(
+        IReadOnlyList<AssetSpec> assets,
+        IReadOnlyDictionary<string, string> assetSourceHashes,
+        string outputDir,
+        string projectDir
+    )
+    {
+        foreach (var asset in assets)
+        {
+            if (
+                !assetSourceHashes.TryGetValue(
+                    CacheKeyBuilder.ComputeAssetCacheKey(asset),
+                    out var expectedHash
+                )
+            )
+                return false;
+            var relative = ResolveAssetDestination(asset, projectDir);
+            var destination = Path.GetFullPath(Path.Combine(outputDir, relative));
+            if (!File.Exists(destination))
+                return false;
+            using var stream = File.OpenRead(destination);
+            var actual = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(stream));
+            if (!string.Equals(actual, expectedHash, StringComparison.Ordinal))
+                return false;
+        }
         return true;
     }
 
@@ -407,8 +450,16 @@ public static class TranspilerHost
         var outputWithSeparator = outputDirFull.EndsWith(Path.DirectorySeparatorChar)
             ? outputDirFull
             : outputDirFull + Path.DirectorySeparatorChar;
-        return destinationFull.StartsWith(outputWithSeparator, StringComparison.Ordinal)
-            || string.Equals(destinationFull, outputDirFull, StringComparison.Ordinal);
+        // Path comparison is case-insensitive on Windows / macOS HFS+ and
+        // case-sensitive on Linux. Mirror the platform's filesystem so a
+        // mismatched casing between outputDirFull and destinationFull
+        // does not produce a false escape report.
+        var comparison =
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+        return destinationFull.StartsWith(outputWithSeparator, comparison)
+            || string.Equals(destinationFull, outputDirFull, comparison);
     }
 
     private static MetanoDiagnostic CreateMissingAssetDiagnostic(string source) =>

--- a/src/Metano.Compiler/TranspilerHost.cs
+++ b/src/Metano.Compiler/TranspilerHost.cs
@@ -31,6 +31,8 @@ public static class TranspilerHost
     {
         var projectPath = Path.GetFullPath(options.ProjectPath);
         var outputDir = Path.GetFullPath(options.OutputDir);
+        var projectDir = Path.GetDirectoryName(projectPath) ?? Directory.GetCurrentDirectory();
+        var assets = options.Assets ?? [];
 
         var totalSw = Stopwatch.StartNew();
         var compileSw = Stopwatch.StartNew();
@@ -62,11 +64,13 @@ public static class TranspilerHost
         // run does not pay the SHA bill.
         IReadOnlyDictionary<string, string>? sourceHashes = null;
         IReadOnlyDictionary<string, string>? referenceFingerprints = null;
+        IReadOnlyDictionary<string, string>? assetSourceHashes = null;
         var configFingerprint = BuildConfigFingerprint(target, options);
         if (ShouldAttemptCache(options))
         {
             sourceHashes = CacheKeyBuilder.ComputeSourceHashes(compilation);
             referenceFingerprints = CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
+            assetSourceHashes = CacheKeyBuilder.ComputeAssetFingerprints(assets);
             if (
                 TryShortCircuitFromCache(
                     outputDir,
@@ -74,6 +78,7 @@ public static class TranspilerHost
                     configFingerprint,
                     sourceHashes,
                     referenceFingerprints,
+                    assetSourceHashes,
                     options.FilePrefix,
                     options.ShowTimings,
                     totalSw,
@@ -132,6 +137,12 @@ public static class TranspilerHost
         }
 
         await EmitFilesAsync(outputDir, output.Files, options.Clean, options.FilePrefix);
+        var assetDiagnostics = await CopyAssetsAsync(assets, outputDir, projectDir);
+        var (assetWarnings, assetErrors) =
+            assetDiagnostics.Count > 0 ? ReportDiagnostics(assetDiagnostics) : (0, 0);
+        warningCount += assetWarnings;
+        if (assetErrors > 0)
+            return new TranspileResult(false, output.Files, warningCount, assetErrors);
         emitSw.Stop();
         totalSw.Stop();
 
@@ -151,6 +162,8 @@ public static class TranspilerHost
             configFingerprint,
             sourceHashes,
             referenceFingerprints,
+            assetSourceHashes,
+            assets,
             compilation
         );
 
@@ -174,6 +187,8 @@ public static class TranspilerHost
         string configFingerprint,
         IReadOnlyDictionary<string, string>? sourceHashes,
         IReadOnlyDictionary<string, string>? referenceFingerprints,
+        IReadOnlyDictionary<string, string>? assetSourceHashes,
+        IReadOnlyList<AssetSpec> assets,
         Microsoft.CodeAnalysis.Compilation compilation
     )
     {
@@ -188,12 +203,14 @@ public static class TranspilerHost
         // consultable on the next run.
         sourceHashes ??= CacheKeyBuilder.ComputeSourceHashes(compilation);
         referenceFingerprints ??= CacheKeyBuilder.ComputeReferenceFingerprints(compilation);
+        assetSourceHashes ??= CacheKeyBuilder.ComputeAssetFingerprints(assets);
         var cache = new TranspilationCache(
             FormatVersion: TranspilationCache.CurrentFormatVersion,
             Target: target.Language.ToString(),
             ConfigurationFingerprint: configFingerprint,
             SourceHashes: sourceHashes,
             ReferenceFingerprints: referenceFingerprints,
+            AssetSourceHashes: assetSourceHashes,
             OutputHashes: outputHashes
         );
         cache.Write(outputDir);
@@ -205,6 +222,7 @@ public static class TranspilerHost
         string configFingerprint,
         IReadOnlyDictionary<string, string> sourceHashes,
         IReadOnlyDictionary<string, string> referenceFingerprints,
+        IReadOnlyDictionary<string, string> assetSourceHashes,
         string? filePrefix,
         bool showTimings,
         Stopwatch totalSw,
@@ -228,6 +246,8 @@ public static class TranspilerHost
         if (!CacheKeyBuilder.DictionariesEqual(cache.SourceHashes, sourceHashes))
             return false;
         if (!CacheKeyBuilder.DictionariesEqual(cache.ReferenceFingerprints, referenceFingerprints))
+            return false;
+        if (!CacheKeyBuilder.DictionariesEqual(cache.AssetSourceHashes, assetSourceHashes))
             return false;
 
         var prefixBlock = string.IsNullOrEmpty(filePrefix) ? null : filePrefix + "\n";
@@ -274,6 +294,150 @@ public static class TranspilerHost
         var newlines = content.AsSpan().Count('\n');
         return content[^1] == '\n' ? newlines : newlines + 1;
     }
+
+    /// <summary>
+    /// Copies <see cref="AssetSpec"/> entries declared on the run into
+    /// <paramref name="outputDir"/>. Destination is the spec's
+    /// <see cref="AssetSpec.RelativeDestination"/> when present;
+    /// otherwise the source's path relative to <paramref name="projectDir"/>
+    /// is mirrored under the output tree. Each copy is sandboxed: any
+    /// resolved destination that escapes <paramref name="outputDir"/>
+    /// (rooted path or <c>..</c> segment), missing source file, or any
+    /// I/O failure surfaces as an
+    /// <see cref="DiagnosticCodes.AssetCopyFailure"/> error so the
+    /// build fails fast — a manifest bug that silently shipped a
+    /// broken artifact would be far worse than a loud diagnostic.
+    /// </summary>
+    internal static async Task<IReadOnlyList<MetanoDiagnostic>> CopyAssetsAsync(
+        IReadOnlyList<AssetSpec> assets,
+        string outputDirFull,
+        string projectDir
+    )
+    {
+        if (assets.Count == 0)
+            return [];
+
+        var diagnostics = new List<MetanoDiagnostic>();
+        foreach (var asset in assets)
+            await CopyOneAssetAsync(asset, outputDirFull, projectDir, diagnostics);
+        return diagnostics;
+    }
+
+    private static async Task CopyOneAssetAsync(
+        AssetSpec asset,
+        string outputDirFull,
+        string projectDir,
+        List<MetanoDiagnostic> diagnostics
+    )
+    {
+        if (!File.Exists(asset.Source))
+        {
+            diagnostics.Add(CreateMissingAssetDiagnostic(asset.Source));
+            return;
+        }
+
+        if (HasRootedDestination(asset.RelativeDestination))
+        {
+            diagnostics.Add(
+                CreateEscapingAssetDiagnostic(asset.Source, asset.RelativeDestination!)
+            );
+            return;
+        }
+
+        var relative = ResolveAssetDestination(asset, projectDir);
+        var destination = Path.GetFullPath(Path.Combine(outputDirFull, relative));
+        if (!IsInsideOutputDir(destination, outputDirFull))
+        {
+            diagnostics.Add(CreateEscapingAssetDiagnostic(asset.Source, relative));
+            return;
+        }
+
+        try
+        {
+            var destinationDir = Path.GetDirectoryName(destination);
+            if (destinationDir is not null)
+                Directory.CreateDirectory(destinationDir);
+            await using var source = File.OpenRead(asset.Source);
+            await using var sink = File.Create(destination);
+            await source.CopyToAsync(sink);
+            Console.WriteLine($"  Copied asset: {relative}");
+        }
+        catch (Exception ex)
+        {
+            diagnostics.Add(CreateAssetIoDiagnostic(asset.Source, relative, ex));
+        }
+    }
+
+    /// <summary>
+    /// Rooted destinations (<c>/abs/path</c>, <c>C:\path</c>) would
+    /// silently relocate the asset outside the output tree once
+    /// <c>Path.Combine</c> dropped the relative prefix. Reject them
+    /// up-front so the user sees an explicit MS0025 diagnostic
+    /// instead of either a confusing "escapes output directory"
+    /// message or a silent rewrite.
+    /// </summary>
+    private static bool HasRootedDestination(string? relativeDestination) =>
+        !string.IsNullOrEmpty(relativeDestination)
+        && (Path.IsPathRooted(relativeDestination) || relativeDestination.StartsWith('/'));
+
+    /// <summary>
+    /// Resolves the output-relative destination for an asset. An
+    /// explicit override (from <c>%(MetanoAsset.OutputPath)</c>) wins
+    /// over the source-mirror heuristic. The fallback mirrors the
+    /// asset's path relative to the consumer's project directory so a
+    /// typical <c>&lt;MetanoAsset Include="schema.sql" /&gt;</c> lands
+    /// at <c>OutputDir/schema.sql</c>, and a nested
+    /// <c>assets/seed.json</c> preserves its <c>assets/</c> prefix.
+    /// </summary>
+    private static string ResolveAssetDestination(AssetSpec asset, string projectDir)
+    {
+        if (!string.IsNullOrEmpty(asset.RelativeDestination))
+            return NormalizeRelative(asset.RelativeDestination);
+
+        var sourceFull = Path.GetFullPath(asset.Source);
+        var projectFull = Path.GetFullPath(projectDir);
+        var mirrored = Path.GetRelativePath(projectFull, sourceFull);
+        return NormalizeRelative(mirrored);
+    }
+
+    private static string NormalizeRelative(string path) => path.Replace('\\', '/');
+
+    private static bool IsInsideOutputDir(string destinationFull, string outputDirFull)
+    {
+        var outputWithSeparator = outputDirFull.EndsWith(Path.DirectorySeparatorChar)
+            ? outputDirFull
+            : outputDirFull + Path.DirectorySeparatorChar;
+        return destinationFull.StartsWith(outputWithSeparator, StringComparison.Ordinal)
+            || string.Equals(destinationFull, outputDirFull, StringComparison.Ordinal);
+    }
+
+    private static MetanoDiagnostic CreateMissingAssetDiagnostic(string source) =>
+        new(
+            MetanoDiagnosticSeverity.Error,
+            DiagnosticCodes.AssetCopyFailure,
+            $"Asset '{source}' was not found on disk. "
+                + "Check the <MetanoAsset Include=\"...\"> path in the csproj."
+        );
+
+    private static MetanoDiagnostic CreateEscapingAssetDiagnostic(string source, string relative) =>
+        new(
+            MetanoDiagnosticSeverity.Error,
+            DiagnosticCodes.AssetCopyFailure,
+            $"Asset '{source}' resolved to '{relative}', which escapes the output "
+                + "directory. <MetanoAsset OutputPath=\"...\"> must be a relative path "
+                + "without leading slashes, drive letters, or '..' segments."
+        );
+
+    private static MetanoDiagnostic CreateAssetIoDiagnostic(
+        string source,
+        string relative,
+        Exception ex
+    ) =>
+        new(
+            MetanoDiagnosticSeverity.Error,
+            DiagnosticCodes.AssetCopyFailure,
+            $"Failed to copy asset '{source}' to '{relative}': {ex.Message}"
+        );
 
     private static async Task EmitFilesAsync(
         string outputDir,

--- a/targets/js/sample-queryable-sqlite/src/provider/db.ts
+++ b/targets/js/sample-queryable-sqlite/src/provider/db.ts
@@ -12,6 +12,11 @@ import { Database } from "bun:sqlite";
 import { Decimal } from "decimal.js";
 import { Product } from "#/product";
 
+// Loaded eagerly from disk so the bootstrap helper does not need to be
+// async. The transpiler copies samples/SampleQueryableSqlite/schema.sql
+// to provider/schema.sql via <MetanoAsset> (FR-048).
+const SCHEMA_SQL = await Bun.file(new URL("./schema.sql", import.meta.url)).text();
+
 /** Entity-property → SQLite-column name table for the `products` row. */
 export const PRODUCT_COLUMN_MAP: Record<string, string> = {
   id: "id",
@@ -71,16 +76,7 @@ export function mapProductRow(row: ProductRow): Product {
  */
 export function createSeededDatabase(): Database {
   const db = new Database(":memory:");
-  db.exec(`
-    CREATE TABLE products (
-      id INTEGER PRIMARY KEY,
-      name TEXT NOT NULL,
-      display_name TEXT NOT NULL,
-      unit_price REAL NOT NULL,
-      stock_count INTEGER NOT NULL,
-      is_active INTEGER NOT NULL
-    );
-  `);
+  db.exec(SCHEMA_SQL);
   const insert = db.prepare(
     "INSERT INTO products (id, name, display_name, unit_price, stock_count, is_active) VALUES (?, ?, ?, ?, ?, ?)",
   );

--- a/targets/js/sample-queryable-sqlite/src/provider/schema.sql
+++ b/targets/js/sample-queryable-sqlite/src/provider/schema.sql
@@ -1,0 +1,13 @@
+-- Schema for the SampleQueryableSqlite product fixture.
+-- Shipped as a <MetanoAsset> so the same DDL is the single source of
+-- truth for both the C# side (if a query analyser ever wants to read
+-- it) and the generated TS bootstrap (provider/db.ts loads this file
+-- at module init).
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  unit_price REAL NOT NULL,
+  stock_count INTEGER NOT NULL,
+  is_active INTEGER NOT NULL
+);

--- a/tests/Metano.Tests/Caching/AssetFlagParserTests.cs
+++ b/tests/Metano.Tests/Caching/AssetFlagParserTests.cs
@@ -1,0 +1,65 @@
+using Metano.Compiler;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pins the CLI <c>--asset</c> parsing contract. Both transpiler CLIs
+/// (TypeScript / Dart) route their <c>string[]?</c> flag through
+/// <see cref="AssetFlagParser"/> so the host receives uniform
+/// <see cref="AssetSpec"/> instances regardless of which target ran.
+/// </summary>
+public class AssetFlagParserTests
+{
+    [Test]
+    public async Task Parse_ReturnsEmpty_OnNull()
+    {
+        var assets = AssetFlagParser.Parse(null);
+        await Assert.That(assets.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Parse_BareSource_OmitsRelativeDestination()
+    {
+        var assets = AssetFlagParser.Parse(["/abs/schema.sql"]);
+
+        await Assert.That(assets.Count).IsEqualTo(1);
+        await Assert.That(assets[0].Source).IsEqualTo("/abs/schema.sql");
+        await Assert.That(assets[0].RelativeDestination).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_SourceEqualsDestination_SplitsOnFirstEquals()
+    {
+        var assets = AssetFlagParser.Parse(["/abs/schema.sql=provider/schema.sql"]);
+
+        await Assert.That(assets[0].Source).IsEqualTo("/abs/schema.sql");
+        await Assert.That(assets[0].RelativeDestination).IsEqualTo("provider/schema.sql");
+    }
+
+    [Test]
+    public async Task Parse_TrailingEqualsSign_ProducesNullDestination()
+    {
+        var assets = AssetFlagParser.Parse(["/abs/schema.sql="]);
+
+        await Assert.That(assets[0].Source).IsEqualTo("/abs/schema.sql");
+        await Assert.That(assets[0].RelativeDestination).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_SkipsBlankEntries()
+    {
+        var assets = AssetFlagParser.Parse(["", "   ", "/abs/schema.sql"]);
+
+        await Assert.That(assets.Count).IsEqualTo(1);
+        await Assert.That(assets[0].Source).IsEqualTo("/abs/schema.sql");
+    }
+
+    [Test]
+    public async Task Parse_MultipleEquals_SplitsOnFirstOnly()
+    {
+        var assets = AssetFlagParser.Parse(["/abs/foo=a=b"]);
+
+        await Assert.That(assets[0].Source).IsEqualTo("/abs/foo");
+        await Assert.That(assets[0].RelativeDestination).IsEqualTo("a=b");
+    }
+}

--- a/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilationCacheTests.cs
@@ -38,6 +38,10 @@ public class TranspilationCacheTests
             {
                 ["/refs/Bar.dll"] = "12345:6789",
             },
+            AssetSourceHashes: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["/proj/schema.sql"] = "asset-hash-1",
+            },
             OutputHashes: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["src/foo.ts"] = "def456",
@@ -57,6 +61,9 @@ public class TranspilationCacheTests
         await Assert
             .That(roundTripped.ReferenceFingerprints["/refs/Bar.dll"])
             .IsEqualTo("12345:6789");
+        await Assert
+            .That(roundTripped.AssetSourceHashes["/proj/schema.sql"])
+            .IsEqualTo("asset-hash-1");
         await Assert.That(roundTripped.OutputHashes["src/foo.ts"]).IsEqualTo("def456");
     }
 
@@ -81,6 +88,7 @@ public class TranspilationCacheTests
               "configurationFingerprint": "",
               "sourceHashes": {},
               "referenceFingerprints": {},
+              "assetSourceHashes": {},
               "outputHashes": {}
             }
             """
@@ -242,6 +250,71 @@ public class TranspilationCacheTests
 
         var result = CacheKeyBuilder.ValidateAndRehydrate(dir, hashes, prefixBlock: null);
         await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task ComputeAssetFingerprints_ReturnsHashKeyedByCacheKey()
+    {
+        var dir = MakeTempDir();
+        var assetPath = Path.Combine(dir, "schema.sql");
+        await File.WriteAllTextAsync(assetPath, "CREATE TABLE t (id INTEGER);");
+
+        var hashes = CacheKeyBuilder.ComputeAssetFingerprints([
+            new AssetSpec(assetPath, RelativeDestination: "provider/schema.sql"),
+        ]);
+
+        await Assert.That(hashes.Count).IsEqualTo(1);
+        await Assert
+            .That(hashes.Keys.Single())
+            .Contains("schema.sql")
+            .And.Contains("=>provider/schema.sql");
+    }
+
+    [Test]
+    public async Task ComputeAssetFingerprints_SkipsMissingFiles()
+    {
+        var dir = MakeTempDir();
+        var present = Path.Combine(dir, "present.sql");
+        var missing = Path.Combine(dir, "missing.sql");
+        await File.WriteAllTextAsync(present, "CREATE TABLE t (id INTEGER);");
+
+        var hashes = CacheKeyBuilder.ComputeAssetFingerprints([
+            new AssetSpec(missing),
+            new AssetSpec(present),
+        ]);
+
+        await Assert.That(hashes.Count).IsEqualTo(1);
+        await Assert.That(hashes.Keys.Single()).Contains("present.sql");
+    }
+
+    [Test]
+    public async Task ComputeAssetFingerprints_DistinguishesDestinations()
+    {
+        var dir = MakeTempDir();
+        var source = Path.Combine(dir, "schema.sql");
+        await File.WriteAllTextAsync(source, "x");
+
+        var hashes = CacheKeyBuilder.ComputeAssetFingerprints([
+            new AssetSpec(source, RelativeDestination: "a.sql"),
+            new AssetSpec(source, RelativeDestination: "b.sql"),
+        ]);
+
+        await Assert.That(hashes.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ComputeAssetFingerprints_ChangesWhenContentChanges()
+    {
+        var dir = MakeTempDir();
+        var asset = Path.Combine(dir, "schema.sql");
+        await File.WriteAllTextAsync(asset, "v1");
+
+        var first = CacheKeyBuilder.ComputeAssetFingerprints([new AssetSpec(asset)]);
+
+        await File.WriteAllTextAsync(asset, "v2");
+        var second = CacheKeyBuilder.ComputeAssetFingerprints([new AssetSpec(asset)]);
+
+        await Assert.That(first.Values.Single()).IsNotEqualTo(second.Values.Single());
     }
 
     private string MakeTempDir()

--- a/tests/Metano.Tests/Caching/TranspilerHostAssetCopyTests.cs
+++ b/tests/Metano.Tests/Caching/TranspilerHostAssetCopyTests.cs
@@ -1,0 +1,163 @@
+using Metano.Compiler;
+using Metano.Compiler.Diagnostics;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin the asset-copy contract that <see cref="TranspilerHost"/>
+/// applies after <c>EmitFilesAsync</c>. Covers the sandbox checks
+/// (rooted destinations, `..` escapes), missing-source handling,
+/// and the happy-path copy with both mirrored and explicit
+/// destinations.
+/// </summary>
+public class TranspilerHostAssetCopyTests
+{
+    private readonly List<string> _tempDirs = new();
+
+    [After(Test)]
+    public void DeleteTempDirs()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_NoAssets_ReturnsEmpty()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var diagnostics = await TranspilerHost.CopyAssetsAsync([], outputDir, projectDir);
+        await Assert.That(diagnostics.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_MirroredDestination_CopiesAlongsideSource()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var assetPath = Path.Combine(projectDir, "schema.sql");
+        await File.WriteAllTextAsync(assetPath, "CREATE TABLE t (id INTEGER);");
+
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [new AssetSpec(assetPath)],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(0);
+        var landed = Path.Combine(outputDir, "schema.sql");
+        await Assert.That(File.Exists(landed)).IsTrue();
+        await Assert
+            .That(await File.ReadAllTextAsync(landed))
+            .IsEqualTo("CREATE TABLE t (id INTEGER);");
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_ExplicitDestination_OverridesMirror()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var assetPath = Path.Combine(projectDir, "schema.sql");
+        await File.WriteAllTextAsync(assetPath, "CREATE TABLE t (id INTEGER);");
+
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [new AssetSpec(assetPath, RelativeDestination: "provider/schema.sql")],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(0);
+        await Assert.That(File.Exists(Path.Combine(outputDir, "provider", "schema.sql"))).IsTrue();
+        await Assert.That(File.Exists(Path.Combine(outputDir, "schema.sql"))).IsFalse();
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_MissingSource_ReportsErrorMs0025()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [new AssetSpec(Path.Combine(projectDir, "missing.sql"))],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Code).IsEqualTo(DiagnosticCodes.AssetCopyFailure);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(MetanoDiagnosticSeverity.Error);
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_ParentEscape_ReportsError_DoesNotWrite()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var assetPath = Path.Combine(projectDir, "schema.sql");
+        await File.WriteAllTextAsync(assetPath, "x");
+
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [new AssetSpec(assetPath, RelativeDestination: "../escape.sql")],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(MetanoDiagnosticSeverity.Error);
+        await Assert
+            .That(File.Exists(Path.Combine(Path.GetDirectoryName(outputDir)!, "escape.sql")))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_RootedDestination_ReportsError()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var assetPath = Path.Combine(projectDir, "schema.sql");
+        await File.WriteAllTextAsync(assetPath, "x");
+
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [new AssetSpec(assetPath, RelativeDestination: "/etc/escape.sql")],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Severity).IsEqualTo(MetanoDiagnosticSeverity.Error);
+    }
+
+    [Test]
+    public async Task CopyAssetsAsync_MultipleAssets_CollectsAllDiagnostics()
+    {
+        var (projectDir, outputDir) = MakeWorkspace();
+        var goodAsset = Path.Combine(projectDir, "good.sql");
+        await File.WriteAllTextAsync(goodAsset, "y");
+
+        var diagnostics = await TranspilerHost.CopyAssetsAsync(
+            [
+                new AssetSpec(goodAsset),
+                new AssetSpec(Path.Combine(projectDir, "missing.sql")),
+                new AssetSpec(goodAsset, RelativeDestination: "../escape.sql"),
+            ],
+            outputDir,
+            projectDir
+        );
+
+        await Assert.That(diagnostics.Count).IsEqualTo(2);
+        await Assert
+            .That(diagnostics.All(d => d.Severity == MetanoDiagnosticSeverity.Error))
+            .IsTrue();
+        await Assert.That(File.Exists(Path.Combine(outputDir, "good.sql"))).IsTrue();
+    }
+
+    private (string ProjectDir, string OutputDir) MakeWorkspace()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "metano-asset-test-" + Guid.NewGuid().ToString("N")
+        );
+        var projectDir = Path.Combine(root, "project");
+        var outputDir = Path.Combine(root, "output");
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(outputDir);
+        _tempDirs.Add(root);
+        return (projectDir, outputDir);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `<MetanoAsset Include="..." OutputPath="..." Language="..." />` MSBuild item that copies static asset files (schemas, fixtures, resources) into `MetanoOutputDir` alongside generated TS/Dart files.
- Repeatable `--asset SRC[=DEST]` CLI flag on both transpiler CLIs feeds `TranspilerHost.CopyAssetsAsync`, which runs after `EmitFilesAsync` and participates in the incremental cache via a new `AssetSourceHashes` section (cache format bumped to v3).
- Missing source, escape attempts (`..` segments or rooted destinations), and I/O failures raise MS0025 as **errors** so a broken manifest fails fast.
- `samples/SampleQueryableSqlite` now ships its DDL as a real `schema.sql` asset loaded from disk by `provider/db.ts`, replacing the inlined fixture string.

## Schema decisions
- **`OutputPath` (not `Output`)** — MSBuild reserves `Output` (MSB4066/MSB4118).
- **`Language` (not `Target`)** — same reason. `_MetanoTargetLanguage` defaults to `typescript`; downstream Dart integrations override before `MetanoTranspile` fires.
- **`<MetanoAsset>` defaults `<Language>all</Language>`** via `ItemDefinitionGroup`, so a bare `<MetanoAsset Include="x" />` applies to every target.

## Spec
- New FR-048 (`spec/04-functional-requirements.md`).
- Feature matrix row marked **Implemented**.
- New diagnostic MS0025 (`AssetCopyFailure`) catalogued.

## Test plan
- [x] `dotnet run --project tests/Metano.Tests/` — 1094 pass / 0 fail / 7 skipped (CS9282 pre-existing).
- [x] New unit tests:
  - `AssetFlagParserTests` — null / bare / `=` / trailing `=` / multiple `=` / blank entries.
  - `TranspilationCacheTests` — v3 round-trip, `ComputeAssetFingerprints` keying / skip-missing / destination-distinct / content-sensitive.
  - `TranspilerHostAssetCopyTests` — no-op empty list, mirrored happy path, explicit destination override, missing-source error, parent-escape error, rooted-destination error, multi-asset partial failure.
- [x] End-to-end: `dotnet build samples/SampleQueryableSqlite/SampleQueryableSqlite.csproj` copies `schema.sql` → `provider/schema.sql` next to the hand-written `db.ts`.
- [x] Incremental cache: rerun with no changes short-circuits via the new asset fingerprint; editing the asset content invalidates the cache.
- [x] CSharpier + Biome pre-commit / pre-push hooks all green (the 2 biome warnings on `sample-issue-tracker` are pre-existing).

## Follow-ups (not in this PR)
- Symlink-safe sandbox check (compiler-man flagged `Path.GetFullPath` does not resolve symlinks). Current check matches the destination string against the output prefix; defense-in-depth.
- Dart MSBuild target integration (when the Dart project gets its own `.targets`, it should override `_MetanoTargetLanguage=dart`).

Closes #199