### PR TITLE
refactor(compiler): preserve concrete export kind in per-group cache (#220)

### DIFF
--- a/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/CachedFileMetadata.cs
@@ -13,8 +13,13 @@ namespace Metano.Compiler.TypeScript.Caching;
 /// Imports preserve every detail of <c>TsImport</c> because both
 /// downstream consumers read the full shape (typeOnly,
 /// per-name typeOnlyNames, default form, namespace form, aliases).
-/// Exports keep only the name + a coarse type-vs-value flag — that
-/// is the only distinction the barrel emitter cares about.
+/// Exports carry a <see cref="CachedExportKind"/> discriminator so a
+/// stub rebuild produces the same concrete AST shape (<c>TsClass</c>
+/// vs <c>TsConstObject</c> vs <c>TsInterface</c> vs <c>TsTypeAlias</c>,
+/// …). The cache must keep enough state to round-trip the exact
+/// classification any downstream stage applies — otherwise a stage
+/// that distinguishes <c>TsTypeAlias</c> from <c>TsInterface</c>
+/// would silently see the wrong shape on a cache hit.
 /// </para>
 /// </summary>
 public sealed record CachedFileMetadata(
@@ -34,4 +39,31 @@ public sealed record CachedImport(
     IReadOnlyDictionary<string, string>? Aliases = null
 );
 
-public sealed record CachedExport(string Name, bool TypeOnly);
+public sealed record CachedExport(string Name, CachedExportKind Kind);
+
+/// <summary>
+/// Discriminator for the concrete <c>TsTopLevel</c> shape an export
+/// originated from. Used on cache-rehydration to rebuild the same
+/// shape so <c>BarrelFileGenerator.GetExportedName</c> and
+/// <c>IsTypeOnlyExport</c> classify the stub identically to the
+/// fresh AST. Adding a new exported <c>TsTopLevel</c> subtype must
+/// land here and in <c>FileMetadataExtractor</c>'s switch — the
+/// reflection-based <c>Extract_CoversEveryTsTopLevelSubtype</c> test
+/// and the runtime <c>default</c> arm both fail otherwise.
+/// <para>
+/// The on-disk schema persists each value by name (see
+/// <c>GroupCacheFile</c>'s <c>JsonStringEnumConverter</c>), so the
+/// enum can be reordered without invalidating caches. New values
+/// can be appended at any position.
+/// </para>
+/// </summary>
+public enum CachedExportKind
+{
+    Class,
+    Function,
+    Enum,
+    ConstObject,
+    Namespace,
+    TypeAlias,
+    Interface,
+}

--- a/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/FileMetadataExtractor.cs
@@ -14,19 +14,24 @@ namespace Metano.Compiler.TypeScript.Caching;
 /// on-disk content is what actually gets written.
 ///
 /// <para>
-/// Imports go through unchanged. Exports collapse to the
-/// minimum shape each downstream stage reads:
+/// Imports go through unchanged. Exports preserve the original
+/// concrete <see cref="TsTopLevel"/> shape via
+/// <see cref="CachedExportKind"/> so a cache rehydration produces
+/// the exact same node type the fresh AST would (a
+/// <c>TsTypeAlias</c> rebuilds as <c>TsTypeAlias</c>, not as a
+/// generic type-only stub). This guards against silent
+/// misclassification when a downstream stage adds a check that
+/// distinguishes one type-only shape from another.
 /// </para>
-/// <list type="bullet">
-///   <item>Value exports → <see cref="TsConstObject"/> with the
-///   same <see cref="TsTopLevel"/>-level name. <c>BarrelFileGenerator</c>
-///   matches <c>TsConstObject { Exported: true }</c> in its
-///   <c>GetExportedName</c> switch and treats it as a value
-///   re-export.</item>
-///   <item>Type-only exports → <see cref="TsInterface"/>, which the
-///   barrel emitter treats as type-only. The empty
-///   property list keeps the stub minimal.</item>
-/// </list>
+/// <para>
+/// Non-exported and side-effect-only shapes
+/// (<see cref="TsTopLevelStatement"/>, <see cref="TsReExport"/>,
+/// <see cref="TsModuleExport"/>, <see cref="TsExportImportAlias"/>)
+/// participate via the file's on-disk content but contribute nothing
+/// to the barrel's export surface; the switch acknowledges them
+/// explicitly so a future addition to <see cref="TsTopLevel"/> has
+/// to land here too (the <c>default</c> arm throws).
+/// </para>
 /// </summary>
 public static class FileMetadataExtractor
 {
@@ -37,46 +42,106 @@ public static class FileMetadataExtractor
 
         foreach (var stmt in file.Statements)
         {
-            switch (stmt)
+            if (stmt is TsImport import)
             {
-                case TsImport import:
-                    imports.Add(
-                        new CachedImport(
-                            import.Names,
-                            import.From,
-                            import.TypeOnly,
-                            import.IsDefault,
-                            import.TypeOnlyNames is null ? null : import.TypeOnlyNames.ToArray(),
-                            import.IsNamespace,
-                            import.Aliases
-                        )
-                    );
-                    break;
-                case TsClass { Exported: true } c:
-                    exports.Add(new CachedExport(c.Name, TypeOnly: false));
-                    break;
-                case TsFunction { Exported: true } f:
-                    exports.Add(new CachedExport(f.Name, TypeOnly: false));
-                    break;
-                case TsEnum { Exported: true } e:
-                    exports.Add(new CachedExport(e.Name, TypeOnly: false));
-                    break;
-                case TsConstObject { Exported: true } co:
-                    exports.Add(new CachedExport(co.Name, TypeOnly: false));
-                    break;
-                case TsNamespaceDeclaration { Exported: true } ns:
-                    exports.Add(new CachedExport(ns.Name, TypeOnly: false));
-                    break;
-                case TsTypeAlias { Exported: true } ta:
-                    exports.Add(new CachedExport(ta.Name, TypeOnly: true));
-                    break;
-                case TsInterface { Exported: true } i:
-                    exports.Add(new CachedExport(i.Name, TypeOnly: true));
-                    break;
+                imports.Add(CaptureImport(import));
+                continue;
             }
+
+            if (TryClassifyExport(stmt) is { } export)
+            {
+                exports.Add(export);
+                continue;
+            }
+
+            RequireKnownNonExportShape(stmt);
         }
 
         return new CachedFileMetadata(file.FileName, Sha256(content), imports, exports);
+    }
+
+    private static CachedImport CaptureImport(TsImport import) =>
+        new(
+            import.Names,
+            import.From,
+            import.TypeOnly,
+            import.IsDefault,
+            import.TypeOnlyNames is null ? null : import.TypeOnlyNames.ToArray(),
+            import.IsNamespace,
+            import.Aliases
+        );
+
+    /// <summary>
+    /// Maps each exported <c>TsTopLevel</c> subtype to its
+    /// <see cref="CachedExport"/> entry. Returns <see langword="null"/>
+    /// for non-exported variants and for shapes that contribute
+    /// nothing to the barrel surface — the caller treats both cases
+    /// as "not an export" via <see cref="RequireKnownNonExportShape"/>.
+    /// </summary>
+    private static CachedExport? TryClassifyExport(TsTopLevel stmt) =>
+        stmt switch
+        {
+            TsClass c when c.Exported => new CachedExport(c.Name, CachedExportKind.Class),
+            TsFunction f when f.Exported => new CachedExport(f.Name, CachedExportKind.Function),
+            TsEnum e when e.Exported => new CachedExport(e.Name, CachedExportKind.Enum),
+            TsConstObject co when co.Exported => new CachedExport(
+                co.Name,
+                CachedExportKind.ConstObject
+            ),
+            TsNamespaceDeclaration ns when ns.Exported => new CachedExport(
+                ns.Name,
+                CachedExportKind.Namespace
+            ),
+            TsTypeAlias ta when ta.Exported => new CachedExport(
+                ta.Name,
+                CachedExportKind.TypeAlias
+            ),
+            TsInterface i when i.Exported => new CachedExport(i.Name, CachedExportKind.Interface),
+            _ => null,
+        };
+
+    /// <summary>
+    /// Enforces that a non-export statement belongs to one of the
+    /// shapes the cache deliberately ignores. Splitting the catch-all
+    /// into two named groups keeps the intent explicit:
+    /// <list type="bullet">
+    ///   <item>Non-exported variants of the seven exportable shapes —
+    ///   contribute on-disk content only.</item>
+    ///   <item>Side-effect / re-export / alias shapes — barrel emitter
+    ///   ignores them by design.</item>
+    /// </list>
+    /// Anything else throws so a future <c>TsTopLevel</c> subtype
+    /// cannot slip in unnoticed and silently miss the cache.
+    /// </summary>
+    private static void RequireKnownNonExportShape(TsTopLevel stmt)
+    {
+        switch (stmt)
+        {
+            // Non-exported variants — body still ships on disk.
+            case TsClass:
+            case TsFunction:
+            case TsEnum:
+            case TsConstObject:
+            case TsNamespaceDeclaration:
+            case TsTypeAlias:
+            case TsInterface:
+                return;
+
+            // Side-effect / re-export / alias shapes — the barrel
+            // emitter does not classify them as exportable surface.
+            case TsTopLevelStatement:
+            case TsReExport:
+            case TsModuleExport:
+            case TsExportImportAlias:
+                return;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unhandled TsTopLevel subtype '{stmt.GetType().Name}' in "
+                        + "FileMetadataExtractor. Add an explicit case so cache "
+                        + "rehydration stays consistent with the fresh AST."
+                );
+        }
     }
 
     /// <summary>
@@ -112,15 +177,38 @@ public static class FileMetadataExtractor
         }
 
         foreach (var export in metadata.Exports)
-        {
-            if (export.TypeOnly)
-                statements.Add(new TsInterface(export.Name, []));
-            else
-                statements.Add(new TsConstObject(export.Name, []));
-        }
+            statements.Add(BuildExportStub(export));
 
         return new TsSourceFile(metadata.Path, statements);
     }
+
+    /// <summary>
+    /// Reconstructs a minimal <see cref="TsTopLevel"/> node of the
+    /// exact original kind. Empty bodies / parameter lists are fine
+    /// because the cached on-disk file is what actually ships;
+    /// downstream stages only consume the node's type and exported
+    /// name.
+    /// </summary>
+    private static TsTopLevel BuildExportStub(CachedExport export) =>
+        export.Kind switch
+        {
+            CachedExportKind.Class => new TsClass(export.Name, Constructor: null, Members: []),
+            CachedExportKind.Function => new TsFunction(
+                export.Name,
+                Parameters: [],
+                ReturnType: new TsVoidType(),
+                Body: []
+            ),
+            CachedExportKind.Enum => new TsEnum(export.Name, Members: []),
+            CachedExportKind.ConstObject => new TsConstObject(export.Name, Entries: []),
+            CachedExportKind.Namespace => new TsNamespaceDeclaration(export.Name, Functions: []),
+            CachedExportKind.TypeAlias => new TsTypeAlias(export.Name, Type: new TsAnyType()),
+            CachedExportKind.Interface => new TsInterface(export.Name, Properties: []),
+            _ => throw new InvalidOperationException(
+                $"Unhandled CachedExportKind '{export.Kind}' in BuildExportStub. "
+                    + "Add a switch arm matching the new enum value."
+            ),
+        };
 
     /// <summary>
     /// Rejects rooted paths and any segment equal to <c>..</c> so a

--- a/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
+++ b/src/Metano.Compiler.TypeScript/Caching/GroupCacheFile.cs
@@ -29,13 +29,22 @@ public sealed record GroupCacheFile(
     IReadOnlyDictionary<string, GroupCacheEntry> Groups
 )
 {
-    public const int CurrentFormatVersion = 2;
+    // v3 introduced CachedExportKind (#220): the v2 shape persisted a
+    // bool `typeOnly` per export which silently misclassified type-only
+    // shapes on rehydration when deserialised by v3 code (the missing
+    // `kind` field would default to 0 = Class). Bumping the version
+    // invalidates every stale v2 file so the next run rebuilds the
+    // group cache from scratch.
+    public const int CurrentFormatVersion = 3;
     public const string FileName = ".metano-cache-groups-typescript.json";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        // Persist CachedExportKind as its name so the on-disk schema
+        // stays debuggable AND survives reordering of the enum.
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
     };
 
     public static GroupCacheFile? TryRead(string outputDir)

--- a/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
+++ b/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
@@ -124,24 +124,34 @@ public class FileMetadataExtractorTests
 
         await Assert.That(stub.FileName).IsEqualTo("foo/bar.ts");
         await Assert.That(stub.Statements.OfType<TsImport>().Count()).IsEqualTo(1);
-        await Assert.That(stub.Statements.OfType<TsClass>().Any(c => c.Name == "CClass")).IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsFunction>().Any(f => f.Name == "fFunc"))
+            .That(stub.Statements.OfType<TsClass>().Any(c => c.Name == "CClass" && c.Exported))
             .IsTrue();
-        await Assert.That(stub.Statements.OfType<TsEnum>().Any(e => e.Name == "EEnum")).IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsConstObject>().Any(co => co.Name == "CoConst"))
+            .That(stub.Statements.OfType<TsFunction>().Any(f => f.Name == "fFunc" && f.Exported))
+            .IsTrue();
+        await Assert
+            .That(stub.Statements.OfType<TsEnum>().Any(e => e.Name == "EEnum" && e.Exported))
             .IsTrue();
         await Assert
             .That(
-                stub.Statements.OfType<TsNamespaceDeclaration>().Any(ns => ns.Name == "NNamespace")
+                stub.Statements.OfType<TsConstObject>()
+                    .Any(co => co.Name == "CoConst" && co.Exported)
             )
             .IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsTypeAlias>().Any(ta => ta.Name == "TAlias"))
+            .That(
+                stub.Statements.OfType<TsNamespaceDeclaration>()
+                    .Any(ns => ns.Name == "NNamespace" && ns.Exported)
+            )
             .IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsInterface>().Any(i => i.Name == "IIface"))
+            .That(
+                stub.Statements.OfType<TsTypeAlias>().Any(ta => ta.Name == "TAlias" && ta.Exported)
+            )
+            .IsTrue();
+        await Assert
+            .That(stub.Statements.OfType<TsInterface>().Any(i => i.Name == "IIface" && i.Exported))
             .IsTrue();
     }
 

--- a/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
+++ b/tests/Metano.Tests/Caching/FileMetadataExtractorTests.cs
@@ -30,20 +30,93 @@ public class FileMetadataExtractorTests
         await Assert.That(meta.Imports[0].From).IsEqualTo("#/shared-kernel/user-id");
         await Assert.That(meta.Imports[0].Names[0]).IsEqualTo("UserId");
         await Assert.That(meta.Exports.Count).IsEqualTo(2);
-        await Assert.That(meta.Exports.Any(e => e.Name == "Bar" && !e.TypeOnly)).IsTrue();
-        await Assert.That(meta.Exports.Any(e => e.Name == "BarOptions" && e.TypeOnly)).IsTrue();
+        await Assert
+            .That(meta.Exports.Any(e => e.Name == "Bar" && e.Kind == CachedExportKind.Class))
+            .IsTrue();
+        await Assert
+            .That(
+                meta.Exports.Any(e =>
+                    e.Name == "BarOptions" && e.Kind == CachedExportKind.Interface
+                )
+            )
+            .IsTrue();
     }
 
     [Test]
-    public async Task Stub_Roundtrip_HasMatchingImportsAndExportMarkers()
+    public async Task Extract_PreservesExportKindPerShape()
+    {
+        var source = new TsSourceFile(
+            "foo/bar.ts",
+            [
+                new TsClass("CClass", null, [], Exported: true),
+                new TsFunction("fFunc", [], new TsVoidType(), [], Exported: true),
+                new TsEnum("EEnum", [], Exported: true),
+                new TsConstObject("CoConst", [], Exported: true),
+                new TsNamespaceDeclaration("NNamespace", [], Exported: true),
+                new TsTypeAlias("TAlias", new TsAnyType(), Exported: true),
+                new TsInterface("IIface", [], Exported: true),
+            ]
+        );
+
+        var meta = FileMetadataExtractor.Extract(source, "content-placeholder");
+
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "CClass").Kind)
+            .IsEqualTo(CachedExportKind.Class);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "fFunc").Kind)
+            .IsEqualTo(CachedExportKind.Function);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "EEnum").Kind)
+            .IsEqualTo(CachedExportKind.Enum);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "CoConst").Kind)
+            .IsEqualTo(CachedExportKind.ConstObject);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "NNamespace").Kind)
+            .IsEqualTo(CachedExportKind.Namespace);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "TAlias").Kind)
+            .IsEqualTo(CachedExportKind.TypeAlias);
+        await Assert
+            .That(meta.Exports.Single(e => e.Name == "IIface").Kind)
+            .IsEqualTo(CachedExportKind.Interface);
+    }
+
+    [Test]
+    public async Task Extract_AcknowledgesSideEffectShapes_WithoutThrowing()
+    {
+        var source = new TsSourceFile(
+            "foo/bar.ts",
+            [
+                new TsReExport(["Foo"], "#/foo"),
+                new TsModuleExport("Bar", IsDefault: false),
+                new TsExportImportAlias("Alias", "Target"),
+            ]
+        );
+
+        var meta = FileMetadataExtractor.Extract(source, "content-placeholder");
+
+        // Side-effect shapes ride along in the cached on-disk content
+        // and contribute nothing to the metadata's export surface.
+        await Assert.That(meta.Exports.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Stub_Roundtrip_RebuildsConcreteAstShape()
     {
         var meta = new CachedFileMetadata(
             "foo/bar.ts",
             "deadbeef",
             [new CachedImport(["UserId"], "#/shared-kernel/user-id")],
             [
-                new CachedExport("Bar", TypeOnly: false),
-                new CachedExport("BarOptions", TypeOnly: true),
+                new CachedExport("CClass", CachedExportKind.Class),
+                new CachedExport("fFunc", CachedExportKind.Function),
+                new CachedExport("EEnum", CachedExportKind.Enum),
+                new CachedExport("CoConst", CachedExportKind.ConstObject),
+                new CachedExport("NNamespace", CachedExportKind.Namespace),
+                new CachedExport("TAlias", CachedExportKind.TypeAlias),
+                new CachedExport("IIface", CachedExportKind.Interface),
             ]
         );
 
@@ -51,13 +124,24 @@ public class FileMetadataExtractorTests
 
         await Assert.That(stub.FileName).IsEqualTo("foo/bar.ts");
         await Assert.That(stub.Statements.OfType<TsImport>().Count()).IsEqualTo(1);
-        // Value export → TsConstObject with matching name.
+        await Assert.That(stub.Statements.OfType<TsClass>().Any(c => c.Name == "CClass")).IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsConstObject>().Any(c => c.Name == "Bar"))
+            .That(stub.Statements.OfType<TsFunction>().Any(f => f.Name == "fFunc"))
             .IsTrue();
-        // Type-only export → TsInterface.
+        await Assert.That(stub.Statements.OfType<TsEnum>().Any(e => e.Name == "EEnum")).IsTrue();
         await Assert
-            .That(stub.Statements.OfType<TsInterface>().Any(i => i.Name == "BarOptions"))
+            .That(stub.Statements.OfType<TsConstObject>().Any(co => co.Name == "CoConst"))
+            .IsTrue();
+        await Assert
+            .That(
+                stub.Statements.OfType<TsNamespaceDeclaration>().Any(ns => ns.Name == "NNamespace")
+            )
+            .IsTrue();
+        await Assert
+            .That(stub.Statements.OfType<TsTypeAlias>().Any(ta => ta.Name == "TAlias"))
+            .IsTrue();
+        await Assert
+            .That(stub.Statements.OfType<TsInterface>().Any(i => i.Name == "IIface"))
             .IsTrue();
     }
 
@@ -77,4 +161,73 @@ public class FileMetadataExtractorTests
         await Assert.That(meta.Imports.Count).IsEqualTo(1);
         await Assert.That(meta.Exports.Count).IsEqualTo(0);
     }
+
+    /// <summary>
+    /// Golden coverage guard: every concrete <c>TsTopLevel</c> subtype
+    /// shipped under <c>TypeScript/AST/</c> must be acknowledged by
+    /// <see cref="FileMetadataExtractor.Extract"/> (either through a
+    /// kind-specific case or one of the side-effect / non-exported
+    /// fall-through cases). The default arm throws on anything else,
+    /// so a freshly added subtype that no one wired in fails this
+    /// test before it can silently miss the cache.
+    /// <para>
+    /// The placeholder table is hand-maintained on purpose. A new
+    /// <c>TsTopLevel</c> subtype that doesn't appear in
+    /// <see cref="PlaceholdersBySubtype"/> trips the
+    /// <c>NotSupportedException</c> branch below — the contributor
+    /// then has two choices: wire the subtype into the extractor's
+    /// switch and add a placeholder here, or document why it cannot
+    /// flow through the cache.
+    /// </para>
+    /// </summary>
+    [Test]
+    public async Task Extract_CoversEveryTsTopLevelSubtype()
+    {
+        var subtypes = typeof(TsTopLevel)
+            .Assembly.GetTypes()
+            .Where(t => t.IsSealed && !t.IsAbstract && typeof(TsTopLevel).IsAssignableFrom(t))
+            .ToList();
+
+        await Assert
+            .That(subtypes.Count)
+            .IsGreaterThan(0)
+            .Because("Reflection failed to find any TsTopLevel subtype.");
+
+        foreach (var subtype in subtypes)
+        {
+            if (!PlaceholdersBySubtype.TryGetValue(subtype, out var placeholder))
+                throw new NotSupportedException(
+                    $"Add a placeholder for TsTopLevel subtype {subtype.Name} to "
+                        + "FileMetadataExtractorTests.PlaceholdersBySubtype, then "
+                        + "ensure FileMetadataExtractor.Extract recognises it."
+                );
+
+            var source = new TsSourceFile("coverage.ts", [placeholder]);
+            FileMetadataExtractor.Extract(source, "ignored");
+        }
+    }
+
+    /// <summary>
+    /// Minimal valid instances per TsTopLevel subtype. The contract
+    /// the test enforces is: <c>FileMetadataExtractor.Extract</c>
+    /// accepts every shape (either as an export or as a known
+    /// no-op). Empty member lists / placeholder names suffice — the
+    /// extractor never reads the bodies.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<Type, TsTopLevel> PlaceholdersBySubtype =
+        new Dictionary<Type, TsTopLevel>
+        {
+            [typeof(TsClass)] = new TsClass("CCls", null, []),
+            [typeof(TsFunction)] = new TsFunction("fFn", [], new TsVoidType(), []),
+            [typeof(TsEnum)] = new TsEnum("EEn", []),
+            [typeof(TsConstObject)] = new TsConstObject("CoCo", []),
+            [typeof(TsNamespaceDeclaration)] = new TsNamespaceDeclaration("NNs", []),
+            [typeof(TsTypeAlias)] = new TsTypeAlias("TTa", new TsAnyType()),
+            [typeof(TsInterface)] = new TsInterface("IIf", []),
+            [typeof(TsImport)] = new TsImport(["X"], "#/x"),
+            [typeof(TsReExport)] = new TsReExport(["X"], "#/x"),
+            [typeof(TsModuleExport)] = new TsModuleExport("Mod", false),
+            [typeof(TsExportImportAlias)] = new TsExportImportAlias("Alias", "Target"),
+            [typeof(TsTopLevelStatement)] = new TsTopLevelStatement(new TsRawStatement(";")),
+        };
 }

--- a/tests/Metano.Tests/Caching/GroupCacheFileTests.cs
+++ b/tests/Metano.Tests/Caching/GroupCacheFileTests.cs
@@ -1,0 +1,91 @@
+using Metano.Compiler.TypeScript.Caching;
+
+namespace Metano.Tests.Caching;
+
+/// <summary>
+/// Pin the on-disk format-version guard on
+/// <see cref="GroupCacheFile"/>. The v2 → v3 bump (#220) added
+/// <see cref="CachedExportKind"/>; a stale v2 cache silently
+/// deserialising under v3 code would default every <c>kind</c> to
+/// <c>Class</c> and misclassify every type-only export.
+/// </summary>
+public class GroupCacheFileTests
+{
+    private readonly List<string> _tempDirs = new();
+
+    [After(Test)]
+    public void DeleteTempDirs()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryRead_RejectsStaleV2File()
+    {
+        var dir = MakeTempDir();
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, GroupCacheFile.FileName),
+            """
+            {
+              "formatVersion": 2,
+              "configurationFingerprint": "fp",
+              "groups": {}
+            }
+            """
+        );
+
+        var cache = GroupCacheFile.TryRead(dir);
+        await Assert.That(cache).IsNull();
+    }
+
+    [Test]
+    public async Task RoundTrip_PersistsCachedExportKindByName()
+    {
+        var dir = MakeTempDir();
+        var original = new GroupCacheFile(
+            FormatVersion: GroupCacheFile.CurrentFormatVersion,
+            ConfigurationFingerprint: "fp",
+            Groups: new Dictionary<string, GroupCacheEntry>(StringComparer.Ordinal)
+            {
+                ["g"] = new GroupCacheEntry(
+                    "closure-hash",
+                    [
+                        new CachedFileMetadata(
+                            "foo.ts",
+                            "deadbeef",
+                            [],
+                            [new CachedExport("Foo", CachedExportKind.TypeAlias)]
+                        ),
+                    ]
+                ),
+            }
+        );
+
+        original.Write(dir);
+        var raw = await File.ReadAllTextAsync(Path.Combine(dir, GroupCacheFile.FileName));
+
+        // String-enum serialisation: caches survive enum-value reordering.
+        await Assert.That(raw).Contains("\"TypeAlias\"");
+
+        var roundTripped = GroupCacheFile.TryRead(dir);
+        await Assert.That(roundTripped).IsNotNull();
+        await Assert
+            .That(roundTripped!.Groups["g"].Files[0].Exports[0].Kind)
+            .IsEqualTo(CachedExportKind.TypeAlias);
+    }
+
+    private string MakeTempDir()
+    {
+        var dir = Path.Combine(
+            Path.GetTempPath(),
+            "metano-group-cache-test-" + Guid.NewGuid().ToString("N")
+        );
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the `bool TypeOnly` flag on `CachedExport` with a `CachedExportKind` discriminator (Class/Function/Enum/ConstObject/Namespace/TypeAlias/Interface) so cache rehydration rebuilds the exact original `TsTopLevel` shape.
- Reshapes `FileMetadataExtractor.Extract` around three named helpers: `CaptureImport`, `TryClassifyExport`, `RequireKnownNonExportShape`. The last enforces that every `TsTopLevel` subtype is acknowledged; the default arm throws on unknown shapes so a future addition cannot silently miss the cache.
- Adds a reflection-based `Extract_CoversEveryTsTopLevelSubtype` golden test backed by a hand-maintained `PlaceholdersBySubtype` table — every concrete `TsTopLevel` descendant must land in the table or the test fails loudly.
- Bumps `GroupCacheFile.CurrentFormatVersion` to **v3** so stale v2 files invalidate cleanly (v2 files were missing the `kind` field; deserialising under v3 would default every export to `Class` and corrupt type-only entries).
- Adds `JsonStringEnumConverter` to the on-disk schema so `CachedExportKind` persists by name, surviving future reordering of the enum.

## Motivation
ADR-0024 promises cache-hit content matches `target.Transform` output. The boolean-flag shape kept that promise *by coincidence*: `BarrelFileGenerator.IsTypeOnlyExport` happened to switch on `TsTypeAlias` ⌐or⌐ `TsInterface`, both rebuilt as `TsInterface`. The moment any downstream stage learned to distinguish them, cache hits would silently misclassify — Bob's audit flagged this as silent-regression risk #1. Closes #220.

## Test plan
- [x] `dotnet run --project tests/Metano.Tests/` — 1099 pass / 0 fail / 7 skipped (CS9282 pre-existing).
- [x] New tests:
  - `Extract_PreservesExportKindPerShape` — round-trip preserves each of the 7 kinds.
  - `Extract_AcknowledgesSideEffectShapes_WithoutThrowing` — TsReExport / TsModuleExport / TsExportImportAlias flow through silently.
  - `Stub_Roundtrip_RebuildsConcreteAstShape` — `BuildStub` emits the exact concrete AST type per kind.
  - `Extract_CoversEveryTsTopLevelSubtype` — reflection + placeholder table covers every sealed descendant.
  - `GroupCacheFileTests.TryRead_RejectsStaleV2File` — v2 → v3 invalidation.
  - `GroupCacheFileTests.RoundTrip_PersistsCachedExportKindByName` — string-enum on-disk shape.

## Follow-up not in this PR
- Compiler-man flagged that swapping the `JsonStringEnumConverter` to a number serialiser would still break stale caches even after the v3 bump — handled here by going string-name.

Closes #220