### PR TITLE
feat: add configurable isolated subpath-import alias for generated packages

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-jsx-codegen-from-csharp"
+  "feature_directory": "specs/004-configurable-import-alias"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,13 +208,16 @@ Rules:
 - **Diagrams.** Always use Mermaid for any diagram in markdown (README, docs/, ADRs, specs). Never ASCII art — it breaks in proportional fonts and can't be zoomed. Prefer GitHub-native syntax: `flowchart`, `sequenceDiagram`, `classDiagram`, `stateDiagram-v2`, `erDiagram`.
 
 <!-- SPECKIT START -->
-Active feature plan: `specs/002-jsx-codegen-from-csharp/plan.md`
-(first vertical slice of JSX/TSX code generation from C# renderable record components,
-proving target SolidJS, with library-agnostic renderable-type recognition).
+Active feature plan: `specs/004-configurable-import-alias/plan.md`
+(opt-in, isolated Node.js subpath-import alias for internal imports in generated
+TypeScript — `--import-alias` CLI flag / `MetanoImportAlias` MSBuild property — so
+generated code can be emitted into a subfolder of an existing npm project without
+colliding with that project's own `#` alias; default behavior is unchanged).
 For technologies, project structure, and other context, read that plan and its sibling
 `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/`.
-The foundational JS-interop primitives — `[JsTuple]`, `[JsCallable]`, tuple deconstruction —
-are merged at `specs/003-js-interop-primitives/plan.md`; the 002 reactivity refactor consumes them.
+Prior shipped features: JSX/TSX code generation at `specs/002-jsx-codegen-from-csharp/plan.md`;
+foundational JS-interop primitives (`[JsTuple]`, `[JsCallable]`, tuple deconstruction)
+at `specs/003-js-interop-primitives/plan.md`.
 The project baseline + multi-target evolution roadmap remains at
 `specs/001-project-baseline-evolution/plan.md`.
 <!-- SPECKIT END -->

--- a/specs/004-configurable-import-alias/checklists/requirements.md
+++ b/specs/004-configurable-import-alias/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Configurable Isolated Subpath-Import Alias for Generated Packages
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- The domain vocabulary (subpath-imports, `package.json`, alias key) is the
+  established terminology of the consuming ecosystem and is used descriptively, not
+  as implementation prescription. The CLI/MSBuild surfaces are referenced as
+  capabilities (FR-005) without prescribing flag/property spelling, which is fixed
+  during planning.
+- All open design questions were resolved before specification (opt-in default,
+  configuration surface, alias normalization, multi-project responsibility), so no
+  [NEEDS CLARIFICATION] markers are present.
+- A detailed design/implementation guide backs this spec at
+  `/Users/danfma/.claude/plans/vamos-adicionar-suporte-a-dynamic-hopcroft.md`.

--- a/specs/004-configurable-import-alias/contracts/cli-and-msbuild.md
+++ b/specs/004-configurable-import-alias/contracts/cli-and-msbuild.md
@@ -1,0 +1,55 @@
+# Contract: CLI flag & MSBuild property
+
+The configuration surface for the import alias. Mirrors the existing
+`--dist` / `--src-root` / `--package-root` pattern.
+
+## CLI: `--import-alias`
+
+Command: `metano-typescript` (`src/Metano.Compiler.TypeScript/Commands.cs`).
+
+| Property | Value |
+|----------|-------|
+| Flag | `--import-alias <name>` |
+| Parameter | `string? importAlias = null` |
+| Default | `null` (alias unset → legacy `#` behavior) |
+| Normalization | Trim; strip one leading `#`; blank → unset |
+
+**Behavior**:
+- Unset → generated internal imports and `package.json` use `#` / `#/*` (unchanged).
+- Set (e.g. `--import-alias contracts`) → internal imports use `#contracts/...`,
+  `package.json` gets `#contracts` / `#contracts/*` only; host `#` untouched.
+
+**Example**:
+
+```sh
+dotnet run --project src/Metano.Compiler.TypeScript/ -- \
+  -p samples/Abc.Contracts/Abc.Contracts.csproj \
+  -o ../frontend/src/abc/contracts \
+  --import-alias contracts --clean
+```
+
+## MSBuild: `MetanoImportAlias`
+
+File: `src/Metano.Build/build/Metano.Build.targets`.
+
+| Property | Value |
+|----------|-------|
+| Property name | `MetanoImportAlias` |
+| Maps to | `--import-alias "$(MetanoImportAlias)"` |
+| Condition | Emitted only when `'$(MetanoImportAlias)' != ''` |
+
+**Example (`.csproj`)**:
+
+```xml
+<PropertyGroup>
+  <MetanoOutputDir>../frontend/src/abc/contracts</MetanoOutputDir>
+  <MetanoImportAlias>contracts</MetanoImportAlias>
+</PropertyGroup>
+```
+
+## Contract guarantees
+
+- Providing the value with or without a leading `#` yields the same alias key.
+- A blank/whitespace value is equivalent to not setting it.
+- Changing the value forces regeneration (the alias participates in the incremental
+  cache fingerprint).

--- a/specs/004-configurable-import-alias/contracts/generated-imports.md
+++ b/specs/004-configurable-import-alias/contracts/generated-imports.md
@@ -1,0 +1,54 @@
+# Contract: generated import specifiers & package.json entries
+
+Defines the exact emitted shape, as a function of the alias state. These are the
+observable outputs the acceptance scenarios assert against.
+
+## In-file import specifiers
+
+For a target type whose namespace (after the project root namespace is stripped and
+kebab-cased) is `<ns>`:
+
+| Case | Unset (default) | Set: alias `contracts` |
+|------|-----------------|------------------------|
+| Cross-namespace, non-root | `import { T } from "#/<ns>"` | `import { T } from "#contracts/<ns>"` |
+| Cross-namespace, root namespace | `import { T } from "#"` | `import { T } from "#contracts"` |
+| Same namespace | `import { T } from "./<kebab-type>"` | `import { T } from "./<kebab-type>"` (unchanged) |
+| External package (`[EmitPackage("pkg")]`) | `import { T } from "pkg/<sub>"` | `import { T } from "pkg/<sub>"` (unchanged) |
+
+## package.json `imports` entries
+
+| Alias state | Keys emitted |
+|-------------|--------------|
+| Unset | `#/*` (+ `#` if a root barrel exists) |
+| Set `contracts` | `#contracts/*` (+ `#contracts` if a root barrel exists) |
+
+Worked example — output dir `src/abc/contracts` inside a host package whose root is
+the parent, alias `contracts`:
+
+```jsonc
+{
+  "imports": {
+    // host project's own alias — PRESERVED, never written by Metano
+    "#/*": { "default": "./src/*.ts" },
+
+    // Metano-managed, alias-scoped, depth-correct, no double slash
+    "#contracts/*": {
+      "types":   "./dist/abc/contracts/*.d.ts",
+      "import":  "./dist/abc/contracts/*.js",
+      "default": "./src/abc/contracts/*.ts"
+    }
+  }
+}
+```
+
+## Invariants
+
+1. **Isolation (FR-003)**: when an alias is set, Metano writes only the
+   alias-scoped keys; it never adds or modifies `#`/`#/*`.
+2. **Backward compatibility (FR-004)**: when unset, every emitted byte equals the
+   pre-feature output.
+3. **External imports unaffected (FR-006)**: package-name specifiers are identical
+   regardless of alias.
+4. **Well-formed paths (FR-008)**: no doubled path separators at any depth.
+5. **Cycle detection (FR-009)**: a circular reference is reported (diagnostic
+   MS0005) whether or not an alias is set.

--- a/specs/004-configurable-import-alias/data-model.md
+++ b/specs/004-configurable-import-alias/data-model.md
@@ -1,0 +1,83 @@
+# Phase 1 Data Model: Configurable Isolated Subpath-Import Alias
+
+This feature has no persistent or runtime data model. The relevant "entities" are
+the configuration value and the derived emission artifacts that flow through the
+TypeScript target adapter at transpile time.
+
+## Entity: Import Alias (configured value)
+
+The developer-supplied alias name.
+
+| Attribute | Description |
+|-----------|-------------|
+| Raw value | The string passed via `--import-alias` / `MetanoImportAlias`. May be `null`/absent. |
+| Normalized value | Trimmed; a single leading `#` stripped if present; empty/whitespace → treated as absent. |
+| Effective state | `Unset` → default key `#`; `Set(name)` → key `#<name>`. |
+
+**Validation rules (FR-007)**:
+- `null`, `""`, or whitespace-only → **Unset** (legacy `#` behavior).
+- `"contracts"` and `"#contracts"` → both normalize to name `contracts`.
+- Surrounding whitespace is trimmed before use.
+
+**State diagram**:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unset: no flag / blank
+    [*] --> Set: --import-alias name
+    Unset --> Unset: AliasPrefix = "#"
+    Set --> Set: AliasPrefix = "#" + name
+```
+
+## Entity: Alias Prefix (derived, in-memory)
+
+Computed once in `PathNaming` from the normalized alias.
+
+| Effective state | `AliasPrefix` | Bare-root specifier | Namespace specifier |
+|-----------------|---------------|---------------------|---------------------|
+| Unset | `#` | `#` | `#/<ns>` |
+| Set(`contracts`) | `#contracts` | `#contracts` | `#contracts/<ns>` |
+
+The same-namespace import (`./<kebab-type>`) is **never** aliased (relative import,
+avoids barrel self-cycles).
+
+## Entity: Generated `package.json` imports entries (output)
+
+Produced by `PackageJsonWriter.BuildImports`. Exactly two keys are emitted; which
+two depends on the alias state.
+
+| Effective state | Pattern key (`starKey`) | Root key (`rootKey`, only if a root barrel exists) |
+|-----------------|-------------------------|----------------------------------------------------|
+| Unset | `#/*` | `#` |
+| Set(`contracts`) | `#contracts/*` | `#contracts` |
+
+Each key maps to a conditional object:
+
+```json
+{
+  "types":   "./<dist>/<outputPrefix>/<...>.d.ts",
+  "import":  "./<dist>/<outputPrefix>/<...>.js",
+  "default": "./<src>/<...>.ts"
+}
+```
+
+**Invariants**:
+- When `Set`, the default `#`/`#/*` keys are **never written** (the writer only ever
+  emits `starKey`/`rootKey`), so a host project's own `#`/`#/*` is preserved (FR-003).
+- Path values contain no doubled separators at any depth — `outputPrefix` is
+  trailing-trimmed before interpolation (FR-008).
+- Existing user-authored keys are preserved by the write-if-missing merge; alias
+  keys are additive (Edge case: user `#`/`#/*` + alias coexist).
+
+## Entity: Import graph node key (cycle detector, internal)
+
+`CyclicReferenceDetector` normalizes in-file specifiers to graph keys.
+
+| Specifier (Unset) | Specifier (Set `contracts`) | Normalized key |
+|-------------------|-----------------------------|----------------|
+| `#` | `#contracts` | `""` (root) |
+| `#/<ns>` | `#contracts/<ns>` | `<ns>` |
+| `./<file>` | `./<file>` (unchanged) | relative path |
+
+**Invariant (FR-009)**: cross-namespace edges are recognized under the active alias,
+so cycles are still detected (no false negatives).

--- a/specs/004-configurable-import-alias/plan.md
+++ b/specs/004-configurable-import-alias/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Configurable Isolated Subpath-Import Alias for Generated Packages
+
+**Branch**: `004-configurable-import-alias` | **Date**: 2026-06-23 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/004-configurable-import-alias/spec.md`
+
+## Summary
+
+Add an opt-in, configurable, isolated Node.js subpath-import alias for **internal**
+(same-project) imports in Metano-generated TypeScript. Today the alias key is the
+hardcoded `#` (`#/<ns>` specifiers + `#`/`#/*` `package.json` entries), which
+collides with a host project's own `#` when generated code is emitted into a
+subfolder of an existing npm package, and resolves to the wrong path because the
+in-file specifier ignores the output directory.
+
+The chosen approach threads a single optional `importAlias` value — set via a new
+`--import-alias` CLI flag and `MetanoImportAlias` MSBuild property — into (a) the
+in-file specifier builder (`PathNaming`) and (b) the `package.json` writer
+(`PackageJsonWriter`), plus the read-side cycle detector
+(`CyclicReferenceDetector`). When set (e.g. `contracts`), internal specifiers
+become `#contracts/<ns>` and `package.json` gets only `#contracts`/`#contracts/*`
+entries scoped to the output subfolder, leaving the host's `#` untouched. When
+unset, output is byte-identical to today. The change is confined to the TypeScript
+target adapter; the target-agnostic core (`Metano.Compiler`) is not touched. A
+pre-existing double-slash path bug in nested-output `package.json` entries is fixed
+as a companion correctness item.
+
+## Technical Context
+
+**Language/Version**: C# 14 on .NET 10 (compiler); emitted output is TypeScript consumed under Bun/Node.
+
+**Primary Dependencies**: Roslyn 5.3.0 (Microsoft.CodeAnalysis) for semantic analysis; ConsoleAppFramework for the `metano-typescript` CLI; the `Metano.Build` MSBuild integration that mirrors CLI flags as `Metano*` properties.
+
+**Storage**: N/A — the transpiler reads a `.csproj` and writes `.ts` files plus a merged `package.json`.
+
+**Testing**: TUnit for .NET (`dotnet run --project tests/Metano.Tests/`); bun:test for generated TypeScript and runtime.
+
+**Target Platform**: .NET 10 CLI / MSBuild build step; generated artifacts target Node/Bun module resolution (subpath imports).
+
+**Project Type**: Compiler / transpiler (target-agnostic core library + per-language target adapters + CLI).
+
+**Performance Goals**: No performance-sensitive path is affected. The alias is a string-prefix substitution computed once per run; no measurable impact on transpile throughput.
+
+**Constraints**: Strictly backward compatible — default (unset) output is byte-identical to current behavior. `TreatWarningsAsErrors` and `dotnet csharpier .` cleanliness are mandatory. The cache fingerprint MUST incorporate the alias so changing it invalidates stale output.
+
+**Scale/Scope**: Small, localized change in the TypeScript target adapter — ~7 production files plus tests; no new project, no core change, no new dependency.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Verdict |
+|-----------|------------|---------|
+| I. Clean Code as the Baseline | One small responsibility per edit; the alias-normalization rule is extracted into a named helper rather than inlined into a condition; csharpier + warnings-as-errors enforced. | ✅ Pass |
+| II. Expressive, Intention-Revealing Code | `ImportAlias` / `AliasPrefix` / `starKey` / `rootKey` name the concept directly; the public surface (`--import-alias`, `MetanoImportAlias`) reveals intent. | ✅ Pass |
+| III. Screaming, Feature-Semantic Organization | Edits land in existing capability folders (`Transformation/PathNaming.cs`, `Transformation/CyclicReferenceDetector.cs`, `PackageJsonWriter.cs`); no new generic `Helpers/`/`Utils/` bucket introduced. | ✅ Pass |
+| IV. Clean Architecture via Ports & Adapters | The alias is a TypeScript-emission concern and lives **entirely in the TS target adapter** (`Commands.cs`, `TypeScriptTarget.cs`, `TypeTransformer.cs`, the writer). The core (`Metano.Compiler`, `TranspileOptions`) is **not** touched — dependencies still point inward. | ✅ Pass |
+| V. Developer Experience First | Single documented CLI flag + MSBuild property; golden/expected-output tests accompany the behavior; no silent failure (the multi-project collision limitation is documented, not hidden). | ✅ Pass |
+| VI. Pragmatism Over Dogma | Opt-in, minimal threading; no new config-file layer, no speculative cross-project collision machinery (explicitly deferred). | ✅ Pass |
+
+**Result**: All gates pass. No deviations to record — Complexity Tracking is empty.
+
+> Process note: the constitution's "Worktree per issue" workflow rule was waived by
+> the user for this session (work proceeds on branch `004-configurable-import-alias`
+> in the main working directory). User instruction takes precedence; this is a
+> workflow choice, not a code-complexity violation, so it is not tracked as a gate
+> failure.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-configurable-import-alias/
+├── plan.md              # This file (/speckit-plan output)
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output — decisions & rationale
+├── data-model.md        # Phase 1 output — config value objects & flow
+├── quickstart.md        # Phase 1 output — developer walkthrough
+├── contracts/           # Phase 1 output — CLI/MSBuild + generated-shape contracts
+│   ├── cli-and-msbuild.md
+│   └── generated-imports.md
+└── checklists/
+    └── requirements.md  # Spec quality checklist (from /speckit-specify)
+```
+
+### Source Code (repository root)
+
+Changes are confined to the TypeScript target adapter and the build integration.
+The target-agnostic core (`src/Metano.Compiler/`) is intentionally untouched.
+
+```text
+src/
+├── Metano.Compiler/                      # CORE — NOT modified (no alias leaks here)
+└── Metano.Compiler.TypeScript/
+    ├── Commands.cs                        # + --import-alias flag; thread to target + writer
+    ├── TypeScriptTarget.cs                # + ImportAlias prop; cache fingerprint
+    ├── PackageJsonWriter.cs               # alias-scoped imports keys + double-slash fix
+    └── Transformation/
+        ├── PathNaming.cs                  # AliasPrefix → in-file specifier
+        ├── TypeTransformer.cs             # construct PathNaming w/ alias; pass to detector
+        └── CyclicReferenceDetector.cs     # recognize alias keys in the import graph
+src/Metano.Build/
+└── build/Metano.Build.targets            # + MetanoImportAlias property → --import-alias
+
+tests/
+└── Metano.Tests/                         # PathNaming, EmitPackage (package.json),
+                                          # Cyclic, + new alias golden/no-regression tests
+```
+
+**Structure Decision**: Single-project compiler with target adapters (Option 1,
+specialized). The feature is a TypeScript-emission concern, so it is implemented in
+`src/Metano.Compiler.TypeScript/` (the TS adapter) and `src/Metano.Build/` (its
+MSBuild surface), keeping the core port (`ITranspilerTarget` / `Metano.Compiler`)
+free of language-specific path knobs — consistent with Principle IV.
+
+## Complexity Tracking
+
+> No constitution violations. No entries.

--- a/specs/004-configurable-import-alias/quickstart.md
+++ b/specs/004-configurable-import-alias/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Emit generated code into a subfolder of an existing project
+
+This walkthrough shows how to use the configurable import alias to generate a C#
+contracts library into a subfolder of an existing TypeScript/npm project without
+colliding with that project's own `#` alias.
+
+## Scenario
+
+- Existing frontend `frontend/` whose `src/` is the source root, already exposing
+  `#/*` → `./src/*` in its `package.json`.
+- C# project `Abc.Contracts` (`[assembly: TranspileAssembly]`) with types under
+  namespaces like `Abc.Contracts.Serialization`.
+- You want the generated TypeScript under `frontend/src/abc/contracts`, referenced
+  by both your app code and by other generated types.
+
+## Steps
+
+### 1. Configure the output dir and alias
+
+Via MSBuild (in `Abc.Contracts.csproj`):
+
+```xml
+<PropertyGroup>
+  <MetanoOutputDir>../frontend/src/abc/contracts</MetanoOutputDir>
+  <MetanoImportAlias>contracts</MetanoImportAlias>
+  <MetanoClean>true</MetanoClean>
+</PropertyGroup>
+```
+
+Or directly via the CLI:
+
+```sh
+dotnet run --project src/Metano.Compiler.TypeScript/ -- \
+  -p Abc.Contracts/Abc.Contracts.csproj \
+  -o frontend/src/abc/contracts \
+  --import-alias contracts --clean
+```
+
+### 2. Transpile
+
+Run the build (or the CLI command above). Metano emits the `.ts` files under
+`frontend/src/abc/contracts` and merges alias entries into the nearest
+`package.json` (the frontend's).
+
+### 3. Verify the generated imports
+
+Internal cross-namespace imports now use the isolated alias:
+
+```ts
+import { MyType } from "#contracts/serialization";
+```
+
+…and the frontend `package.json` has, side by side:
+
+```jsonc
+{
+  "imports": {
+    "#/*": { "default": "./src/*.ts" },          // your app's alias — untouched
+    "#contracts/*": {                              // Metano-managed, depth-correct
+      "types":   "./dist/abc/contracts/*.d.ts",
+      "import":  "./dist/abc/contracts/*.js",
+      "default": "./src/abc/contracts/*.ts"
+    }
+  }
+}
+```
+
+### 4. Build the TypeScript
+
+```sh
+cd frontend && bun run build
+```
+
+Resolution succeeds with zero manual edits to imports, and your app's own `#/...`
+imports keep working.
+
+## Verifying the contract (acceptance checks)
+
+- **Isolation**: your pre-existing `#`/`#/*` entries are unchanged after transpile.
+- **Correct resolution**: every generated `#contracts/...` import points at a real
+  emitted file.
+- **No malformed paths**: no `//` appears in any `imports`/`exports` path value.
+- **Backward compatible**: drop `--import-alias` / `MetanoImportAlias` and the
+  output reverts byte-for-byte to the default `#`/`#/*` form.
+
+## Notes
+
+- If several Metano projects target the same TypeScript package, give each a
+  distinct `MetanoImportAlias` (e.g. `contracts`, `events`) to avoid key clashes —
+  cross-project conflict detection is not provided in this version.
+- Imports of types from referenced packages (`[EmitPackage("name")]`) are
+  unaffected — they continue to import from `name/...`.

--- a/specs/004-configurable-import-alias/research.md
+++ b/specs/004-configurable-import-alias/research.md
@@ -1,0 +1,118 @@
+# Phase 0 Research: Configurable Isolated Subpath-Import Alias
+
+All decisions below were resolved during exploration of the current Metano
+codebase; no `NEEDS CLARIFICATION` remains. File:line references are to the code as
+it exists on `main` at the time of writing.
+
+## Decision 1 — Mechanism: isolated subpath-import alias (not a relative base path, not reusing `--src-root`)
+
+**Decision**: Introduce a configurable, isolated Node.js subpath-import **alias key**
+(default `#`, e.g. `#contracts` when set) for internal imports.
+
+**Rationale**: The failure has two coupled causes — (a) a **key collision** (host
+project also uses `#`/`#/*`) and (b) a **specifier assumption** (the in-file
+`#/<ns>` ignores the output directory, see `PathNaming.ComputeRelativeImportPath`,
+`PathNaming.cs:81-87`). A distinct alias key whose `package.json` target encodes the
+output-subfolder depth fixes both at once: the key no longer collides, and the alias
+target absorbs the depth so the specifier resolves correctly regardless of nesting.
+
+**Alternatives considered**:
+- *Relative/base path between generated files*: would emit brittle `../../../`
+  chains and fights the existing namespace-rooted barrel layout
+  (`PathNaming.GetRelativePath`). Rejected.
+- *Reuse `--src-root` / `OutputPrefix.Resolve`*: those shape the **path values** of
+  `package.json` entries, never the **key** (`#`) and never the in-file specifier
+  (`OutputPrefix.cs`; `PackageJsonWriter.cs:353-385`). They cannot address a key
+  collision. Rejected.
+
+## Decision 2 — Node subpath-import key form: `#name` + `#name/*`
+
+**Decision**: The alias key is `#<name>` (literal) plus `#<name>/*` (pattern). The
+in-file specifier is `#<name>/<ns>` (and bare `#<name>` for the root-namespace case).
+
+**Rationale**: Node `imports` keys must start with `#`. `#contracts` and
+`#contracts/*` are exactly the shape the writer already emits for `#`/`#/*`, just
+with a longer literal — proven legitimate by the existing user-merge test
+(`EmitPackageTests.cs`, the `#custom/*` case). `#/contracts` (extra slash) is a
+*subpath under the `#/*` pattern*, so it would only resolve if a `#/*` alias existed
+— exactly the alias we are avoiding — and is therefore normalized away.
+
+## Decision 3 — Opt-in (default behavior unchanged)
+
+**Decision**: The alias is opt-in. With no configuration, `AliasPrefix == "#"` and
+the writer emits `#`/`#/*` — byte-identical to today.
+
+**Rationale**: Backward compatibility is a release gate (Spec SC-002). The repo's
+own samples emit into their package src root where `#/*` is correct, and ~hundreds
+of golden fixtures pin the `#/...` form. A default change would force regeneration
+of all of them and diverge from the repo's `#/*` convention. Opt-in is the minimal,
+Principle-VI-aligned choice.
+
+## Decision 4 — Configuration surface: CLI flag + MSBuild property (no `metano.json`)
+
+**Decision**: New `--import-alias <name>` flag on `metano-typescript`
+(`Commands.cs`) and a mirrored `MetanoImportAlias` MSBuild property
+(`Metano.Build.targets`).
+
+**Rationale**: This is the established knob pattern (`--dist`, `--src-root`,
+`--package-root`, `--namespace-barrels`). No configuration-file mechanism exists in
+Metano today (`metano.json` is only a prose example in `CLAUDE.md`); introducing one
+would be the first config-file layer and is unjustified for a single knob (YAGNI,
+Principle VI). A future `metano.json` can reuse the same value.
+
+## Decision 5 — Placement: TypeScript adapter only (core untouched)
+
+**Decision**: The alias lives in the TS target adapter
+(`Commands.cs` → `TypeScriptTarget` → `TypeTransformer` → `PathNaming`, and
+`Commands.cs` → `PackageJsonWriter`). It is **not** added to the target-agnostic
+`TranspileOptions` (`src/Metano.Compiler/`).
+
+**Rationale**: The alias shapes TypeScript subpath imports — a language-specific
+emission concern. `TranspileOptions` documents that target-specific flags live in
+the target CLI layer (the same place `--dist`/`--src-root` already live). Keeping it
+out of the core preserves inward-pointing dependencies (Constitution Principle IV).
+
+```mermaid
+flowchart LR
+  CLI["--import-alias (Commands.cs)"] --> TGT["TypeScriptTarget.ImportAlias"]
+  CLI --> PJW["PackageJsonWriter.UpdateOrCreate(importAlias)"]
+  TGT --> TT["TypeTransformer.ImportAlias"]
+  TGT --> FP["BuildConfigurationFingerprint (cache)"]
+  TT --> PN["new PathNaming(rootNs, importAlias)"]
+  TT --> CRD["CyclicReferenceDetector.DetectAndReport(importAlias)"]
+  PN --> SPEC["in-file #alias/&lt;ns&gt; specifier"]
+  PJW --> PKG["package.json #alias / #alias/*"]
+```
+
+## Decision 6 — Cache correctness: alias enters the configuration fingerprint
+
+**Decision**: Append the alias to `TypeScriptTarget.BuildConfigurationFingerprint`.
+
+**Rationale**: The incremental cache keys generated output on a configuration
+fingerprint. Flipping the alias changes every internal specifier; without it in the
+fingerprint, a cached run would reuse stale `#/...` output. This satisfies Spec
+FR-010.
+
+## Decision 7 — Cross-package / `exports` path is NOT changed
+
+**Decision**: Leave the cross-package import path and `package.json#exports`
+generation untouched.
+
+**Rationale**: Consumers import a referenced package by its **npm name**
+(`ImportCollector.cs:222-225`; `PathNaming.ComputeSubPath`), which never sees the
+producer's local `imports` map — so the internal alias cannot collide with or affect
+any downstream import. The producer's `exports` already encode nested-output depth
+via `outputPrefix` (`PackageJsonWriter.BuildExports`). Internal-alias-only is
+sufficient (Spec FR-006). Verified end-to-end against the `SampleTodo.Service`
+cross-package sample.
+
+## Decision 8 — Bundle the double-slash path fix
+
+**Decision**: Fix the nested-output double-slash bug (`.../contracts//index.d.ts`)
+as part of this feature.
+
+**Rationale**: `outputPrefix` is interpolated into `distBase` without trailing-trim
+(`PackageJsonWriter.cs:362`) while `src` is trimmed (`:360`); the twin bug is in
+`BuildExports` (`:401`). The defect manifests precisely in the nested-output
+scenario this feature targets, so fixing it here is cohesive and required for Spec
+FR-008 / SC-004.

--- a/specs/004-configurable-import-alias/spec.md
+++ b/specs/004-configurable-import-alias/spec.md
@@ -1,0 +1,187 @@
+# Feature Specification: Configurable Isolated Subpath-Import Alias for Generated Packages
+
+**Feature Branch**: `004-configurable-import-alias`
+
+**Created**: 2026-06-23
+
+**Status**: Draft
+
+**Input**: User description: "Add an opt-in, configurable, isolated subpath-import alias for Metano-generated TypeScript packages, so generated code can be emitted into a subfolder of an existing npm project without colliding with that project's own `#` subpath-imports alias. A new `--import-alias` CLI flag (and matching `MetanoImportAlias` MSBuild property) sets the alias; when set, generated internal imports and the package.json entries use the isolated alias key instead of the default `#`, leaving the host project's `#` untouched. When unset, behavior is unchanged (fully backward compatible)."
+
+> Detailed problem statement, solution rationale, design decisions, edge cases,
+> and a step-by-step implementation guide live in the design guide at
+> `/Users/danfma/.claude/plans/vamos-adicionar-suporte-a-dynamic-hopcroft.md`.
+> This specification captures the normative WHAT/WHY; the guide captures the HOW.
+
+## User Scenarios & Testing *(mandatory)*
+
+The "users" of this feature are developers who run Metano to generate TypeScript
+and consume the output inside a TypeScript/npm project.
+
+### User Story 1 - Emit into a subfolder of an existing project (Priority: P1)
+
+A developer has an existing npm/TypeScript frontend whose `src/` directory is its
+source root, already exposed through the `#/*` subpath-imports alias. They want to
+generate a C# contracts library (e.g. `Abc.Contracts.Serialization`) into a
+subfolder of that project, such as `src/abc/contracts`, and reference the
+generated types from their hand-written code and from one generated type to
+another (for example a serializer-configuration type that references sibling
+generated types).
+
+Today this breaks: Metano emits internal imports like
+`import { MyType } from "#/my-type"` that resolve against the host project's own
+`#/*` alias (→ the wrong path), and Metano also writes a conflicting `#`/`#/*`
+entry into the host project's `package.json`.
+
+With this feature, the developer configures an isolated alias (e.g. `contracts`)
+for that Metano project. Generated internal imports then use the isolated key
+(`#contracts/...`), the generated `package.json` entry maps that key to the actual
+output subfolder, and the host project's own `#`/`#/*` alias is left untouched.
+
+**Why this priority**: This is the core problem the feature exists to solve.
+Without it, Metano cannot be used to generate code into a subfolder of an existing
+project that already relies on `#`, which is a common, practical integration shape.
+
+**Independent Test**: Configure the isolated alias on a Metano project whose output
+directory is a nested subfolder of a host package that already defines `#/*`.
+Transpile, then confirm the generated TypeScript compiles/resolves with no manual
+edits and the host's pre-existing `#`/`#/*` entries are unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a host package that defines its own `#/*` alias and a Metano project
+   whose output is a nested subfolder, **When** the developer configures an
+   isolated alias and transpiles, **Then** every internal import in the generated
+   code uses the isolated alias key and resolves to the correct file.
+2. **Given** the same setup, **When** Metano updates the host `package.json`,
+   **Then** only the isolated-alias entries are added (scoped to the output
+   subfolder) and the host's existing `#`/`#/*` entries are neither added nor
+   modified.
+3. **Given** a generated type that lives in the project's root namespace,
+   **When** another generated type imports it, **Then** the import uses the bare
+   isolated-alias key (no trailing subpath).
+
+### User Story 2 - Existing projects are unaffected (Priority: P1)
+
+A developer who already uses Metano and does NOT configure an alias must observe
+no change whatsoever in the generated output after this feature ships.
+
+**Why this priority**: Backward compatibility is a release gate. Any change to the
+default output would force regeneration of every existing consumer and invalidate
+the project's golden test fixtures.
+
+**Independent Test**: Transpile any existing sample with no alias configured and
+diff the output against the pre-feature output — it must be identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Metano project with no alias configured, **When** it is transpiled,
+   **Then** the generated TypeScript and `package.json` are byte-identical to the
+   current (default `#`/`#/*`) behavior.
+
+### User Story 3 - Correct paths at any output depth (Priority: P2)
+
+A developer emitting into a deeply nested output directory gets well-formed
+`package.json` import/export path values regardless of nesting depth.
+
+**Why this priority**: Nested output is exactly the scenario this feature targets,
+and a malformed path (e.g. a doubled separator) would break resolution. It is a
+correctness companion to Story 1, but narrower in impact.
+
+**Independent Test**: Transpile into a nested output directory and inspect the
+generated `package.json` import/export entries for malformed path segments.
+
+**Acceptance Scenarios**:
+
+1. **Given** a nested output directory, **When** Metano writes the `package.json`
+   import/export entries, **Then** no path value contains a doubled path separator.
+
+### Edge Cases
+
+- The developer provides the alias value with or without a leading marker
+  character — both forms yield the same alias key.
+- The developer provides an empty or whitespace-only alias value — it is treated
+  as "no alias configured" (default behavior).
+- The host `package.json` already contains user-authored `#`/`#/*` entries and an
+  alias is configured — the user entries are preserved AND the isolated-alias
+  entries are added; nothing collides.
+- Multiple Metano projects emit into the same TypeScript package — each project's
+  alias is honored; choosing distinct aliases is the developer's responsibility
+  (see Assumptions).
+- A generated module participates in a circular reference while a custom alias is
+  in effect — the cycle is still detected and reported as before.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Metano MUST provide an opt-in configuration option that sets a
+  custom, isolated subpath-import alias for internal (same-project) imports in the
+  generated TypeScript.
+- **FR-002**: When an alias is configured, every internal import in the generated
+  code MUST use the configured alias key (e.g. `#contracts/...`, and the bare
+  alias key for root-namespace types) instead of the default `#`.
+- **FR-003**: When an alias is configured, the generated/updated `package.json`
+  MUST contain only the alias-scoped subpath-import entries, scoped to the output
+  directory, and MUST NOT add or modify the default `#`/`#/*` entries.
+- **FR-004**: When no alias is configured, the generated TypeScript and
+  `package.json` MUST be identical to the current default behavior, preserving full
+  backward compatibility.
+- **FR-005**: The alias MUST be configurable through both existing configuration
+  surfaces (the command-line interface and the build-system integration) on a
+  per-project basis.
+- **FR-006**: Configuring an alias MUST NOT change how imports of types from
+  externally referenced packages are emitted; those continue to use the referenced
+  package's published package name.
+- **FR-007**: The alias value MUST be normalized: a leading marker character, if
+  supplied, is accepted equivalently to its absence, and an empty or
+  whitespace-only value MUST be treated as "no alias configured".
+- **FR-008**: Subpath-import path values written to `package.json` MUST be free of
+  malformed segments (e.g. doubled path separators) at any output-directory depth.
+- **FR-009**: Internal cyclic-reference detection and reporting MUST continue to
+  function correctly when a custom alias is in effect.
+- **FR-010**: Changing the alias configuration MUST invalidate any cached
+  generation output so that stale output produced under a different alias is never
+  reused.
+
+### Key Entities
+
+- **Subpath-import alias**: The configurable key under which a project's internal
+  generated modules are exposed and imported (default: `#`). When set, it is an
+  isolated key distinct from the host project's own `#`.
+- **Generated package.json imports map**: The set of subpath-import entries Metano
+  contributes to the consuming package, mapping the alias key to the build and
+  source locations of the generated code.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer can emit generated code into a subfolder of an existing
+  npm project and the generated TypeScript resolves/builds with zero manual edits
+  to import statements.
+- **SC-002**: For projects that do not configure an alias, generated output is
+  unchanged — zero differences across all existing samples and golden outputs.
+- **SC-003**: After Metano runs against a host project that already defines `#`,
+  the host's pre-existing `#`/`#/*` entries show zero modifications.
+- **SC-004**: Generated `package.json` import/export path values contain zero
+  malformed (doubled-separator) segments at any tested output depth.
+- **SC-005**: The alias is configurable with a single setting in either the CLI or
+  the project file, requiring no manual post-processing of the generated artifacts.
+
+## Assumptions
+
+- The audience is developers integrating Metano-generated TypeScript into existing
+  npm/TypeScript projects; the alias is a build-time configuration, not an
+  end-user-facing runtime concern.
+- The feature is opt-in; the default behavior (key `#`) is unchanged so existing
+  consumers and the project's golden test fixtures are not disturbed.
+- When several Metano projects emit into the same TypeScript package, each project
+  is responsible for choosing a distinct alias. Automatic detection of conflicting
+  aliases across projects is out of scope for this version (documented as a known
+  limitation; a future diagnostic may be added).
+- No new configuration-file format (e.g. `metano.json`) is introduced; the existing
+  command-line and build-system configuration surfaces are reused. A future config
+  file may reuse the same setting.
+- Cross-package export/import resolution for referenced packages already works for
+  nested output directories and is not changed by this feature.

--- a/specs/004-configurable-import-alias/tasks.md
+++ b/specs/004-configurable-import-alias/tasks.md
@@ -1,0 +1,202 @@
+---
+description: "Task list for: Configurable Isolated Subpath-Import Alias for Generated Packages"
+---
+
+# Tasks: Configurable Isolated Subpath-Import Alias for Generated Packages
+
+**Input**: Design documents from `/specs/004-configurable-import-alias/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED. The Metano constitution (Principle V) mandates golden/
+expected-output tests for transpiler behavior, and the plan enumerates them.
+
+**Organization**: Tasks are grouped by user story. The implementation is a single
+cohesive change to the TypeScript target adapter; the Foundational phase wires the
+config value through without changing behavior, then each story layers behavior +
+tests on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+
+## Path Conventions
+
+Single-project compiler with target adapters. Production code under
+`src/Metano.Compiler.TypeScript/` and `src/Metano.Build/`; tests under
+`tests/Metano.Tests/`. The core `src/Metano.Compiler/` is intentionally NOT touched.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a clean, green baseline to compare backward compatibility against.
+
+- [x] T001 Capture a green baseline: run `dotnet build` and `dotnet run --project tests/Metano.Tests/` and record that all tests pass before any change (used as the no-regression reference for US2).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Thread the optional `importAlias` value end-to-end through the TypeScript
+adapter WITHOUT changing emitted output yet (default stays `#`). Everything below
+this line builds on these seams.
+
+**⚠️ CRITICAL**: No user story behavior work begins until this phase is complete.
+
+- [x] T002 [P] Add `ImportAlias` init property to `TypeScriptTarget`, pass it into `new TypeTransformer { ... }`, and append it to `BuildConfigurationFingerprint` so a changed alias invalidates the cache (FR-010) in `src/Metano.Compiler.TypeScript/TypeScriptTarget.cs`
+- [x] T003 [P] Add `ImportAlias` init property to `TypeTransformer` in `src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs`
+- [x] T004 [P] Add a defaulted `string? importAlias = null` parameter to `PackageJsonWriter.UpdateOrCreate` and `BuildImports`, threaded through unused for now (keeps existing test call sites compiling) in `src/Metano.Compiler.TypeScript/PackageJsonWriter.cs`
+- [x] T005 [P] Add the `MetanoImportAlias` MSBuild property mapped to a conditional `--import-alias "$(MetanoImportAlias)"` arg, plus its doc-block entry, in `src/Metano.Build/build/Metano.Build.targets`
+- [x] T006 Add the `--import-alias <name>` parameter (with XML doc) to `Commands.Transpile`, set `ImportAlias` on the `TypeScriptTarget`, and pass `importAlias:` into the `PackageJsonWriter.UpdateOrCreate(...)` call in `src/Metano.Compiler.TypeScript/Commands.cs` (depends on T002 and T004)
+
+**Checkpoint**: Solution builds; alias value flows to the target, the cache key, and
+the writer; emitted output is still byte-identical to today.
+
+---
+
+## Phase 3: User Story 1 - Emit into a subfolder of an existing project (Priority: P1) 🎯 MVP
+
+**Goal**: With an alias configured, internal imports use `#<alias>/...` and the
+`package.json` gets only the alias-scoped keys, leaving the host project's `#` untouched.
+
+**Independent Test**: Transpile a 2-namespace sample with `--import-alias contracts`
+into a nested output dir under a host package that already defines `#/*`; confirm
+generated imports are `#contracts/...`, the host `#`/`#/*` is unchanged, and the
+output resolves.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they fail)
+
+- [x] T007 [P] [US1] `PathNaming` unit tests for the aliased specifier: alias `contracts` → `#contracts/<ns>`; root-namespace → bare `#contracts`; same-namespace → still `./<kebab-type>`; normalization (`#contracts` ≡ `contracts`, blank → `#`) in `tests/Metano.Tests/ImportAliasTests.cs`
+- [x] T008 [P] [US1] End-to-end golden test: a 2-namespace inline sample transpiled with the alias emits internal imports as `from "#contracts/..."` and zero `from "#/..."` in `tests/Metano.Tests/ImportAliasTests.cs`
+- [x] T009 [P] [US1] `PackageJsonWriter` test: `importAlias: "contracts"` produces `imports` with `#contracts` + `#contracts/*` (and NOT `#`/`#/*`), with targets scoped to the output subfolder, in `tests/Metano.Tests/EmitPackageTests.cs`
+- [x] T010 [P] [US1] Isolation-merge test: a `package.json` with pre-existing user `#`/`#/*` plus a configured alias keeps the user keys AND adds `#contracts`/`#contracts/*` (no collision, no clobber) in `tests/Metano.Tests/EmitPackageTests.cs`
+- [x] T011 [P] [US1] Cyclic-reference test under a custom alias: a two-file import cycle with `--import-alias contracts` still reports MS0005 in `tests/Metano.Tests/CyclicReferenceTests.cs`
+
+### Implementation for User Story 1
+
+- [x] T012 [US1] Parameterize `PathNaming` (ctor `(string rootNamespace, string? importAlias = null)`, derive `AliasPrefix` with the normalization helper) and use `AliasPrefix` in the two `#` branches of `ComputeRelativeImportPath` (keep the `./` same-namespace fallback); construct it as `new PathNaming(ir.LocalRootNamespace, ImportAlias)` in `TypeTransformer` — `src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs` (+ the construction line in `TypeTransformer.cs`)
+- [x] T013 [US1] In `PackageJsonWriter.BuildImports`, derive `starKey`/`rootKey` from the alias and emit only those keys (when an alias is set, `#`/`#/*` are never written) in `src/Metano.Compiler.TypeScript/PackageJsonWriter.cs`
+- [x] T014 [US1] Teach `CyclicReferenceDetector` the alias: add an `importAlias` param to `DetectAndReport`, thread `aliasPrefix` into `TryNormalizeLocalImport` and `ToDisplayImportPath`, and pass `ImportAlias` from the `DetectAndReport` call site in `TypeTransformer` — `src/Metano.Compiler.TypeScript/Transformation/CyclicReferenceDetector.cs` (+ the call site in `TypeTransformer.cs`)
+
+**Checkpoint**: US1 fully functional — alias behavior verified by T007–T011.
+
+---
+
+## Phase 4: User Story 2 - Existing projects are unaffected (Priority: P1)
+
+**Goal**: With no alias configured, generated TypeScript and `package.json` are
+byte-identical to the pre-feature output.
+
+**Independent Test**: Transpile any existing sample with no alias and diff against the
+baseline (T001) — identical.
+
+### Tests for User Story 2 ⚠️
+
+- [x] T015 [P] [US2] `PathNaming` no-regression unit test: with no alias, specifiers are `#/<ns>` and bare `#` exactly as before, in `tests/Metano.Tests/ImportAliasTests.cs`
+- [x] T016 [P] [US2] End-to-end no-regression golden test: the same 2-namespace sample with NO alias emits `from "#/..."` (default), in `tests/Metano.Tests/ImportAliasTests.cs`
+
+### Implementation / Verification for User Story 2
+
+- [x] T017 [US2] Run the full existing .NET suite (`dotnet run --project tests/Metano.Tests/`) and regenerate the in-repo samples (e.g. `targets/js/sample-todo-service`); confirm zero golden-fixture diffs and byte-identical sample regeneration vs the T001 baseline (SC-002)
+
+**Checkpoint**: US1 and US2 both hold — opt-in works, default is untouched.
+
+---
+
+## Phase 5: User Story 3 - Correct paths at any output depth (Priority: P2)
+
+**Goal**: `package.json` import/export path values are well-formed (no doubled
+separators) at any output-directory depth.
+
+**Independent Test**: Transpile into a deeply nested output dir and inspect the
+generated `imports`/`exports` for `//`.
+
+### Tests for User Story 3 ⚠️
+
+- [x] T018 [P] [US3] Double-slash regression test: a nested output (non-empty `outputPrefix`) yields no `//` in any `imports` or `exports` path value, in `tests/Metano.Tests/EmitPackageTests.cs`
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Trailing-trim `outputPrefix` before building `distBase` in `PackageJsonWriter.BuildImports`, and apply the identical fix in `BuildExports`, in `src/Metano.Compiler.TypeScript/PackageJsonWriter.cs` (same file as T013 — sequence after it)
+
+**Checkpoint**: All three stories independently verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T020 [P] Document `--import-alias` / `MetanoImportAlias` (purpose, normalization, multi-project known limitation) in the CLI flag list and MSBuild property/conventions tables of `CLAUDE.md`
+- [ ] T021 [P] Record the new knob in the baseline flag/attribute catalog under `specs/001-project-baseline-evolution/baseline/` — DEFERRED to ship-time (the feature is recorded in its own spec 004; baseline backfill happens when 004 merges, per the project's spec-reconciliation convention)
+- [x] T022 Run `dotnet csharpier .` and `bunx biome check` (in the relevant `targets/js/*`); fix any formatting/lint findings
+- [x] T023 Dual-agent review per constitution: run `compiler-man` (semantics/IR/pipeline) and `bob` (Clean Code) in parallel on the diff; fix findings before commit
+- [x] T024 Run the `quickstart.md` walkthrough end-to-end: transpile a sample into a subfolder with `--import-alias`, then `bun run build` the target to confirm the alias resolves
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2)**: after Setup — BLOCKS all stories. T002–T005 are parallel; T006 depends on T002 + T004.
+- **User Stories (Phase 3–5)**: all depend on Foundational. US1 is the MVP; US2 and US3 can follow.
+- **Polish (Phase 6)**: after the desired stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after Foundational. Delivers the core alias behavior (MVP).
+- **US2 (P1)**: after Foundational. Independently testable; its no-regression tests pass as long as the default path is preserved (which T012/T013 must maintain).
+- **US3 (P2)**: after Foundational. T019 shares `PackageJsonWriter.cs` with T013 — sequence T019 after T013 to avoid edit conflicts in `BuildImports`.
+
+### Shared-file sequencing (not parallel)
+
+- `PackageJsonWriter.cs`: T004 → T013 → T019 (same file, ordered).
+- `TypeTransformer.cs`: T003 → T012 (construction) → T014 (detector call) (same file, ordered).
+
+### Parallel Opportunities
+
+- Foundational: T002, T003, T004, T005 in parallel (distinct files); then T006.
+- US1 tests: T007, T008, T009, T010, T011 in parallel (T007/T008 share `ImportAliasTests.cs`, so co-author or sequence those two).
+- US2 tests: T015, T016 in parallel with each other and with US1 tests.
+- Polish: T020, T021 in parallel.
+
+---
+
+## Parallel Example: Foundational phase
+
+```bash
+# Distinct files, no interdependencies — run together:
+Task: "Add ImportAlias prop + cache fingerprint in TypeScriptTarget.cs"        # T002
+Task: "Add ImportAlias prop in TypeTransformer.cs"                              # T003
+Task: "Add importAlias param to PackageJsonWriter.UpdateOrCreate/BuildImports" # T004
+Task: "Add MetanoImportAlias MSBuild property in Metano.Build.targets"         # T005
+# Then wire them together:
+Task: "Add --import-alias flag in Commands.cs"                                 # T006
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → green baseline.
+2. Phase 2 Foundational → value plumbing (no behavior change).
+3. Phase 3 US1 → alias behavior + tests.
+4. **STOP and VALIDATE**: alias works end-to-end into a nested subfolder; host `#` untouched.
+
+### Incremental Delivery
+
+- US1 (MVP) → US2 (prove default unchanged) → US3 (double-slash fix) → Polish.
+- Each story is an independently testable increment; none breaks the previous.
+
+---
+
+## Notes
+
+- The core `src/Metano.Compiler/` and `TranspileOptions` are NOT modified (Constitution Principle IV).
+- Backward compatibility (US2) is a release gate — keep the default path byte-identical.
+- Commit after each logical group; run the dual-agent review (T023) before committing the feature.
+- Avoid same-file parallelism on `PackageJsonWriter.cs` and `TypeTransformer.cs` (see sequencing).

--- a/src/Metano.Build/build/Metano.Build.targets
+++ b/src/Metano.Build/build/Metano.Build.targets
@@ -19,6 +19,7 @@
       MetanoDist             (optional)  JS dist dir relative to package root (default: ./dist)
       MetanoPackageRoot      (optional)  Root of the npm package (default: parent of OutputDir)
       MetanoSrcRoot          (optional)  TS source root relative to package root (default: inferred)
+      MetanoImportAlias      (optional)  Isolated subpath-imports alias for internal imports in generated TS (e.g. `contracts` → `#contracts/...`). Lets generated code live in a subfolder of an existing npm project without colliding with that project's own `#` alias. Leading `#` optional; use a simple identifier (letters, digits, `-`, `_`). Default: unset (uses `#`). When several Metano projects target the same package, give each a distinct alias.
       MetanoSkipPackageJson  (optional)  true to skip package.json generation (default: false)
       MetanoShowTimings      (optional)  true to print timing info (default: false)
       MetanoNamespaceBarrels (optional)  true to emit a root src/index.ts barrel mirroring C# namespaces (default: false)
@@ -124,6 +125,10 @@
       <_MetanoArg
         Include="--src-root &quot;$(MetanoSrcRoot)&quot;"
         Condition="'$(MetanoSrcRoot)' != ''"
+      />
+      <_MetanoArg
+        Include="--import-alias &quot;$(MetanoImportAlias)&quot;"
+        Condition="'$(MetanoImportAlias)' != ''"
       />
       <_MetanoArg Include="--skip-package-json" Condition="'$(MetanoSkipPackageJson)' == 'true'" />
       <_MetanoArg Include="--namespace-barrels" Condition="'$(MetanoNamespaceBarrels)' == 'true'" />

--- a/src/Metano.Compiler.TypeScript/Commands.cs
+++ b/src/Metano.Compiler.TypeScript/Commands.cs
@@ -16,6 +16,7 @@ public class Commands
     /// <param name="packageRoot">Root directory of the consumer package (default: parent of --output)</param>
     /// <param name="dist">Path (relative to packageRoot) where the JS build output lives (default: ./dist)</param>
     /// <param name="srcRoot">TypeScript source root relative to packageRoot (default: inferred from first segment of output path). Used to compute the dist prefix when output targets a subdirectory (e.g., src/domain/).</param>
+    /// <param name="importAlias">Isolated Node.js subpath-imports alias for internal imports in the generated TypeScript (e.g. `contracts` → `#contracts/...`). When set, generated internal imports and the package.json `#&lt;alias&gt;`/`#&lt;alias&gt;/*` entries use this key instead of the default `#`, so generated code can live in a subfolder of a host project without colliding with that project's own `#` alias. A leading `#` is optional; use a simple identifier (letters, digits, `-`, `_`); blank means unset (default `#`). Does not affect cross-package imports, which use the referenced package's npm name.</param>
     /// <param name="skipPackageJson">Skip generating/updating package.json</param>
     /// <param name="namespaceBarrels">Emit an additional src/index.ts root barrel mirroring the C# namespace hierarchy via `export namespace` blocks (opt-in; see ADR-0006).</param>
     /// <param name="stripInterfacePrefix">Drop the C# `I` prefix from generated interface names when it is followed by another uppercase letter (opt-in). Collisions with sibling types in the same namespace keep the prefix and emit MS0017.</param>
@@ -33,6 +34,7 @@ public class Commands
         string? packageRoot = null,
         string dist = "./dist",
         string? srcRoot = null,
+        string? importAlias = null,
         bool skipPackageJson = false,
         bool namespaceBarrels = false,
         bool stripInterfacePrefix = false,
@@ -47,6 +49,7 @@ public class Commands
         {
             NamespaceBarrels = namespaceBarrels,
             StripInterfacePrefix = stripInterfacePrefix,
+            ImportAlias = importAlias,
         };
 
         var options = new TranspileOptions(
@@ -90,7 +93,8 @@ public class Commands
                     authoritativePackageName: target.LastEmitPackageName,
                     crossPackageDependencies: target.LastCrossPackageDependencies,
                     isExecutable: target.LastIsExecutable,
-                    srcRoot: srcRoot
+                    srcRoot: srcRoot,
+                    importAlias: importAlias
                 );
 
                 foreach (var d in pkgDiagnostics)

--- a/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
+++ b/src/Metano.Compiler.TypeScript/PackageJsonWriter.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Metano.Compiler.Diagnostics;
 using Metano.Compiler.TypeScript.AST;
+using Metano.Compiler.TypeScript.Transformation;
 
 namespace Metano;
 
@@ -57,7 +58,8 @@ public static class PackageJsonWriter
         string? authoritativePackageName = null,
         IReadOnlyDictionary<string, string>? crossPackageDependencies = null,
         bool isExecutable = false,
-        string? srcRoot = null
+        string? srcRoot = null,
+        string? importAlias = null
     )
     {
         var diagnostics = new List<MetanoDiagnostic>();
@@ -84,7 +86,8 @@ public static class PackageJsonWriter
             srcRelative,
             distDirRelativeToPackageRoot,
             hasRootIndex,
-            outputPrefix
+            outputPrefix,
+            importAlias
         );
 
         JsonObject root;
@@ -112,13 +115,15 @@ public static class PackageJsonWriter
         WriteIfMissing(root, "sideEffects", false);
 
         // Imports follow the same write-if-missing rule as the
-        // scalar fields above: the transpiler seeds `#` and `#/*`
-        // on first creation, but a consumer who has retargeted
-        // either alias by hand (e.g. pointing `#/*` at `./lib/*`
-        // for a non-default build directory) keeps that mapping
-        // across regenerations. Keys absent from the existing
-        // object are added; existing keys — including transpiler-
-        // shaped ones from a previous run — are left alone.
+        // scalar fields above: the transpiler seeds its alias keys
+        // (`#` and `#/*` by default, or `#<alias>` and `#<alias>/*`
+        // when --import-alias is set) on first creation, but a
+        // consumer who has retargeted an alias by hand (e.g. pointing
+        // `#/*` at `./lib/*` for a non-default build directory) keeps
+        // that mapping across regenerations. Keys absent from the
+        // existing object are added; existing keys — including a
+        // host project's own `#` and transpiler-shaped ones from a
+        // previous run — are left alone.
         SeedMissingImports(root, imports);
 
         // Exports merge additively — see `MergeTranspilerManagedExports`
@@ -354,16 +359,24 @@ public static class PackageJsonWriter
         string srcRelative,
         string distRelative,
         bool hasRootIndex,
-        string outputPrefix
+        string outputPrefix,
+        string? importAlias
     )
     {
         var src = NormalizePath(srcRelative).TrimEnd('/');
         var dist = NormalizePath(distRelative).TrimEnd('/');
-        var distBase = outputPrefix.Length > 0 ? $"{dist}/{outputPrefix}" : dist;
+        var prefix = outputPrefix.TrimEnd('/');
+        var distBase = prefix.Length > 0 ? $"{dist}/{prefix}" : dist;
+
+        // Default `#` → keys `#/*` and `#`; a configured alias → `#<alias>/*` and
+        // `#<alias>`. When an alias is set the default `#`/`#/*` keys are never emitted,
+        // so a host project's own `#` alias is left untouched.
+        var aliasPrefix = PathNaming.NormalizeImportAliasPrefix(importAlias);
+        var starKey = $"{aliasPrefix}/*";
 
         var imports = new JsonObject
         {
-            ["#/*"] = new JsonObject
+            [starKey] = new JsonObject
             {
                 ["types"] = $"./{distBase}/*.d.ts",
                 ["import"] = $"./{distBase}/*.js",
@@ -373,7 +386,7 @@ public static class PackageJsonWriter
 
         if (hasRootIndex)
         {
-            imports["#"] = new JsonObject
+            imports[aliasPrefix] = new JsonObject
             {
                 ["types"] = $"./{distBase}/index.d.ts",
                 ["import"] = $"./{distBase}/index.js",
@@ -398,7 +411,8 @@ public static class PackageJsonWriter
     )
     {
         var dist = NormalizePath(distRelative).TrimEnd('/');
-        var distBase = outputPrefix.Length > 0 ? $"{dist}/{outputPrefix}" : dist;
+        var prefix = outputPrefix.TrimEnd('/');
+        var distBase = prefix.Length > 0 ? $"{dist}/{prefix}" : dist;
         var exports = new JsonObject();
 
         var barrels = files
@@ -417,8 +431,8 @@ public static class PackageJsonWriter
             // root index.ts with prefix "domain" → "./domain"
             // users/index.ts with prefix "domain" → "./domain/users"
             string subpath;
-            if (outputPrefix.Length > 0)
-                subpath = parent.Length == 0 ? $"./{outputPrefix}" : $"./{outputPrefix}/{parent}";
+            if (prefix.Length > 0)
+                subpath = parent.Length == 0 ? $"./{prefix}" : $"./{prefix}/{parent}";
             else
                 subpath = parent.Length == 0 ? "." : $"./{parent}";
 

--- a/src/Metano.Compiler.TypeScript/Transformation/CyclicReferenceDetector.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/CyclicReferenceDetector.cs
@@ -17,8 +17,9 @@ namespace Metano.Compiler.TypeScript.Transformation;
 /// Each distinct cycle is reported once — the visited set guarantees we don't re-enter
 /// nodes whose subgraphs have already been explored.
 ///
-/// Only intra-project paths (the root alias <c>#</c> and subpath aliases starting with
-/// <c>#/</c>) participate in the graph. Imports from external packages
+/// Only intra-project paths (the configurable root alias — <c>#</c> by default, or
+/// <c>#&lt;alias&gt;</c> when <c>--import-alias</c> is set — plus its <c>/</c> subpaths)
+/// participate in the graph. Imports from external packages
 /// (<c>metano-runtime</c>, <c>@js-temporal/polyfill</c>, etc.) are skipped — their
 /// resolution lives outside Metano's view of the world.
 /// </summary>
@@ -26,11 +27,14 @@ public static class CyclicReferenceDetector
 {
     public static void DetectAndReport(
         IReadOnlyList<TsSourceFile> files,
-        Action<MetanoDiagnostic> reportDiagnostic
+        Action<MetanoDiagnostic> reportDiagnostic,
+        string? importAlias = null
     )
     {
         if (files.Count == 0)
             return;
+
+        var aliasPrefix = PathNaming.NormalizeImportAliasPrefix(importAlias);
 
         // Build the file index keyed by the kebab-cased relative path WITHOUT the .ts
         // extension. For index files we also register the directory barrel alias:
@@ -64,7 +68,9 @@ public static class CyclicReferenceDetector
             {
                 if (stmt is not TsImport import)
                     continue;
-                if (!TryNormalizeLocalImport(import.From, key, out var targetImportKey))
+                if (
+                    !TryNormalizeLocalImport(import.From, key, aliasPrefix, out var targetImportKey)
+                )
                     continue;
                 if (byImportKey.TryGetValue(targetImportKey, out var canonicalTarget))
                     targets.Add(canonicalTarget);
@@ -83,7 +89,16 @@ public static class CyclicReferenceDetector
         {
             if (visited.Contains(start))
                 continue;
-            DfsVisit(start, graph, visited, onStack, pathStack, seenCycles, reportDiagnostic);
+            DfsVisit(
+                start,
+                graph,
+                visited,
+                onStack,
+                pathStack,
+                seenCycles,
+                reportDiagnostic,
+                aliasPrefix
+            );
         }
     }
 
@@ -94,7 +109,8 @@ public static class CyclicReferenceDetector
         HashSet<string> onStack,
         List<string> pathStack,
         HashSet<string> seenCycles,
-        Action<MetanoDiagnostic> reportDiagnostic
+        Action<MetanoDiagnostic> reportDiagnostic,
+        string aliasPrefix
     )
     {
         onStack.Add(node);
@@ -117,11 +133,20 @@ public static class CyclicReferenceDetector
                 // from each starting node we DFS into it from.
                 var canonical = Canonicalize(cycle);
                 if (seenCycles.Add(canonical))
-                    reportDiagnostic(BuildDiagnostic(cycle));
+                    reportDiagnostic(BuildDiagnostic(cycle, aliasPrefix));
             }
             else if (!visited.Contains(target))
             {
-                DfsVisit(target, graph, visited, onStack, pathStack, seenCycles, reportDiagnostic);
+                DfsVisit(
+                    target,
+                    graph,
+                    visited,
+                    onStack,
+                    pathStack,
+                    seenCycles,
+                    reportDiagnostic,
+                    aliasPrefix
+                );
             }
         }
 
@@ -154,9 +179,9 @@ public static class CyclicReferenceDetector
         return string.Join("→", rotated);
     }
 
-    private static MetanoDiagnostic BuildDiagnostic(IReadOnlyList<string> cycle)
+    private static MetanoDiagnostic BuildDiagnostic(IReadOnlyList<string> cycle, string aliasPrefix)
     {
-        var chain = string.Join(" → ", cycle.Select(ToDisplayImportPath));
+        var chain = string.Join(" → ", cycle.Select(key => ToDisplayImportPath(key, aliasPrefix)));
         return new MetanoDiagnostic(
             MetanoDiagnosticSeverity.Warning,
             DiagnosticCodes.CyclicReference,
@@ -164,17 +189,23 @@ public static class CyclicReferenceDetector
         );
     }
 
-    private static bool TryNormalizeLocalImport(string from, string importerKey, out string key)
+    private static bool TryNormalizeLocalImport(
+        string from,
+        string importerKey,
+        string aliasPrefix,
+        out string key
+    )
     {
-        if (from == "#")
+        if (from == aliasPrefix)
         {
             key = "";
             return true;
         }
 
-        if (from.StartsWith("#/", StringComparison.Ordinal))
+        var aliasSubpathPrefix = aliasPrefix + "/";
+        if (from.StartsWith(aliasSubpathPrefix, StringComparison.Ordinal))
         {
-            key = from[2..];
+            key = from[aliasSubpathPrefix.Length..];
             return true;
         }
 
@@ -191,13 +222,13 @@ public static class CyclicReferenceDetector
         return false;
     }
 
-    private static string ToDisplayImportPath(string key)
+    private static string ToDisplayImportPath(string key, string aliasPrefix)
     {
         if (key == "index")
-            return "#";
+            return aliasPrefix;
         if (key.EndsWith("/index", StringComparison.Ordinal))
-            return "#/" + key[..^"/index".Length];
-        return "#/" + key;
+            return aliasPrefix + "/" + key[..^"/index".Length];
+        return aliasPrefix + "/" + key;
     }
 
     private static string StripTsExtension(string fileName) =>

--- a/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/PathNaming.cs
@@ -9,9 +9,36 @@ namespace Metano.Compiler.TypeScript.Transformation;
 /// dot-separated prefix across all transpilable types) so that subpath imports
 /// (<c>#/foo/bar</c>) and on-disk file paths can both be computed consistently.
 /// </summary>
-public sealed class PathNaming(string rootNamespace)
+public sealed class PathNaming(string rootNamespace, string? importAlias = null)
 {
     public string RootNamespace { get; } = rootNamespace;
+
+    /// <summary>
+    /// Subpath-imports key prefix for internal imports — <c>#</c> by default, or
+    /// <c>#&lt;alias&gt;</c> when an import alias is configured. Keeping internal imports
+    /// under an isolated key lets generated code live in a subfolder of a host project
+    /// without colliding with that project's own <c>#</c> alias.
+    /// </summary>
+    private string AliasPrefix { get; } = NormalizeImportAliasPrefix(importAlias);
+
+    /// <summary>
+    /// Normalizes a raw <c>--import-alias</c> value into a subpath-imports key prefix.
+    /// Blank (null/empty/whitespace) → <c>#</c> (the default). A single leading <c>#</c>
+    /// is optional, so both <c>contracts</c> and <c>#contracts</c> yield <c>#contracts</c>.
+    /// This is the single source of truth for the alias key shape, shared by
+    /// <see cref="CyclicReferenceDetector"/> and <c>PackageJsonWriter</c>.
+    /// </summary>
+    public static string NormalizeImportAliasPrefix(string? importAlias)
+    {
+        if (string.IsNullOrWhiteSpace(importAlias))
+            return "#";
+
+        var name = importAlias.Trim();
+        if (name.StartsWith('#'))
+            name = name[1..].Trim();
+
+        return name.Length == 0 ? "#" : "#" + name;
+    }
 
     public static string GetNamespace(INamedTypeSymbol type)
     {
@@ -81,10 +108,10 @@ public sealed class PathNaming(string rootNamespace)
             return "./" + SymbolHelper.ToKebabCase(typeName);
         }
 
-        // Different namespace: import the namespace barrel.
+        // Different namespace: import the namespace barrel under the local alias key.
         if (toParts.Length == 0)
-            return "#";
-        return "#/" + string.Join("/", toParts);
+            return AliasPrefix;
+        return AliasPrefix + "/" + string.Join("/", toParts);
     }
 
     /// <summary>

--- a/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
+++ b/src/Metano.Compiler.TypeScript/Transformation/TypeTransformer.cs
@@ -67,6 +67,13 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
     public bool StripInterfacePrefix { get; init; }
 
     /// <summary>
+    /// Optional isolated subpath-imports alias for internal imports, forwarded to
+    /// <see cref="PathNaming"/> and <see cref="CyclicReferenceDetector"/>. <c>null</c>
+    /// keeps the default <c>#</c> behavior. Set via <c>--import-alias</c>.
+    /// </summary>
+    public string? ImportAlias { get; init; }
+
+    /// <summary>
     /// Output directory for the active run, supplied by the host
     /// (<see cref="Metano.Compiler.TranspilerHost"/>) so the per-group
     /// cache (ADR-0023) can live next to the generated <c>.ts</c> files.
@@ -267,7 +274,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
 
         // All callers now use the explicit TypeMappingContext — no static assignment needed.
 
-        _pathNaming = new PathNaming(ir.LocalRootNamespace);
+        _pathNaming = new PathNaming(ir.LocalRootNamespace, ImportAlias);
 
         var declarativeMappings = DeclarativeMappingRegistry.FromIr(ir);
 
@@ -407,7 +414,7 @@ public sealed class TypeTransformer(IrCompilation ir, Compilation compilation)
         // diagnostics for each distinct cycle. Cycles are reported as warnings — the
         // build proceeds, but the consumer sees the chain in their build log instead
         // of debugging it through tsgo's downstream error.
-        CyclicReferenceDetector.DetectAndReport(files, ReportDiagnostic);
+        CyclicReferenceDetector.DetectAndReport(files, ReportDiagnostic, ImportAlias);
 
         DrainCrossPackageMisses(typeMappingContext);
         DrainCrossPackageDependencies(typeMappingContext);

--- a/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
+++ b/src/Metano.Compiler.TypeScript/TypeScriptTarget.cs
@@ -78,14 +78,22 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     public bool StripInterfacePrefix { get; init; }
 
     /// <summary>
-    /// Cache fingerprint (ADR-0021): pin the two emit-affecting flags so
-    /// flipping either one invalidates the incremental cache. Format is
-    /// keep small + ordered so future additions extend it without
+    /// Optional isolated subpath-imports alias for internal imports. <c>null</c> keeps
+    /// the default <c>#</c>. When set (e.g. <c>contracts</c>), generated internal imports
+    /// use <c>#contracts/...</c> and the package.json gets only the alias-scoped keys,
+    /// leaving a host project's own <c>#</c> untouched. Set via <c>--import-alias</c>.
+    /// </summary>
+    public string? ImportAlias { get; init; }
+
+    /// <summary>
+    /// Cache fingerprint (ADR-0021): pin the emit-affecting flags so
+    /// flipping any one invalidates the incremental cache. Format is
+    /// kept small + ordered so future additions extend it without
     /// breaking older caches (the format-version bump in
     /// <see cref="TranspilationCache"/> handles structural breaks).
     /// </summary>
     public string ConfigurationFingerprint =>
-        BuildConfigurationFingerprint(NamespaceBarrels, StripInterfacePrefix);
+        BuildConfigurationFingerprint(NamespaceBarrels, StripInterfacePrefix, ImportAlias);
 
     /// <summary>
     /// Per-target fingerprint pinned into the incremental cache key
@@ -95,8 +103,10 @@ public sealed class TypeScriptTarget : ITranspilerTarget
     /// </summary>
     private static string BuildConfigurationFingerprint(
         bool namespaceBarrels,
-        bool stripInterfacePrefix
-    ) => $"namespaceBarrels={namespaceBarrels};stripInterfacePrefix={stripInterfacePrefix}";
+        bool stripInterfacePrefix,
+        string? importAlias
+    ) =>
+        $"namespaceBarrels={namespaceBarrels};stripInterfacePrefix={stripInterfacePrefix};importAlias={PathNaming.NormalizeImportAliasPrefix(importAlias)}";
 
     /// <summary>
     /// Builds the cache-fingerprint composite consumed by
@@ -127,6 +137,7 @@ public sealed class TypeScriptTarget : ITranspilerTarget
         {
             NamespaceBarrels = NamespaceBarrels,
             StripInterfacePrefix = StripInterfacePrefix,
+            ImportAlias = ImportAlias,
             CacheOutputDir = outputDir,
             CacheFilePrefix = filePrefix,
             CacheConfigurationFingerprint = BuildCacheFingerprint(

--- a/tests/Metano.Tests/CyclicReferenceTests.cs
+++ b/tests/Metano.Tests/CyclicReferenceTests.cs
@@ -68,6 +68,40 @@ public class CyclicReferenceTests
     }
 
     [Test]
+    public async Task TwoFileCycle_UnderImportAlias_StillDetectedAndRendersAliasKey()
+    {
+        // The same Node ↔ Edge cycle is still detected when a custom import alias is
+        // configured. Both types share the root namespace, so their real imports are
+        // relative (`./edge`, `./node`); the cycle renderer synthesizes the alias prefix
+        // for display, which is what this asserts (exercising the alias-aware display).
+        var (_, diagnostics) = TranspileHelper.TranspileWithDiagnostics(
+            """
+            namespace Demo
+            {
+                [Transpile]
+                public class Node
+                {
+                    public Edge? OutgoingEdge { get; set; }
+                }
+
+                [Transpile]
+                public class Edge
+                {
+                    public Node? Target { get; set; }
+                }
+            }
+            """,
+            importAlias: "contracts"
+        );
+
+        var cycle = diagnostics.FirstOrDefault(d => d.Code == DiagnosticCodes.CyclicReference);
+        await Assert.That(cycle).IsNotNull();
+        await Assert.That(cycle!.Severity).IsEqualTo(MetanoDiagnosticSeverity.Warning);
+        // The diagnostic message reflects the configured alias key, not the default `#`.
+        await Assert.That(cycle.Message).Contains("#contracts/");
+    }
+
+    [Test]
     public async Task SelfReferenceWithoutPropertyImport_NoDiagnostic()
     {
         // A type that references its own type name doesn't create a file-level import

--- a/tests/Metano.Tests/EmitPackageTests.cs
+++ b/tests/Metano.Tests/EmitPackageTests.cs
@@ -922,6 +922,117 @@ public class EmitPackageTests
         await Assert.That(exports!.ContainsKey("./nested")).IsTrue();
     }
 
+    // ── Configurable isolated import alias (feature 004) ─────────────
+
+    [Test]
+    public async Task Imports_WithImportAlias_UsesAliasScopedKeysOnly()
+    {
+        var tempDir = CreateTempDir();
+        // Generated code lands in a subfolder of an existing project's src root.
+        var srcDir = Path.Combine(tempDir, "src", "abc", "contracts");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[]
+        {
+            new TsSourceFile("index.ts", [], ""),
+            new TsSourceFile("serialization/index.ts", [], ""),
+        };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "abc-contracts",
+            importAlias: "contracts"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+        // Alias-scoped keys present.
+        await Assert.That(imports!.ContainsKey("#contracts/*")).IsTrue();
+        await Assert.That(imports.ContainsKey("#contracts")).IsTrue();
+        // Default keys are NOT emitted when an alias is set.
+        await Assert.That(imports.ContainsKey("#/*")).IsFalse();
+        await Assert.That(imports.ContainsKey("#")).IsFalse();
+        // Targets are scoped to the output subfolder.
+        var wildcard = imports["#contracts/*"] as JsonObject;
+        await Assert
+            .That(wildcard!["default"]?.GetValue<string>())
+            .IsEqualTo("./src/abc/contracts/*.ts");
+        await Assert
+            .That(wildcard["types"]?.GetValue<string>())
+            .IsEqualTo("./dist/abc/contracts/*.d.ts");
+    }
+
+    [Test]
+    public async Task Imports_WithImportAlias_PreservesHostOwnHashAlias()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src", "abc", "contracts");
+        Directory.CreateDirectory(srcDir);
+        // Host project already uses `#/*` for its own src root.
+        File.WriteAllText(
+            Path.Combine(tempDir, "package.json"),
+            """
+            {
+              "name": "host-app",
+              "imports": {
+                "#/*": { "default": "./src/*.ts" }
+              }
+            }
+            """
+        );
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir,
+            files,
+            authoritativePackageName: "host-app",
+            importAlias: "contracts"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+        // Host's own `#/*` is left exactly as it was.
+        var hostAlias = imports!["#/*"] as JsonObject;
+        await Assert.That(hostAlias!["default"]?.GetValue<string>()).IsEqualTo("./src/*.ts");
+        // Metano's isolated alias is added alongside, without touching `#`.
+        await Assert.That(imports.ContainsKey("#contracts/*")).IsTrue();
+        await Assert.That(imports.ContainsKey("#contracts")).IsTrue();
+        await Assert.That(imports.ContainsKey("#")).IsFalse();
+    }
+
+    [Test]
+    public async Task Imports_NestedOutputWithTrailingSlash_NoDoubleSlash()
+    {
+        var tempDir = CreateTempDir();
+        var srcDir = Path.Combine(tempDir, "src", "domain");
+        Directory.CreateDirectory(srcDir);
+
+        var files = new[] { new TsSourceFile("index.ts", [], "") };
+
+        // Output dir carries a trailing separator — the path-joining must still
+        // produce single-slash segments (no `.../domain//index.d.ts`).
+        PackageJsonWriter.UpdateOrCreate(
+            tempDir,
+            srcDir + Path.DirectorySeparatorChar,
+            files,
+            authoritativePackageName: "test-pkg"
+        );
+
+        var pkg = ReadJson(tempDir);
+        var imports = pkg["imports"] as JsonObject;
+        await Assert.That(imports).IsNotNull();
+        var wildcard = imports!["#/*"] as JsonObject;
+        await Assert.That(wildcard!["types"]?.GetValue<string>()).DoesNotContain("//");
+        await Assert.That(wildcard["import"]?.GetValue<string>()).DoesNotContain("//");
+        await Assert.That(wildcard["default"]?.GetValue<string>()).DoesNotContain("//");
+    }
+
     private string CreateTempDir()
     {
         var dir = Path.Combine(Path.GetTempPath(), $"metasharp-test-{Guid.NewGuid():N}");

--- a/tests/Metano.Tests/ImportAliasTests.cs
+++ b/tests/Metano.Tests/ImportAliasTests.cs
@@ -1,0 +1,122 @@
+using Metano.Compiler.TypeScript.Transformation;
+
+namespace Metano.Tests;
+
+/// <summary>
+/// Tests for the configurable isolated subpath-import alias (<c>--import-alias</c>).
+/// Covers both the unit-level specifier shaping in <see cref="PathNaming"/> and the
+/// end-to-end emitted imports, plus the no-regression guarantee when no alias is set.
+/// The package.json side is covered in <see cref="EmitPackageTests"/>.
+/// </summary>
+public class ImportAliasTests
+{
+    // ── Alias normalization (FR-007) ─────────────────────────────────
+
+    [Test]
+    [Arguments("contracts", "#contracts")]
+    [Arguments("#contracts", "#contracts")]
+    [Arguments("  contracts  ", "#contracts")]
+    [Arguments(null, "#")]
+    [Arguments("", "#")]
+    [Arguments("   ", "#")]
+    [Arguments("#", "#")]
+    public async Task NormalizeImportAliasPrefix_NormalizesValue(string? input, string expected)
+    {
+        await Assert.That(PathNaming.NormalizeImportAliasPrefix(input)).IsEqualTo(expected);
+    }
+
+    // ── In-file specifier with an alias (FR-002) ─────────────────────
+
+    [Test]
+    public async Task ComputeRelativeImportPath_WithAlias_UsesAliasKey()
+    {
+        var naming = new PathNaming("App", "contracts");
+
+        // Cross-namespace → alias-scoped barrel.
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Services", "App.Models", "Money"))
+            .IsEqualTo("#contracts/models");
+        // Root namespace → bare alias key.
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Services", "App", "Root"))
+            .IsEqualTo("#contracts");
+        // Same namespace → relative file import, never aliased.
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Models", "App.Models", "Money"))
+            .IsEqualTo("./money");
+    }
+
+    [Test]
+    public async Task ComputeRelativeImportPath_AliasNormalized_LeadingHashEquivalent()
+    {
+        var withHash = new PathNaming("App", "#contracts");
+        var withoutHash = new PathNaming("App", "contracts");
+
+        await Assert
+            .That(withHash.ComputeRelativeImportPath("App.A", "App.B", "T"))
+            .IsEqualTo(withoutHash.ComputeRelativeImportPath("App.A", "App.B", "T"));
+    }
+
+    // ── No-regression when unset (FR-004 / SC-002) ───────────────────
+
+    [Test]
+    public async Task ComputeRelativeImportPath_NoAlias_UsesDefaultHashKey()
+    {
+        var naming = new PathNaming("App");
+
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Services", "App.Models", "Money"))
+            .IsEqualTo("#/models");
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Services", "App", "Root"))
+            .IsEqualTo("#");
+        await Assert
+            .That(naming.ComputeRelativeImportPath("App.Models", "App.Models", "Money"))
+            .IsEqualTo("./money");
+    }
+
+    // ── End-to-end emitted imports (FR-002) ──────────────────────────
+
+    private const string TwoNamespaceSource = """
+        namespace App.Models
+        {
+            [Transpile]
+            public class Money
+            {
+                public decimal Amount { get; set; }
+            }
+        }
+
+        namespace App.Services
+        {
+            [Transpile]
+            public class Wallet
+            {
+                public App.Models.Money Balance { get; set; } = new();
+            }
+        }
+        """;
+
+    [Test]
+    public async Task Transpile_WithAlias_EmitsAliasScopedInternalImports()
+    {
+        var files = TranspileHelper.Transpile(TwoNamespaceSource, importAlias: "contracts");
+
+        // The cross-namespace reference resolves through the isolated alias key.
+        await Assert.That(files.Values.Any(c => c.Contains("from \"#contracts/models\""))).IsTrue();
+        // The default `#` alias never appears.
+        await Assert.That(files.Values.Any(c => c.Contains("from \"#/"))).IsFalse();
+        await Assert.That(files.Values.Any(c => c.Contains("from \"#\""))).IsFalse();
+    }
+
+    [Test]
+    public async Task Transpile_NoAlias_EmitsDefaultHashImports()
+    {
+        var files = TranspileHelper.Transpile(TwoNamespaceSource);
+
+        // Default behavior is unchanged: internal imports use `#/...`.
+        await Assert.That(files.Values.Any(c => c.Contains("from \"#/models\""))).IsTrue();
+        // No alias-scoped key leaks in.
+        await Assert.That(files.Values.Any(c => c.Contains("#contracts"))).IsFalse();
+    }
+}

--- a/tests/Metano.Tests/TranspileHelper.cs
+++ b/tests/Metano.Tests/TranspileHelper.cs
@@ -133,7 +133,8 @@ public static class TranspileHelper
         CSharpCompilation compilation,
         bool useIrBodies = true,
         bool namespaceBarrels = false,
-        bool stripInterfacePrefix = false
+        bool stripInterfacePrefix = false,
+        string? importAlias = null
     )
     {
         var ir = new CSharpSourceFrontend().ExtractFromCompilation(compilation);
@@ -142,6 +143,7 @@ public static class TranspileHelper
             UseIrBodiesWhenCovered = useIrBodies,
             NamespaceBarrels = namespaceBarrels,
             StripInterfacePrefix = stripInterfacePrefix,
+            ImportAlias = importAlias,
         };
         var files = transformer.TransformAll();
         var printer = new Printer();
@@ -165,11 +167,12 @@ public static class TranspileHelper
     /// </summary>
     public static Dictionary<string, string> Transpile(
         string csharpSource,
-        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary
+        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
+        string? importAlias = null
     )
     {
         var compilation = CompileAssembly(csharpSource, "TestAssembly", outputKind);
-        return TranspileCore(compilation).Files;
+        return TranspileCore(compilation, importAlias: importAlias).Files;
     }
 
     /// <summary>
@@ -289,14 +292,14 @@ public static class TranspileHelper
     public static (
         Dictionary<string, string> Files,
         IReadOnlyList<Metano.Compiler.Diagnostics.MetanoDiagnostic> Diagnostics
-    ) TranspileWithDiagnostics(string csharpSource)
+    ) TranspileWithDiagnostics(string csharpSource, string? importAlias = null)
     {
         var compilation = CompileAssembly(
             csharpSource,
             "TestAssembly",
             OutputKind.DynamicallyLinkedLibrary
         );
-        return TranspileCore(compilation);
+        return TranspileCore(compilation, importAlias: importAlias);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Adds an opt-in, configurable, isolated Node.js subpath-import alias for **internal** (same-project) imports in generated TypeScript.

A new `--import-alias <name>` CLI flag (mirrored by the `MetanoImportAlias` MSBuild property) sets the alias. When set (e.g. `contracts`):

- internal specifiers become `#contracts/<ns>` (bare `#contracts` for root-namespace types);
- the generated `package.json` gets only `#contracts` / `#contracts/*` entries scoped to the output directory;
- the host project's own `#` / `#/*` alias is left untouched.

When **unset**, output is byte-identical to today (`#` / `#/*`) — fully backward compatible.

## Why

Emitting generated code into a subfolder of an existing npm project broke twice: the hardcoded `#/x` collided with the host's own `#/*` alias and resolved to the wrong path, and Metano wrote a conflicting `#`/`#/*` entry into the host's `package.json`. One mechanism — an isolated alias key scoped to the output dir — fixes both the key collision and the depth problem.

## Notable details

- Cross-package imports (external `[EmitPackage]`) are unaffected — they use the referenced package's npm name, which never sees the producer's local `imports`.
- Companion fix: trims a trailing slash that produced `.../contracts//index.d.ts` in nested-output `package.json` imports/exports.
- The change is confined to the TypeScript target adapter; the target-agnostic core (`Metano.Compiler`) is untouched.
- Alias-key normalization is centralized in `PathNaming.NormalizeImportAliasPrefix`, shared by the specifier builder, the `package.json` writer, and the cycle detector.
- The alias participates in the incremental-cache fingerprint, so changing it invalidates stale output.

## Verification

- `dotnet build` clean (0 warnings/errors); `dotnet csharpier .` clean.
- 1171 tests pass. New coverage: `PathNaming` unit, e2e golden with/without alias, `package.json` alias keys, host-`#` isolation, double-slash regression, cycle-under-alias.
- In-repo samples regenerate byte-identical (backward compatible).
- Manual e2e: transpiled `SampleIssueTracker` into `src/abc/contracts` of a host package that already defines `#/*` → generated imports use `#contracts/...`, the host `#/*` is preserved, no `//` in paths, and `#contracts/issues/domain` resolves to a real file.
- Dual-agent review (`compiler-man` + `bob`): both approve; findings applied.

## Spec

Feature spec and design artifacts under `specs/004-configurable-import-alias/` (FR-001..010).

## Deferred follow-ups

- Backfill the baseline flag catalog (`specs/001-project-baseline-evolution/baseline/`) when this merges.
- Optional: an alias-validation diagnostic for invalid characters, and a cross-package no-op regression test.
